### PR TITLE
OpenGL module compatibility with OS X 10.5

### DIFF
--- a/modules/juce_opengl/juce_opengl.h
+++ b/modules/juce_opengl/juce_opengl.h
@@ -62,8 +62,16 @@
 #elif JUCE_MAC
  #include <OpenGL/gl.h>
  #include "OpenGL/glext.h"
+ #include <AvailabilityMacros.h>
+ #if JUCE_PPC || (MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_6)
+  #define JUCE_USE_OPENGL_3 0
+ #endif
 #elif JUCE_ANDROID
  #include <GLES2/gl2.h>
+#endif
+
+#if ! defined (JUCE_USE_OPENGL_3)
+ #define JUCE_USE_OPENGL_3 1
 #endif
 
 #if ! defined (JUCE_USE_OPENGL_SHADERS)
@@ -72,6 +80,17 @@
 
 #ifndef JUCE_USE_OPENGL_FIXED_FUNCTION
  #define JUCE_USE_OPENGL_FIXED_FUNCTION 1
+#endif
+
+#if !JUCE_USE_OPENGL_3 && ! defined (GL_FRAMEBUFFER)
+ #define GL_COLOR_ATTACHMENT0 GL_COLOR_ATTACHMENT0_EXT
+ #define GL_DEPTH_ATTACHMENT GL_DEPTH_ATTACHMENT_EXT
+ #define GL_FRAMEBUFFER GL_FRAMEBUFFER_EXT
+ #define GL_FRAMEBUFFER_BINDING GL_FRAMEBUFFER_BINDING_EXT
+ #define GL_FRAMEBUFFER_COMPLETE GL_FRAMEBUFFER_COMPLETE_EXT
+ #define GL_RENDERBUFFER GL_RENDERBUFFER_EXT
+ #define GL_RENDERBUFFER_DEPTH_SIZE GL_RENDERBUFFER_DEPTH_SIZE_EXT
+ #define GL_STENCIL_ATTACHMENT GL_STENCIL_ATTACHMENT_EXT
 #endif
 
 //=============================================================================

--- a/modules/juce_opengl/native/juce_OpenGLExtensions.h
+++ b/modules/juce_opengl/native/juce_OpenGLExtensions.h
@@ -36,7 +36,9 @@
     USE_FUNCTION (glDeleteBuffers,          void, (GLsizei p1, const GLuint* p2), (p1, p2))\
     USE_FUNCTION (glGenBuffers,             void, (GLsizei p1, GLuint* p2), (p1, p2))\
     USE_FUNCTION (glBufferData,             void, (GLenum p1, GLsizeiptr p2, const GLvoid* p3, GLenum p4), (p1, p2, p3, p4))\
-    USE_FUNCTION (glBufferSubData,          void, (GLenum p1, GLintptr p2, GLsizeiptr p3, const GLvoid* p4), (p1, p2, p3, p4))\
+    USE_FUNCTION (glBufferSubData,          void, (GLenum p1, GLintptr p2, GLsizeiptr p3, const GLvoid* p4), (p1, p2, p3, p4))
+
+#define JUCE_GL_3_FUNCTIONS(USE_FUNCTION) \
     USE_FUNCTION (glIsRenderbuffer,         GLboolean, (GLuint p1), (p1))\
     USE_FUNCTION (glBindRenderbuffer,       void, (GLenum p1, GLuint p2), (p1, p2))\
     USE_FUNCTION (glDeleteRenderbuffers,    void, (GLsizei p1, const GLuint* p2), (p1, p2))\
@@ -52,8 +54,14 @@
     USE_FUNCTION (glFramebufferRenderbuffer,  void, (GLenum p1, GLenum p2, GLenum p3, GLuint p4), (p1, p2, p3, p4))\
     USE_FUNCTION (glGetFramebufferAttachmentParameteriv, void, (GLenum p1, GLenum p2, GLenum p3, GLint* p4), (p1, p2, p3, p4))
 
+#if JUCE_USE_OPENGL_3
+ #define JUCE_GL_EXTENSION_FUNCTIONS0(USE_FUNCTION) JUCE_GL_BASIC_EXTENSION_FUNCTIONS(USE_FUNCTION) JUCE_GL_3_FUNCTIONS(USE_FUNCTION)
+#else
+ #define JUCE_GL_EXTENSION_FUNCTIONS0(USE_FUNCTION) JUCE_GL_BASIC_EXTENSION_FUNCTIONS(USE_FUNCTION)
+#endif
+
 #if JUCE_USE_OPENGL_SHADERS
- #define JUCE_GL_EXTENSION_FUNCTIONS1(USE_FUNCTION) JUCE_GL_BASIC_EXTENSION_FUNCTIONS(USE_FUNCTION) \
+ #define JUCE_GL_EXTENSION_FUNCTIONS1(USE_FUNCTION) JUCE_GL_EXTENSION_FUNCTIONS0(USE_FUNCTION) \
     USE_FUNCTION (glCreateProgram,          GLuint, (), ())\
     USE_FUNCTION (glDeleteProgram,          void, (GLuint p1), (p1))\
     USE_FUNCTION (glCreateShader,           GLuint, (GLenum p1), (p1))\
@@ -80,7 +88,7 @@
     USE_FUNCTION (glUniform4i,              void, (GLint p1, GLint p2, GLint p3, GLint p4, GLint p5), (p1, p2, p3, p4, p5))\
     USE_FUNCTION (glUniform1fv,             void, (GLint p1, GLsizei p2, const GLfloat* p3), (p1, p2, p3))
 #else
- #define JUCE_GL_EXTENSION_FUNCTIONS1(USE_FUNCTION) JUCE_GL_BASIC_EXTENSION_FUNCTIONS(USE_FUNCTION)
+ #define JUCE_GL_EXTENSION_FUNCTIONS1(USE_FUNCTION) JUCE_GL_EXTENSION_FUNCTIONS0(USE_FUNCTION)
 #endif
 
 #if JUCE_USE_OPENGL_FIXED_FUNCTION
@@ -118,7 +126,14 @@ struct OpenGLExtensionFunctions
    #endif
 
     JUCE_GL_EXTENSION_FUNCTIONS (JUCE_DECLARE_GL_FUNCTION)
+
     #undef JUCE_DECLARE_GL_FUNCTION
+
+   #if !JUCE_USE_OPENGL_3
+    #define JUCE_DECLARE_GL_FUNCTION(name, returnType, params, callparams) inline static returnType name params { return ::name##EXT callparams; }
+    JUCE_GL_3_FUNCTIONS (JUCE_DECLARE_GL_FUNCTION)
+    #undef JUCE_DECLARE_GL_FUNCTION
+   #endif
 };
 
 #endif   // __JUCE_OPENGLEXTENSIONS_JUCEHEADER__

--- a/modules/juce_opengl/native/juce_OpenGL_osx.h
+++ b/modules/juce_opengl/native/juce_OpenGL_osx.h
@@ -219,5 +219,5 @@ private:
 //==============================================================================
 bool OpenGLHelpers::isContextActive()
 {
-    return CGLGetCurrentContext() != 0;
+    return [NSOpenGLContext currentContext] != nil;
 }


### PR DESCRIPTION
Need to call "EXT" functions rather than OpenGL 3.0 functions.
(those functions are unavailable on OS X 10.5 even though it compiles with 10.5 deployment target).
