### PR TITLE
Fixed coords translation in NSViewComponentPeer

### DIFF
--- a/modules/juce_gui_basics/native/juce_mac_NSViewComponentPeer.mm
+++ b/modules/juce_gui_basics/native/juce_mac_NSViewComponentPeer.mm
@@ -411,9 +411,9 @@ public:
         if (NSWindow* const viewWindow = [view window])
         {
             const NSRect windowFrame = [viewWindow frame];
-            const NSPoint windowPoint = [view convertPoint: NSMakePoint (localPos.x, localPos.y) toView: nil];
+            const NSPoint windowPoint = [view convertPoint: NSMakePoint (localPos.x, viewFrame.size.height - localPos.y) toView: nil];
             const NSPoint screenPoint = NSMakePoint (windowFrame.origin.x + windowPoint.x,
-                                                     windowFrame.origin.y + windowFrame.size.height - windowPoint.y);
+                                                     windowFrame.origin.y + windowPoint.y);
 
             if (! isWindowAtPoint (viewWindow, screenPoint))
                 return false;


### PR DESCRIPTION
Hi Jules,

I've encountered a bug in our After Effects plugin. When some window partially overlaps the main window, mouse click events in certain area above the overlapping window are not being triggered. It is caused by incorrect translation from JUCE coords (with origin in top-left corner) to NSView coordinates with origin in bottom-left corner. Due to this a wrong point is passed to isWindowAtPoint method which returns false afterwards. I'm not sure whether I correctly fixed this but at least I wanted to inform you about this issue.

Cheers,

Martin
