### PR TITLE
Fix global/local coordinates issue.

### DIFF
--- a/modules/juce_gui_basics/native/juce_mac_NSViewComponentPeer.mm
+++ b/modules/juce_gui_basics/native/juce_mac_NSViewComponentPeer.mm
@@ -411,9 +411,10 @@ public:
         if (NSWindow* const viewWindow = [view window])
         {
             const NSRect windowFrame = [viewWindow frame];
-            const NSPoint screenPoint = NSMakePoint (windowFrame.origin.x + localPos.getX(),
-                                                     windowFrame.origin.y + windowFrame.size.height - localPos.getY());
-
+            const NSPoint localPoint = NSMakePoint (localPos.x, localPos.y);
+            const NSPoint windowPoint = [view convertPoint: localPoint toView: nil];
+            const NSPoint screenPoint = NSMakePoint (windowFrame.origin.x + windowPoint.x,
+                                                     windowFrame.origin.y + windowFrame.size.height - windowPoint.y);
             if (! isWindowAtPoint (viewWindow, screenPoint))
                 return false;
         }


### PR DESCRIPTION
Hello, 

Thanks for the fix (and the quick reply), it worked well for most cases, but we found an issue when the left side of the window  is out of the screen (the coordinates become negative). The issue was due to local vs global coordinates, here's a patch that fixes it on our end, if you want to have a look.

Best regards,
Francois.
