### PR TITLE
Update juce_StandaloneFilterWindow.h

### DIFF
--- a/modules/juce_audio_plugin_client/Standalone/juce_StandaloneFilterWindow.h
+++ b/modules/juce_audio_plugin_client/Standalone/juce_StandaloneFilterWindow.h
@@ -271,7 +271,7 @@ public:
         optionsButton.addListener (this);
         optionsButton.setTriggeredOnMouseDown (true);
 
-        pluginHolder = new StandalonePluginHolder (settingsToUse, false);
+        pluginHolder = new StandalonePluginHolder (settingsToUse, true);
 
         createEditorComp();
 


### PR DESCRIPTION
I think it should be true here instead of false , because the Documentation of StandaloneFilterWindow still say: 

 "the object that is passed-in will be owned by this class and deleted automatically when no longer needed. (It can also be null)"

but surely StandaloneFilterWindow can not own "settingsToUse" if "false" here
