### PR TITLE
Add minimum "GUI-less" Linux VST3 support. (host only)

### DIFF
--- a/extras/Projucer/Source/ProjectSaving/jucer_ProjectExport_Make.h
+++ b/extras/Projucer/Source/ProjectSaving/jucer_ProjectExport_Make.h
@@ -179,6 +179,7 @@ public:
                 case VSTPlugIn:
                 case UnityPlugIn:
                 case DynamicLibrary:        return ".so";
+                case VST3PlugIn:            return ".vst3"
                 case SharedCodeTarget:
                 case StaticLibrary:         return ".a";
                 default:                    break;
@@ -352,6 +353,7 @@ public:
             case ProjectType::Target::SharedCodeTarget:
             case ProjectType::Target::AggregateTarget:
             case ProjectType::Target::VSTPlugIn:
+            case ProjectType::Target::VST3PlugIn:
             case ProjectType::Target::StandalonePlugIn:
             case ProjectType::Target::DynamicLibrary:
             case ProjectType::Target::UnityPlugIn:

--- a/extras/Projucer/Source/ProjectSaving/jucer_ProjectExport_Make.h
+++ b/extras/Projucer/Source/ProjectSaving/jucer_ProjectExport_Make.h
@@ -179,7 +179,7 @@ public:
                 case VSTPlugIn:
                 case UnityPlugIn:
                 case DynamicLibrary:        return ".so";
-                case VST3PlugIn:            return ".vst3"
+                case VST3PlugIn:            return ".vst3";
                 case SharedCodeTarget:
                 case StaticLibrary:         return ".a";
                 default:                    break;

--- a/modules/juce_audio_plugin_client/VST3/juce_VST3_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/VST3/juce_VST3_Wrapper.cpp
@@ -27,9 +27,9 @@
 #include "../../juce_core/system/juce_TargetPlatform.h"
 
 //==============================================================================
-#if JucePlugin_Build_VST3 && (__APPLE_CPP__ || __APPLE_CC__ || _WIN32 || _WIN64)
+#if JucePlugin_Build_VST3 && (__APPLE_CPP__ || __APPLE_CC__ || _WIN32 || _WIN64 || __linux__)
 
-#if JUCE_PLUGINHOST_VST3 && (JUCE_MAC || JUCE_WINDOWS)
+#if JUCE_PLUGINHOST_VST3 && (JUCE_MAC || JUCE_WINDOWS || JUCE_LINUX)
  #undef JUCE_VST3HEADERS_INCLUDE_HEADERS_ONLY
  #define JUCE_VST3HEADERS_INCLUDE_HEADERS_ONLY 1
 #endif
@@ -1064,7 +1064,7 @@ private:
             if (component == nullptr)
                 component.reset (new ContentWrapperComponent (*this, pluginInstance));
 
-           #if JUCE_WINDOWS
+           #if !JUCE_MAC
             component->addToDesktop (0, parent);
             component->setOpaque (true);
             component->setVisible (true);
