### PR TITLE
Un-constify getProgramName return value

### DIFF
--- a/modules/juce_audio_processors/format_types/juce_AudioUnitPluginFormat.mm
+++ b/modules/juce_audio_processors/format_types/juce_AudioUnitPluginFormat.mm
@@ -1275,7 +1275,7 @@ public:
         sendAllParametersChangedEvents();
     }
 
-    const String getProgramName (int index) override
+    String getProgramName (int index) override
     {
         String s;
         CFArrayRef presets;

--- a/modules/juce_audio_processors/format_types/juce_LADSPAPluginFormat.cpp
+++ b/modules/juce_audio_processors/format_types/juce_LADSPAPluginFormat.cpp
@@ -365,7 +365,7 @@ public:
                 ladspaParam->reset();
     }
 
-    const String getProgramName (int) override             { return {}; }
+    String getProgramName (int) override             { return {}; }
     void changeProgramName (int, const String&) override   {}
 
     //==============================================================================

--- a/modules/juce_audio_processors/format_types/juce_VST3PluginFormat.cpp
+++ b/modules/juce_audio_processors/format_types/juce_VST3PluginFormat.cpp
@@ -2231,7 +2231,7 @@ public:
 
     //==============================================================================
     int getNumPrograms() override                        { return programNames.size(); }
-    const String getProgramName (int index) override     { return programNames[index]; }
+    String getProgramName (int index) override     { return programNames[index]; }
     int getCurrentProgram() override                     { return jmax (0, (int) editController->getParamNormalized (programParameterID) * (programNames.size() - 1)); }
     void changeProgramName (int, const String&) override {}
 

--- a/modules/juce_audio_processors/format_types/juce_VSTPluginFormat.cpp
+++ b/modules/juce_audio_processors/format_types/juce_VSTPluginFormat.cpp
@@ -1577,7 +1577,7 @@ struct VSTPluginInstance     : public AudioPluginInstance,
             dispatch (Vst2::effSetProgram, 0, jlimit (0, getNumPrograms() - 1, newIndex), nullptr, 0);
     }
 
-    const String getProgramName (int index) override
+    String getProgramName (int index) override
     {
         if (index >= 0)
         {

--- a/modules/juce_audio_processors/processors/juce_AudioProcessor.h
+++ b/modules/juce_audio_processors/processors/juce_AudioProcessor.h
@@ -1049,7 +1049,7 @@ public:
     virtual void setCurrentProgram (int index) = 0;
 
     /** Must return the name of a given program. */
-    virtual const String getProgramName (int index) = 0;
+    virtual String getProgramName (int index) = 0;
 
     /** Called by the host to rename a program. */
     virtual void changeProgramName (int index, const String& newName) = 0;

--- a/modules/juce_audio_processors/processors/juce_AudioProcessorGraph.cpp
+++ b/modules/juce_audio_processors/processors/juce_AudioProcessorGraph.cpp
@@ -1518,7 +1518,7 @@ int AudioProcessorGraph::AudioGraphIOProcessor::getNumPrograms()                
 int AudioProcessorGraph::AudioGraphIOProcessor::getCurrentProgram()                 { return 0; }
 void AudioProcessorGraph::AudioGraphIOProcessor::setCurrentProgram (int)            { }
 
-const String AudioProcessorGraph::AudioGraphIOProcessor::getProgramName (int)       { return {}; }
+String AudioProcessorGraph::AudioGraphIOProcessor::getProgramName (int)       { return {}; }
 void AudioProcessorGraph::AudioGraphIOProcessor::changeProgramName (int, const String&) {}
 
 void AudioProcessorGraph::AudioGraphIOProcessor::getStateInformation (juce::MemoryBlock&) {}

--- a/modules/juce_audio_processors/processors/juce_AudioProcessorGraph.h
+++ b/modules/juce_audio_processors/processors/juce_AudioProcessorGraph.h
@@ -362,7 +362,7 @@ public:
         int getNumPrograms() override;
         int getCurrentProgram() override;
         void setCurrentProgram (int) override;
-        const String getProgramName (int) override;
+        String getProgramName (int) override;
         void changeProgramName (int, const String&) override;
 
         void getStateInformation (juce::MemoryBlock& destData) override;
@@ -398,7 +398,7 @@ public:
     int getNumPrograms() override                           { return 0; }
     int getCurrentProgram() override                        { return 0; }
     void setCurrentProgram (int) override                   { }
-    const String getProgramName (int) override              { return {}; }
+    String getProgramName (int) override              { return {}; }
     void changeProgramName (int, const String&) override    { }
     void getStateInformation (juce::MemoryBlock&) override;
     void setStateInformation (const void* data, int sizeInBytes) override;

--- a/modules/juce_audio_processors/processors/juce_AudioProcessorParameterGroup.cpp
+++ b/modules/juce_audio_processors/processors/juce_AudioProcessorParameterGroup.cpp
@@ -308,7 +308,7 @@ private:
         int getNumPrograms() override { return 0; }
         int getCurrentProgram() override { return 0; }
         void setCurrentProgram (int) override {}
-        const String getProgramName (int) override { return {}; }
+        String getProgramName (int) override { return {}; }
         void changeProgramName (int, const String&) override {}
         void getStateInformation (MemoryBlock&) override {}
         void setStateInformation (const void*, int) override {}

--- a/modules/juce_audio_processors/utilities/juce_AudioProcessorValueTreeState.cpp
+++ b/modules/juce_audio_processors/utilities/juce_AudioProcessorValueTreeState.cpp
@@ -883,7 +883,7 @@ private:
         int getNumPrograms() override { return 1; }
         int getCurrentProgram() override { return {}; }
         void setCurrentProgram (int) override {}
-        const String getProgramName (int) override { return {}; }
+        String getProgramName (int) override { return {}; }
         void changeProgramName (int, const String&) override {}
         void getStateInformation (MemoryBlock&) override {}
         void setStateInformation (const void*, int) override {}


### PR DESCRIPTION
`getProgramName` unconventionally returns `const String` rather than just `String`, and so triggers various warnings. Besides having no advantage AFAICS*, `clang-tidy` triggers the `readability-const-return-type` warning on this.

This is a breaking change for existing overriders, though (*which is a valid reason to keep as-is, though not a great one), so if the pull request is accepted it should also be listed under the breaking changes.