### PR TITLE
Mechanism to address bug discovered when reading sysex events from SMF.

### DIFF
--- a/modules/juce_audio_basics/midi/juce_MidiMessage.cpp
+++ b/modules/juce_audio_basics/midi/juce_MidiMessage.cpp
@@ -175,7 +175,7 @@ MidiMessage::MidiMessage (const void* srcData, int sz, int& numBytesUsed, const 
         if (byte == 0xf0)
         {
             const uint8* d = src;
-            bool haveReadAllLengthBytes = false;
+            bool haveReadAllLengthBytes = !isFromSMF;
             int numVariableLengthSysexBytes = 0;
 
             while (d < src + sz)

--- a/modules/juce_audio_basics/midi/juce_MidiMessage.h
+++ b/modules/juce_audio_basics/midi/juce_MidiMessage.h
@@ -82,10 +82,12 @@ public:
                                 has in fact been dropped.
         @param timeStamp        the time to give the midi message - this value doesn't
                                 use any particular units, so will be application-specific
+        @param isFromSMF        true if this data stream came from a SMF; the interpretation
+                                of sys-ex messages is different in this case
     */
     MidiMessage (const void* data, int maxBytesToUse,
                  int& numBytesUsed, uint8 lastStatusByte,
-                 double timeStamp = 0);
+                 double timeStamp = 0, bool isFromSMF = true);
 
     /** Creates an active-sense message.
         Since the MidiMessage has to contain a valid message, this default constructor


### PR DESCRIPTION
Small tweak that would be useful in the mainline.

Parse semantics differ when the source is a SMF vs when it's from a "normal" MIDI stream.
