### PR TITLE
Add visibility status in ResizableWindow state get/restore methods

### DIFF
--- a/modules/juce_gui_basics/windows/juce_ResizableWindow.cpp
+++ b/modules/juce_gui_basics/windows/juce_ResizableWindow.cpp
@@ -528,18 +528,20 @@ void ResizableWindow::parentSizeChanged()
 String ResizableWindow::getWindowStateAsString()
 {
     updateLastPosIfShowing();
-    return (isFullScreen() && ! isKioskMode() ? "fs " : "") + lastNonFullScreenPos.toString();
+    return String (isVisible() ? "" : "h ") + String (isFullScreen() && ! isKioskMode() ? "fs " : "")
+                                            + lastNonFullScreenPos.toString();
 }
 
-bool ResizableWindow::restoreWindowStateFromString (const String& s)
+bool ResizableWindow::restoreWindowStateFromString (const String& s, bool forceVisible)
 {
     StringArray tokens;
     tokens.addTokens (s, false);
     tokens.removeEmptyStrings();
     tokens.trim();
 
-    const bool fs = tokens[0].startsWithIgnoreCase ("fs");
-    const int firstCoord = fs ? 1 : 0;
+    const bool hidden = tokens[0].startsWithIgnoreCase ("h");
+    const bool fs = tokens[1].startsWithIgnoreCase ("fs");
+    const int firstCoord = (hidden ? 1 : 0) + (fs ? 1 : 0);
 
     if (tokens.size() != firstCoord + 4)
         return false;
@@ -590,6 +592,8 @@ bool ResizableWindow::restoreWindowStateFromString (const String& s)
 
     if (! fs)
         setBoundsConstrained (newPos);
+    
+    setVisible (forceVisible ? true : ! hidden);
 
     return true;
 }

--- a/modules/juce_gui_basics/windows/juce_ResizableWindow.cpp
+++ b/modules/juce_gui_basics/windows/juce_ResizableWindow.cpp
@@ -540,8 +540,9 @@ bool ResizableWindow::restoreWindowStateFromString (const String& s, bool forceV
     tokens.trim();
 
     const bool hidden = tokens[0].startsWithIgnoreCase ("h");
-    const bool fs = tokens[1].startsWithIgnoreCase ("fs");
-    const int firstCoord = (hidden ? 1 : 0) + (fs ? 1 : 0);
+    const int fsToken = (hidden ? 1 : 0);
+    const bool fs = tokens[fsToken].startsWithIgnoreCase ("fs");
+    const int firstCoord = fsToken + (fs ? 1 : 0);
 
     if (tokens.size() != firstCoord + 4)
         return false;

--- a/modules/juce_gui_basics/windows/juce_ResizableWindow.h
+++ b/modules/juce_gui_basics/windows/juce_ResizableWindow.h
@@ -207,9 +207,9 @@ public:
     //==============================================================================
     /** Returns a string which encodes the window's current size and position.
 
-        This string will encapsulate the window's size, position, and whether it's
-        in full-screen mode. It's intended for letting your application save and
-        restore a window's position.
+        This string will encapsulate the window's size, position, whether it's
+        in full-screen mode and wether it's visible. It's intended for letting your
+        application save and restore a window's position.
 
         Use the restoreWindowStateFromString() to restore from a saved state.
 
@@ -219,14 +219,17 @@ public:
 
     /** Restores the window to a previously-saved size and position.
 
-        This restores the window's size, position and full-screen status from an
+        This restores the window's size, position, full-screen and visibility status from a
         string that was previously created with the getWindowStateAsString()
         method.
+     
+        @param forceVisible         if true, then the visibility status from the provided previous
+                                    state will be ignored and forced to true.
 
         @returns false if the string wasn't a valid window state
         @see getWindowStateAsString
     */
-    bool restoreWindowStateFromString (const String& previousState);
+    bool restoreWindowStateFromString (const String& previousState, bool forceVisible = false);
 
 
     //==============================================================================


### PR DESCRIPTION
A small PR to easily also save/restore a window's visibility (e.g. supposably when using `ApplicationProperties` during a GUI application initialisation or shutdown).

The `forceVisible` param is handy to ensure a "main" window would always be visible, thus avoiding the potential confusion for the user to not see any opened window upon starting the application).

Example:
```
mainWindow->restoreWindowStateFromString (applicationProperties.getUserSettings()->getValue ("mainWindowState"), true);
        
auxWindow->restoreWindowStateFromString  (applicationProperties.getUserSettings()->getValue ("auxWindowState"));
```

**Note**: in order not to break anything with previously saved window states, the `restoreWindowStateFromString` method will look for a "h" (for hidden) token in the string.