### PR TITLE
Put Introjucer logfiles in a hidden folder on Linux

### DIFF
--- a/extras/Introjucer/Source/Application/jucer_Application.h
+++ b/extras/Introjucer/Source/Application/jucer_Application.h
@@ -537,7 +537,14 @@ public:
     virtual void doExtraInitialisation() {}
     virtual void addExtraConfigItems (Project&, TreeViewItem&) {}
 
-    virtual String getLogFolderName() const    { return "com.juce.introjucer"; }
+    virtual String getLogFolderName() const
+    {
+       #if JUCE_LINUX
+        return ".config/juce/introjucer";
+       #else
+        return "com.juce.introjucer";
+       #endif
+    }
 
     virtual PropertiesFile::Options getPropertyFileOptionsFor (const String& filename)
     {


### PR DESCRIPTION
Currently Introjucer creates a folder named "com.juce.introjucer" in the user's home directory for logfiles, this is a bit annoying and should instead follow unix conventions and place such data in a hidden folder.
