### PR TITLE
Fix typo in alert message

### DIFF
--- a/extras/Introjucer/Source/Project/jucer_ConfigTree_Modules.h
+++ b/extras/Introjucer/Source/Project/jucer_ConfigTree_Modules.h
@@ -246,7 +246,7 @@ private:
                 if (anyFailed)
                     AlertWindow::showMessageBoxAsync (AlertWindow::WarningIcon,
                                                       "Adding Missing Dependencies",
-                                                      "Couldn't locate some of these modules - you'll beed to find their "
+                                                      "Couldn't locate some of these modules - you'll need to find their "
                                                       "folders manually and add them to the list.");
             }
 


### PR DESCRIPTION
I know that you don't really take pull requests, but I just wanted to point out this typo I noticed in Introjucer.
