### PR TITLE
DSP:  Exposed IR update ramp length parameter in the convolution class

### DIFF
--- a/modules/juce_dsp/frequency/juce_Convolution.cpp
+++ b/modules/juce_dsp/frequency/juce_Convolution.cpp
@@ -398,9 +398,15 @@ struct Convolution::Pimpl  : private Thread
         int start1, size1, start2, size2;
         abstractFifo.prepareToWrite (1, start1, size1, start2, size2);
 
-        // If you hit this assertion then you have requested more impulse response
-        // changes than the Convolution class can handle.
-        jassert (size1 + size2 > 0);
+        // Discard addition if stack already full. User likely required too many updates, 
+        // e.g. impulse response change, without time for processFifo() to empty the stack.
+        // That, or processSamples(), thus processFifo(), is no longer invoked (convolution 
+        // bypassed?) leading to update requests piling up in the stack.
+        if ( !(size1 + size2 > 0) )
+        {
+            DBG("Skipped dsp::convolution filter update, internal request stack full.");
+            return;
+        }
 
         if (size1 > 0)
         {
@@ -423,9 +429,15 @@ struct Convolution::Pimpl  : private Thread
         int start1, size1, start2, size2;
         abstractFifo.prepareToWrite (numEntries, start1, size1, start2, size2);
 
-        // If you hit this assertion then you have requested more impulse response
-        // changes than the Convolution class can handle.
-        jassert (numEntries > 0 && size1 + size2 > 0);
+        // Discard addition if stack already full. User likely required too many updates, 
+        // e.g. impulse response change, without time for processFifo() to empty the stack.
+        // That, or processSamples(), thus processFifo(), is no longer invoked (convolution 
+        // bypassed?) leading to update requests piling up in the stack.
+        if ( !(numEntries > 0 && size1 + size2 > 0) )
+        {
+            DBG("Skipped dsp::convolution filter update, internal request stack full.");
+            return;
+        }
 
         if (size1 > 0)
         {

--- a/modules/juce_dsp/frequency/juce_Convolution.h
+++ b/modules/juce_dsp/frequency/juce_Convolution.h
@@ -149,6 +149,15 @@ public:
                                               bool wantsStereo, bool wantsTrimming, bool wantsNormalisation,
                                               size_t size);
 
+    /** This function defines the time it takes for the convolution engine
+     to fade between impulse responses. Small values (e.g. 0.05) will result in
+     faster transitions, eventually resulting in audible signal discontinuities (zipper noises).
+     Large values (e.g. 0.4) will ensure the output is free of discontinuities at the price of
+     responsiveness of the engine upon impulse response update.
+     
+     @param rampLengthInSeconds      the new ramp length to fade between impulse responses (in seconds)
+     */
+    void setImpulseResponseChangeRampLength (double rampLengthInSeconds);
 
 private:
     //==============================================================================
@@ -162,6 +171,7 @@ private:
     double sampleRate;
     bool currentIsBypassed = false;
     bool isActive = false;
+    double irRampLengthInSeconds = 0.4;
     SmoothedValue<float> volumeDry[2], volumeWet[2];
     AudioBlock<float> dryBuffer;
     HeapBlock<char> dryBufferStorage;


### PR DESCRIPTION
This PR allows users to define the IR switch ramp time, kept to the default 0.4 if not overwritten. The fade duration between IR is application dependent: needs to be smooth for zipper noise critical implementations (e.g. studio mixing), and fast for highly responsive ones (e.g. research on perception threshold on IR shifts).