### PR TITLE
Uniforms hack

### DIFF
--- a/modules/juce_opengl/opengl/juce_OpenGLGraphicsContext.h
+++ b/modules/juce_opengl/opengl/juce_OpenGLGraphicsContext.h
@@ -24,7 +24,7 @@
   ==============================================================================
 */
 
-#include <unordered_map>
+#include <functional>
 
 namespace juce
 {
@@ -83,7 +83,7 @@ struct JUCE_API  OpenGLGraphicsContextCustomShader
     OpenGLShaderProgram* getProgram (LowLevelGraphicsContext&) const;
 
     /** Applies the shader to a rectangle within the graphics context. */
-    void fillRect (LowLevelGraphicsContext&, Rectangle<int> area, std::unordered_map<std::string, std::atomic<float>>& uniforms) const;
+    void fillRect (LowLevelGraphicsContext&, Rectangle<int> area) const;
 
     /** Attempts to compile the program if necessary, and returns an error message if it fails. */
     Result checkCompilation (LowLevelGraphicsContext&);
@@ -91,6 +91,8 @@ struct JUCE_API  OpenGLGraphicsContextCustomShader
     /** Returns the code that was used to create this object. */
     const String& getFragmentShaderCode() const noexcept           { return code; }
 
+    std::function<void(OpenGLShaderProgram*)> onSetUniforms;
+    
 private:
     String code, hashName;
 

--- a/modules/juce_opengl/opengl/juce_OpenGLGraphicsContext.h
+++ b/modules/juce_opengl/opengl/juce_OpenGLGraphicsContext.h
@@ -24,6 +24,8 @@
   ==============================================================================
 */
 
+#include <unordered_map>
+
 namespace juce
 {
 
@@ -81,7 +83,7 @@ struct JUCE_API  OpenGLGraphicsContextCustomShader
     OpenGLShaderProgram* getProgram (LowLevelGraphicsContext&) const;
 
     /** Applies the shader to a rectangle within the graphics context. */
-    void fillRect (LowLevelGraphicsContext&, Rectangle<int> area) const;
+    void fillRect (LowLevelGraphicsContext&, Rectangle<int> area, std::unordered_map<std::string, std::atomic<float>>& uniforms) const;
 
     /** Attempts to compile the program if necessary, and returns an error message if it fails. */
     Result checkCompilation (LowLevelGraphicsContext&);


### PR DESCRIPTION
I raised an issue around setting uniforms using OpenGLGraphicsContextCustomShader - full context on the JUCE forum:

https://forum.juce.com/t/requested-improvements-to-opengl-shader-support-in-juce/27422

This solution allows uniforms to be set using a std::function. It involves a copy of a function which should be improved but this should be the basis of a workable solution.

<!-- gk-ai-analysis-start:7443a2b5acd2b7153c28d786d52c63d7b2ce3eec -->
<!-- gk-ai-analysis-data:eyJzdW1tYXJ5IjoiSW50cm9kdWNlcyBhIGNhbGxiYWNrIG1lY2hhbmlzbSB2aWEgYHN0ZDo6ZnVuY3Rpb25gIHRvIGFsbG93IHNldHRpbmcgY3VzdG9tIHVuaWZvcm1zIG9uIE9wZW5HTCBzaGFkZXJzIGJlZm9yZSByZW5kZXJpbmcuIiwia2V5SW5zaWdodHMiOlt7InRpdGxlIjoiUHVibGljIHVuaWZvcm0gY2FsbGJhY2sgYWRkZWQiLCJkZXNjcmlwdGlvbiI6IkFkZHMgYSBwdWJsaWMgYG9uU2V0VW5pZm9ybXNgIGZpZWxkIHRvIGBPcGVuR0xHcmFwaGljc0NvbnRleHRDdXN0b21TaGFkZXJgIHRoYXQgdXNlcnMgY2FuIGFzc2lnbiBhIGNhbGxiYWNrIHRvLCB3aGljaCB3aWxsIGJlIGV4ZWN1dGVkIHRvIGNvbmZpZ3VyZSB1bmlmb3Jtcy4iLCJzZXZlcml0eSI6Im1lZGl1bSIsImZpbGVQYXRoIjoibW9kdWxlcy9qdWNlX29wZW5nbC9vcGVuZ2wvanVjZV9PcGVuR0xHcmFwaGljc0NvbnRleHQuaCIsImxpbmVTdGFydCI6OTN9LHsidGl0bGUiOiJJbnZvY2F0aW9uIGFmdGVyIGF0dHJpYnV0ZSBiaW5kaW5nIiwiZGVzY3JpcHRpb24iOiJUaGUgY3VzdG9tIGNhbGxiYWNrIGlzIGV4ZWN1dGVkIGltbWVkaWF0ZWx5IGFmdGVyIHNoYWRlciBhdHRyaWJ1dGVzIGFyZSBib3VuZCBhbmQgYmVmb3JlIHRoZSBib3VuZHMgYXJlIGNvbmZpZ3VyZWQgYW5kIHJlbmRlcmVkLiIsInNldmVyaXR5IjoibWVkaXVtIiwiZmlsZVBhdGgiOiJtb2R1bGVzL2p1Y2Vfb3BlbmdsL29wZW5nbC9qdWNlX09wZW5HTEdyYXBoaWNzQ29udGV4dC5jcHAiLCJsaW5lU3RhcnQiOjEzMzQsImxpbmVFbmQiOjEzMzV9XSwiaXNzdWVzIjpbeyJ0aXRsZSI6Ik11dGF0aW9uIG9mIHNoYXJlZCBjYWNoZWQgcHJvZ3JhbSIsImRlc2NyaXB0aW9uIjoiVGhlIGBDdXN0b21Qcm9ncmFtYCBpbnN0YW5jZSByZXR1cm5lZCBieSBgZ2V0T3JDcmVhdGVgIGlzIGNhY2hlZCBhbmQgc2hhcmVkLiBNdXRhdGluZyBgYy0+b25TZXRVbmlmb3Jtc2Agb24gZXZlcnkgYGZpbGxSZWN0YCBjYWxsIG1vZGlmaWVzIHNoYXJlZCBzdGF0ZS4gSWYgdGhlIHNhbWUgY3VzdG9tIHNoYWRlciBjb2RlIGlzIHVzZWQgY29uY3VycmVudGx5IG9yIGludGVybGVhdmVkLCB0aGlzIGNvdWxkIGxlYWQgdG8gaW5jb3JyZWN0IHVuaWZvcm0gY2FsbGJhY2tzIGJlaW5nIGV4ZWN1dGVkLiIsInNldmVyaXR5IjoiaGlnaCIsImZpbGVQYXRoIjoibW9kdWxlcy9qdWNlX29wZW5nbC9vcGVuZ2wvanVjZV9PcGVuR0xHcmFwaGljc0NvbnRleHQuY3BwIiwibGluZVN0YXJ0IjoxOTI0LCJsaW5lRW5kIjoxOTI1fV0sInN1Z2dlc3Rpb25zIjpbeyJ0aXRsZSI6IlBvdGVudGlhbCBoZWFwIGFsbG9jYXRpb24gaW4gcmVuZGVyIGxvb3AiLCJkZXNjcmlwdGlvbiI6IkFzc2lnbmluZyBgYy0+b25TZXRVbmlmb3JtcyA9IG9uU2V0VW5pZm9ybXNgIGNvcGllcyB0aGUgYHN0ZDo6ZnVuY3Rpb25gLiBJZiB0aGUgdXNlciBwcm92aWRlcyBhIGNhcHR1cmluZyBsYW1iZGEgdGhhdCBleGNlZWRzIHRoZSBzbWFsbC1vYmplY3Qgb3B0aW1pemF0aW9uIHNpemUgbGltaXQsIHRoaXMgd2lsbCBjYXVzZSBoZWFwIGFsbG9jYXRpb25zIG9uIGV2ZXJ5IHNpbmdsZSBkcmF3IGNhbGwuIENvbnNpZGVyIGFsdGVyaW5nIHRoZSBpbnRlcm5hbCBBUEkgdG8gcGFzcyB0aGUgY2FsbGJhY2sgZG93biB0byBgZmlsbFJlY3RXaXRoQ3VzdG9tU2hhZGVyYCBkaXJlY3RseSBhcyBhbiBhcmd1bWVudCBvciBgY29uc3Qgc3RkOjpmdW5jdGlvbiZgIHJhdGhlciB0aGFuIHN0b3JpbmcgaXQgb24gdGhlIGNhY2hlZCBwcm9ncmFtLiIsInNldmVyaXR5IjoibWVkaXVtIiwiZmlsZVBhdGgiOiJtb2R1bGVzL2p1Y2Vfb3BlbmdsL29wZW5nbC9qdWNlX09wZW5HTEdyYXBoaWNzQ29udGV4dC5jcHAiLCJsaW5lU3RhcnQiOjE5MjQsImxpbmVFbmQiOjE5MjV9XSwic2VjdXJpdHkiOltdfQ== -->
<!-- gk-ai-analysis-end:7443a2b5acd2b7153c28d786d52c63d7b2ce3eec -->

<!-- gitkraken-review-badge-begin -->
---
<a href="https://gitkraken.dev/review/github/juce-framework/JUCE/pull/384">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://gitkraken.dev/images/figures/gitkraken-review-badge-dark.svg">
    <img src="https://gitkraken.dev/images/figures/gitkraken-review-badge-light.svg" alt="Open with GitKraken">
  </picture>
</a>
<!-- gitkraken-review-badge-end -->