### PR TITLE
Fix juce::String::natureStringCompare

### DIFF
--- a/modules/juce_core/text/juce_String.cpp
+++ b/modules/juce_core/text/juce_String.cpp
@@ -700,7 +700,7 @@ static int naturalStringCompare (String::CharPointerType s1, String::CharPointer
             if (isAlphaNum2 && ! isAlphaNum1) return -1;
             if (isAlphaNum1 && ! isAlphaNum2) return 1;
 
-            return c1 < c2 ? -1 : 1;
+            return CharacterFunctions::toUpperCase (c1) < CharacterFunctions::toUpperCase (c2) ? -1 : 1;
         }
 
         jassert (c1 != 0 && c2 != 0);


### PR DESCRIPTION
Fixes juce::String::compareNatural behaviour: it is case sensitive when characters differ.
This doesn't match the description and means it's not a strict weak ordering and so not useful for sorting.

Consider the following:

assert(juce::String("a").compareNatural("A") == 0);
assert(juce::String("A").compareNatural("B") < 0);
assert(juce::String("a").compareNatural("B") < 0); // Fails
