### PR TITLE
JUCE Brower Plugin Demo

### DIFF
--- a/extras/Introjucer/Source/Project/jucer_ConfigTree_Modules.h
+++ b/extras/Introjucer/Source/Project/jucer_ConfigTree_Modules.h
@@ -246,7 +246,7 @@ private:
                 if (anyFailed)
                     AlertWindow::showMessageBoxAsync (AlertWindow::WarningIcon,
                                                       "Adding Missing Dependencies",
-                                                      "Couldn't locate some of these modules - you'll beed to find their "
+                                                      "Couldn't locate some of these modules - you'll need to find their "
                                                       "folders manually and add them to the list.");
             }
 


### PR DESCRIPTION
![juce](https://cloud.githubusercontent.com/assets/7788738/4164428/7b2ed5f8-34f4-11e4-9467-cf31a0896b29.PNG)
It seems something's depricated or changed on latest Windows and VS. When I open project in "win32" folder, VS2013 started to migrate project and there's some warnings... check this please.
