### PR TITLE
Add ScopedLock on Timer destructor

### DIFF
--- a/modules/juce_events/timers/juce_Timer.cpp
+++ b/modules/juce_events/timers/juce_Timer.cpp
@@ -328,6 +328,7 @@ Timer::~Timer()
     stopTimer();
 
    #if JUCE_DEBUG
+    const TimerThread::LockType::ScopedLockType sl (TimerThread::lock);
     activeTimers.removeValue (this);
    #endif
 }


### PR DESCRIPTION
Currently, every time you read or modify the `activeTimers` set, you use a ScopedLock on `TimerThread::lock` -- except in `~Timer()`, where it should also be done.  Otherwise, I think one may run into trouble, when timers are created/destroyed by different threads.

Obviously, this only affects debug builds, where the `activeTimers` set exists.
