### PR TITLE
Fixed reversed inputs and outputs for Jack.

### DIFF
--- a/modules/juce_audio_devices/native/juce_linux_JackAudio.cpp
+++ b/modules/juce_audio_devices/native/juce_linux_JackAudio.cpp
@@ -183,7 +183,8 @@ public:
                 inputName << "in_" << ++totalNumberOfInputChannels;
 
                 inputPorts.add (juce::jack_port_register (client, inputName.toUTF8(),
-                                                          JACK_DEFAULT_AUDIO_TYPE, JackPortIsInput, 0));
+                                                          JACK_DEFAULT_AUDIO_TYPE, JackPortIsOutput, 0));
+                                                          // (NB: This looks like it's the wrong way round, but it is correct!)
             }
 
             // open output ports
@@ -194,7 +195,8 @@ public:
                 outputName << "out_" << ++totalNumberOfOutputChannels;
 
                 outputPorts.add (juce::jack_port_register (client, outputName.toUTF8(),
-                                                           JACK_DEFAULT_AUDIO_TYPE, JackPortIsOutput, 0));
+                                                           JACK_DEFAULT_AUDIO_TYPE, JackPortIsInput, 0));
+                                                           // (NB: This looks like it's the wrong way round, but it is correct!)
             }
 
             inChans.calloc (totalNumberOfInputChannels + 2);

--- a/modules/juce_audio_devices/native/juce_linux_JackAudio.cpp
+++ b/modules/juce_audio_devices/native/juce_linux_JackAudio.cpp
@@ -536,7 +536,7 @@ public:
         if (jack_client_t* const client = juce::jack_client_open ("JuceJackDummy", JackNoStartServer, &status))
         {
             // scan for output devices
-            for (JackPortIterator i (client, false); i.next();)
+            for (JackPortIterator i (client, true); i.next();)
             {
                 if (i.clientName != (JUCE_JACK_CLIENT_NAME) && ! inputNames.contains (i.clientName))
                 {
@@ -546,7 +546,7 @@ public:
             }
 
             // scan for input devices
-            for (JackPortIterator i (client, true); i.next();)
+            for (JackPortIterator i (client, false); i.next();)
             {
                 if (i.clientName != (JUCE_JACK_CLIENT_NAME) && ! outputNames.contains (i.clientName))
                 {


### PR DESCRIPTION
Following this commit 7 years ago, to fix the JackPortIterator.
https://github.com/WeAreROLI/JUCE/commit/939893922bf2c02158bfeac156c5394bcf3242a4

I applied the same changes to JackAudioIODevice.

```
    JackPortIterator (jack_client_t* const client, const bool forInput)
        : ports (nullptr), index (-1)
    {
        if (client != nullptr)
            ports = juce::jack_get_ports (client, nullptr, nullptr,
                                          forInput ? JackPortIsOutput : JackPortIsInput);
                                            // (NB: This looks like it's the wrong way round, but it is correct!)
    }
```

This should fix https://www.kvraudio.com/forum/viewtopic.php?f=22&t=534699
And https://forum.juce.com/t/jack-input-and-outputs-reversed/37650

![image](https://user-images.githubusercontent.com/747243/78731508-ee6edc80-790d-11ea-9622-770531df8619.png)
