### PR TITLE
fix JNI deliverMessage prototype

### DIFF
--- a/modules/juce_events/native/juce_android_Messaging.cpp
+++ b/modules/juce_events/native/juce_android_Messaging.cpp
@@ -42,7 +42,7 @@ bool MessageManager::postMessageToSystemQueue (MessageManager::MessageBase* cons
     return true;
 }
 
-JUCE_JNI_CALLBACK (JUCE_ANDROID_ACTIVITY_CLASSNAME, deliverMessage, void, (jobject activity, jlong value))
+JUCE_JNI_CALLBACK (JUCE_ANDROID_ACTIVITY_CLASSNAME, deliverMessage, void, (JNIEnv* env, jobject activity, jlong value))
 {
     JUCE_TRY
     {


### PR DESCRIPTION
The first argument has to be JNIEnv*, it was missing from the definition of the deliverMessage method used from Java. This was leading to crashes on Android devices.
