### PR TITLE
Restructure AutoResizingNSViewComponentWithParent to maintain a valid parent pointer during its lifetime

### DIFF
--- a/modules/juce_audio_processors/format_types/juce_VST3PluginFormat.cpp
+++ b/modules/juce_audio_processors/format_types/juce_VST3PluginFormat.cpp
@@ -1379,7 +1379,7 @@ private:
            #elif JUCE_MAC
             embeddedComponent.setBounds (getLocalBounds());
             addAndMakeVisible (embeddedComponent);
-            pluginHandle = (NSView*) embeddedComponent.getView();
+            pluginHandle = (NSView*) embeddedComponent.getParentView();
             jassert (pluginHandle != nil);
            #endif
 

--- a/modules/juce_audio_processors/format_types/juce_VSTPluginFormat.cpp
+++ b/modules/juce_audio_processors/format_types/juce_VSTPluginFormat.cpp
@@ -2762,6 +2762,8 @@ struct VSTPluginWindow   : public AudioProcessorEditor,
                           #if ! JUCE_MAC
                            private ComponentMovementWatcher,
                            private ComponentPeer::ScaleFactorListener,
+                          #elif JUCE_MAC
+                           private AsyncUpdater,
                           #endif
                            private Timer
 {
@@ -2792,6 +2794,7 @@ public:
         {
             cocoaWrapper.reset (new AutoResizingNSViewComponentWithParent());
             addAndMakeVisible (cocoaWrapper.get());
+            triggerAsyncUpdate();
         }
        #endif
 
@@ -2838,13 +2841,21 @@ public:
     {
         g.fillAll (Colours::black);
     }
+    
+    void handleAsyncUpdate() override
+    {
+        // At that point we should have a valid parent view pointer!
+        jassert(cocoaWrapper->getParentView() != nullptr);
+        
+        visibilityChanged();
+    }
 
     void visibilityChanged() override
     {
-        if (cocoaWrapper != nullptr)
+        if (cocoaWrapper->getParentView() != nullptr)
         {
             if (isVisible())
-                openPluginWindow ((NSView*)cocoaWrapper->getView());
+                openPluginWindow ((NSView*)cocoaWrapper->getParentView());
             else
                 closePluginWindow();
         }


### PR DESCRIPTION
This PR proposes a change to `AutoResizingNSViewComponentWithParent` such that its parent `NSView*` is not changed when instantiating VST2/3 plugin editors.

It fixes a crash when showing Softube plugin GUIs in JUCE hosts as well as visibility issues with KORG Gadget plugins (see #614). Both issues can be tested in the AudioPluginHostDemo.

The PR is marked as draft because it still contains an ugly workaround to trigger a resize of the parent window after the view has been attached in `AutoResizingNSViewComponentWithParent::timerCallback()`. Maybe one of the JUCE devs has an idea how to directly trigger the respective events when adding the `NSView` child.