### PR TITLE
Fewer JUCE_MODULE_AVAILABLE_* checks

### DIFF
--- a/modules/juce_audio_plugin_client/AU/juce_AUv3_Wrapper.mm
+++ b/modules/juce_audio_plugin_client/AU/juce_AUv3_Wrapper.mm
@@ -1934,9 +1934,7 @@ private:
 #if JUCE_IOS
 bool JUCE_CALLTYPE juce_isInterAppAudioConnected() { return false; }
 void JUCE_CALLTYPE juce_switchToHostApplication()  {}
-#if JUCE_MODULE_AVAILABLE_juce_gui_basics
 Image JUCE_CALLTYPE juce_getIAAHostIcon (int)      { return {}; }
-#endif
 #endif
 
 JUCE_END_IGNORE_WARNINGS_GCC_LIKE

--- a/modules/juce_audio_plugin_client/Standalone/juce_StandaloneFilterApp.cpp
+++ b/modules/juce_audio_plugin_client/Standalone/juce_StandaloneFilterApp.cpp
@@ -149,7 +149,6 @@ void JUCE_CALLTYPE juce_switchToHostApplication()
         holder->switchToHostApplication();
 }
 
-#if JUCE_MODULE_AVAILABLE_juce_gui_basics
 Image JUCE_CALLTYPE juce_getIAAHostIcon (int size)
 {
     if (auto holder = StandalonePluginHolder::getInstance())
@@ -157,7 +156,6 @@ Image JUCE_CALLTYPE juce_getIAAHostIcon (int size)
 
     return Image();
 }
-#endif
 #endif
 
 #endif

--- a/modules/juce_audio_plugin_client/utility/juce_PluginHostType.h
+++ b/modules/juce_audio_plugin_client/utility/juce_PluginHostType.h
@@ -265,9 +265,7 @@ public:
     /** Switches to the host application when Inter-App Audio is used on iOS. */
     void switchToHostApplication() const;
 
-   #if JUCE_MODULE_AVAILABLE_juce_gui_basics
     Image getHostIcon (int size) const;
-   #endif
 
     //==============================================================================
     /** Returns the complete absolute path of the host application executable. */

--- a/modules/juce_audio_plugin_client/utility/juce_PluginUtilities.cpp
+++ b/modules/juce_audio_plugin_client/utility/juce_PluginUtilities.cpp
@@ -146,9 +146,7 @@ using namespace juce;
  extern bool JUCE_CALLTYPE juce_isInterAppAudioConnected();
  extern void JUCE_CALLTYPE juce_switchToHostApplication();
 
- #if JUCE_MODULE_AVAILABLE_juce_gui_basics
  extern Image JUCE_CALLTYPE juce_getIAAHostIcon (int);
- #endif
 #endif
 
 bool PluginHostType::isInterAppAudioConnected() const
@@ -183,7 +181,6 @@ bool PluginHostType::isInAAXAudioSuite (AudioProcessor& processor)
     return false;
 }
 
-#if JUCE_MODULE_AVAILABLE_juce_gui_basics
 namespace juce {
 
 extern Image JUCE_API getIconFromApplication (const String&, const int);
@@ -206,4 +203,3 @@ Image PluginHostType::getHostIcon (int size) const
 }
 
 }
-#endif

--- a/modules/juce_events/messages/juce_MessageManager.h
+++ b/modules/juce_events/messages/juce_MessageManager.h
@@ -29,11 +29,6 @@ class ActionListener;
 class ActionBroadcaster;
 
 //==============================================================================
-#if JUCE_MODULE_AVAILABLE_juce_opengl
-class OpenGLContext;
-#endif
-
-//==============================================================================
 /** See MessageManager::callFunctionOnMessageThread() for use of this function type. */
 using MessageCallbackFunction = void* (void* userData);
 


### PR DESCRIPTION
This PR removes:
- a check for `JUCE_MODULE_AVAILABLE_juce_opengl` in `juce_events`
- checks for `JUCE_MODULE_AVAILABLE_juce_gui_basics` in `juce_audio_plugin_client`.

@reuk @timuraudio after reading https://forum.juce.com/t/native-built-in-cmake-support-in-juce/38700/53, I had a look at where `JUCE_MODULE_AVAILABLE_*` is used throughout the JUCE codebase and found a few occurrences that don't seem necessary.