### PR TITLE
Speed-up building Projucer with CMake

### DIFF
--- a/extras/Projucer/CMakeLists.txt
+++ b/extras/Projucer/CMakeLists.txt
@@ -160,3 +160,6 @@ target_link_libraries(Projucer PRIVATE
     juce::juce_build_tools
     juce::juce_cryptography
     juce::juce_gui_extra)
+
+target_compile_options(Projucer PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/MP>)
+target_compile_options(ProjucerData PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/MP>)


### PR DESCRIPTION
@reuk there might be other flags on other targets to add in a similar way, but I usually only build Projucer.