### PR TITLE
Convert juce::String to utf16 before assigning it to Steinberg::UString

### DIFF
--- a/modules/juce_audio_processors/format_types/juce_VST3Common.h
+++ b/modules/juce_audio_processors/format_types/juce_VST3Common.h
@@ -76,6 +76,11 @@ inline juce::String toString (const Steinberg::char16* string) noexcept     { re
 inline juce::String toString (const Steinberg::UString128& string) noexcept { return toString (static_cast<const Steinberg::char16*> (string)); }
 inline juce::String toString (const Steinberg::UString256& string) noexcept { return toString (static_cast<const Steinberg::char16*> (string)); }
 
+inline Steinberg::Vst::TChar* toString (const juce::String& source) noexcept
+{
+    return reinterpret_cast<Steinberg::Vst::TChar*> (source.toUTF16().getAddress());
+}
+
 inline void toString128 (Steinberg::Vst::String128 result, const char* source)
 {
     Steinberg::UString (result, 128).fromAscii (source);
@@ -83,12 +88,7 @@ inline void toString128 (Steinberg::Vst::String128 result, const char* source)
 
 inline void toString128 (Steinberg::Vst::String128 result, const juce::String& source)
 {
-    Steinberg::UString (result, 128).assign (static_cast<Steinberg::char16*>(source.toUTF16().getAddress()));
-}
-
-inline Steinberg::Vst::TChar* toString (const juce::String& source) noexcept
-{
-    return reinterpret_cast<Steinberg::Vst::TChar*> (source.toUTF16().getAddress());
+    Steinberg::UString (result, 128).assign (toString(source));
 }
 
 #if JUCE_WINDOWS

--- a/modules/juce_audio_processors/format_types/juce_VST3Common.h
+++ b/modules/juce_audio_processors/format_types/juce_VST3Common.h
@@ -83,7 +83,7 @@ inline void toString128 (Steinberg::Vst::String128 result, const char* source)
 
 inline void toString128 (Steinberg::Vst::String128 result, const juce::String& source)
 {
-    Steinberg::UString (result, 128).fromAscii (source.toUTF8());
+    Steinberg::UString (result, 128).assign (static_cast<Steinberg::char16*>(source.toUTF16().getAddress()));
 }
 
 inline Steinberg::Vst::TChar* toString (const juce::String& source) noexcept


### PR DESCRIPTION
`Steinberg::UString` internally uses an utf16 encoding. `Steinberg::UString::fromAscii` expects a pure ASCII string and simply casts each character to a utf16 character but cannot convert utf8 encoded strings. 

With this patch the function first converts the `juce::String` to a utf16 string and then assigns it to the `Steinberg::UString` to maintain correct string encoding.