@@ -1092,7 +1092,7 @@ private:
         {
             if (component != nullptr)
             {
-               #if JUCE_WINDOWS
+               #if !JUCE_MAC
                 component->removeFromDesktop();
                #else
                 if (macHostWindow != nullptr)
@@ -2830,7 +2830,7 @@ bool shutdownModule()
     extern "C" __declspec (dllexport) bool ExitDll()   { return shutdownModule(); }
     #define JUCE_EXPORTED_FUNCTION
 
-#else
+#elif JUCE_MAC
     #define JUCE_EXPORTED_FUNCTION extern "C" __attribute__ ((visibility ("default")))
 
     CFBundleRef globalBundleInstance = nullptr;
@@ -2881,6 +2881,8 @@ bool shutdownModule()
 
         return false;
     }
+#else
+    #define JUCE_EXPORTED_FUNCTION extern "C" __attribute__ ((visibility ("default")))
 #endif
 
 //==============================================================================

--- a/modules/juce_audio_plugin_client/utility/juce_CheckSettingMacros.h
+++ b/modules/juce_audio_plugin_client/utility/juce_CheckSettingMacros.h
@@ -74,7 +74,7 @@
  #define JucePlugin_Build_RTAS 0
 #endif
 
-#if ! (defined (_MSC_VER) || defined (__APPLE_CPP__) || defined (__APPLE_CC__))
+#if ! (defined (_MSC_VER) || defined (__APPLE_CPP__) || defined (__linux__) || defined (__APPLE_CC__))
  #undef JucePlugin_Build_VST3
  #define JucePlugin_Build_VST3 0
 #endif

--- a/modules/juce_audio_plugin_client/utility/juce_PluginUtilities.cpp
+++ b/modules/juce_audio_plugin_client/utility/juce_PluginUtilities.cpp
@@ -63,7 +63,7 @@ std::function<bool(AudioProcessor&)> PluginHostType::jucePlugInIsRunningInAudioS
  #define JUCE_VST3_CAN_REPLACE_VST2 1
 #endif
 
-#if JucePlugin_Build_VST3 && (__APPLE_CPP__ || __APPLE_CC__ || _WIN32 || _WIN64) && JUCE_VST3_CAN_REPLACE_VST2
+#if JucePlugin_Build_VST3 && (__APPLE_CPP__ || __APPLE_CC__ || _WIN32 || _WIN64 || __linux__) && JUCE_VST3_CAN_REPLACE_VST2
 #define VST3_REPLACEMENT_AVAILABLE 1
 
 // NB: Nasty old-fashioned code in here because it's copied from the Steinberg example code.

--- a/modules/juce_audio_processors/format/juce_AudioPluginFormatManager.cpp
+++ b/modules/juce_audio_processors/format/juce_AudioPluginFormatManager.cpp
@@ -74,7 +74,7 @@ void AudioPluginFormatManager::addDefaultFormats()
         jassert (dynamic_cast<VSTPluginFormat*> (format) == nullptr);
        #endif
 
-       #if JUCE_PLUGINHOST_VST3 && (JUCE_MAC || JUCE_WINDOWS)
+       #if JUCE_PLUGINHOST_VST3 && (JUCE_MAC || JUCE_WINDOWS || JUCE_LINUX)
         jassert (dynamic_cast<VST3PluginFormat*> (format) == nullptr);
        #endif
 
@@ -96,7 +96,7 @@ void AudioPluginFormatManager::addDefaultFormats()
     formats.add (new VSTPluginFormat());
    #endif
 
-   #if JUCE_PLUGINHOST_VST3 && (JUCE_MAC || JUCE_WINDOWS)
+   #if JUCE_PLUGINHOST_VST3 && (JUCE_MAC || JUCE_WINDOWS || JUCE_LINUX)
     formats.add (new VST3PluginFormat());
    #endif
 

--- a/modules/juce_audio_processors/format_types/juce_VST3Headers.h
+++ b/modules/juce_audio_processors/format_types/juce_VST3Headers.h
@@ -168,6 +168,10 @@ namespace Steinberg
  #include <windows.h>
 #endif
 
+#if JUCE_LINUX
+#include <dlfcn.h>
+#endif
+
 //==============================================================================
 #undef ASSERT
 #undef WARNING

--- a/modules/juce_audio_processors/format_types/juce_VST3PluginFormat.h
+++ b/modules/juce_audio_processors/format_types/juce_VST3PluginFormat.h
@@ -27,7 +27,7 @@
 namespace juce
 {
 
-#if (JUCE_PLUGINHOST_VST3 && (JUCE_MAC || JUCE_WINDOWS)) || DOXYGEN
+#if (JUCE_PLUGINHOST_VST3 && (JUCE_MAC || JUCE_WINDOWS || JUCE_LINUX)) || DOXYGEN
 
 /**
     Implements a plugin format for VST3s.

--- a/modules/juce_audio_processors/juce_audio_processors.cpp
+++ b/modules/juce_audio_processors/juce_audio_processors.cpp
@@ -53,7 +53,7 @@
  #undef KeyPress
 #endif
 
-#if ! JUCE_WINDOWS && ! JUCE_MAC
+#if ! JUCE_WINDOWS && ! JUCE_MAC && ! JUCE_LINUX
  #undef JUCE_PLUGINHOST_VST3
  #define JUCE_PLUGINHOST_VST3 0
 #endif


### PR DESCRIPTION
This partly addresses https://github.com/WeAreROLI/JUCE/issues/307 (which is in turn referenced at https://forum.juce.com/t/vst3-support-on-linux/31872/2). The changes aim to bring VST3 to JUCE apps on Linux. This does NOT bring GUI support, but the audio part seems to be working. This seems to help some apps that don't depend on juce_gui_basic. Maybe only partially, but AudioPluginHost successfully listed and loaded some VST3 plugins (mda-vst for example).

![VST3 plugins listed and loaded on AudioPluginHost](https://user-images.githubusercontent.com/53929/57054670-0fc45300-6cd1-11e9-9748-71ba8c30565e.png)