### PR TITLE
fix cast-qual warnings that showed up when compiling with clang-cl

### DIFF
--- a/modules/juce_audio_basics/midi/juce_MidiMessage.cpp
+++ b/modules/juce_audio_basics/midi/juce_MidiMessage.cpp
@@ -109,7 +109,7 @@ MidiMessage::MidiMessage (const void* const d, const int dataSize, const double 
 {
     jassert (dataSize > 0);
     // this checks that the length matches the data..
-    jassert (dataSize > 3 || *(uint8*)d >= 0xf0 || getMessageLengthFromFirstByte (*(uint8*)d) == size);
+    jassert (dataSize > 3 || *(const uint8*)d >= 0xf0 || getMessageLengthFromFirstByte (*(const uint8*)d) == size);
 
     memcpy (allocateSpace (dataSize), d, (size_t) dataSize);
 }

--- a/modules/juce_audio_basics/midi/juce_MidiMessage.h
+++ b/modules/juce_audio_basics/midi/juce_MidiMessage.h
@@ -945,7 +945,8 @@ private:
    #endif
 
     inline bool isHeapAllocated() const noexcept  { return size > (int) sizeof (packedData); }
-    inline uint8* getData() const noexcept        { return isHeapAllocated() ? packedData.allocatedData : (uint8*) packedData.asBytes; }
+    inline const uint8* getData() const noexcept  { return isHeapAllocated() ? packedData.allocatedData : packedData.asBytes; }
+    inline uint8* getData() noexcept              { return isHeapAllocated() ? packedData.allocatedData : packedData.asBytes; }
     uint8* allocateSpace (int);
 };
 

--- a/modules/juce_audio_devices/native/juce_win32_Midi.cpp
+++ b/modules/juce_audio_devices/native/juce_win32_Midi.cpp
@@ -576,7 +576,7 @@ private:
             {
                 MIDIHDR h = { 0 };
 
-                h.lpData = (char*) message.getRawData();
+                h.lpData = (char*) const_cast<uint8*>(message.getRawData());
                 h.dwBytesRecorded = h.dwBufferLength  = (DWORD) message.getRawDataSize();
 
                 if (midiOutPrepareHeader (han->handle, &h, sizeof (MIDIHDR)) == MMSYSERR_NOERROR)
@@ -606,7 +606,7 @@ private:
             {
                 for (int i = 0; i < 50; ++i)
                 {
-                    if (midiOutShortMsg (han->handle, *(unsigned int*) message.getRawData()) != MIDIERR_NOTREADY)
+                    if (midiOutShortMsg (han->handle, *(const unsigned int*) message.getRawData()) != MIDIERR_NOTREADY)
                         break;
 
                     Sleep (1);

--- a/modules/juce_audio_formats/codecs/juce_AiffAudioFormat.cpp
+++ b/modules/juce_audio_formats/codecs/juce_AiffAudioFormat.cpp
@@ -653,7 +653,7 @@ public:
     }
 
     //==============================================================================
-    bool write (const int** data, int numSamples) override
+    bool write (const int* const* data, int numSamples) override
     {
         jassert (numSamples >= 0);
         jassert (data != nullptr && *data != nullptr); // the input must contain at least one channel!

--- a/modules/juce_audio_formats/codecs/juce_FlacAudioFormat.cpp
+++ b/modules/juce_audio_formats/codecs/juce_FlacAudioFormat.cpp
@@ -411,7 +411,7 @@ public:
     }
 
     //==============================================================================
-    bool write (const int** samplesToWrite, int numSamples) override
+    bool write (const int* const* samplesToWrite, int numSamples) override
     {
         if (! ok)
             return false;
@@ -437,10 +437,10 @@ public:
                     destData[j] = (samplesToWrite[i][j] >> bitsToShift);
             }
 
-            samplesToWrite = const_cast<const int**> (channels.get());
+            samplesToWrite = channels.get();
         }
 
-        return FLAC__stream_encoder_process (encoder, (const FlacNamespace::FLAC__int32**) samplesToWrite, (unsigned) numSamples) != 0;
+        return FLAC__stream_encoder_process (encoder, (const FlacNamespace::FLAC__int32* const*) samplesToWrite, (unsigned) numSamples) != 0;
     }
 
     bool writeData (const void* const data, const int size) const

--- a/modules/juce_audio_formats/codecs/juce_FlacAudioFormat.cpp
+++ b/modules/juce_audio_formats/codecs/juce_FlacAudioFormat.cpp
@@ -103,7 +103,8 @@ namespace FlacNamespace
   #define SIZE_MAX 0xffffffff
  #endif
 
- JUCE_BEGIN_IGNORE_WARNINGS_GCC_LIKE ("-Wconversion",
+ JUCE_BEGIN_IGNORE_WARNINGS_GCC_LIKE ("-Wcast-qual",
+                                      "-Wconversion",
                                       "-Wshadow",
                                       "-Wdeprecated-register",
                                       "-Wswitch-enum",

--- a/modules/juce_audio_formats/codecs/juce_LAMEEncoderAudioFormat.cpp
+++ b/modules/juce_audio_formats/codecs/juce_LAMEEncoderAudioFormat.cpp
@@ -88,7 +88,7 @@ public:
         }
     }
 
-    bool write (const int** samplesToWrite, int numSamples)
+    bool write (const int* const* samplesToWrite, int numSamples)
     {
         return writer != nullptr && writer->write (samplesToWrite, numSamples);
     }

--- a/modules/juce_audio_formats/codecs/juce_OggVorbisAudioFormat.cpp
+++ b/modules/juce_audio_formats/codecs/juce_OggVorbisAudioFormat.cpp
@@ -330,7 +330,7 @@ public:
     }
 
     //==============================================================================
-    bool write (const int** samplesToWrite, int numSamples) override
+    bool write (const int* const* samplesToWrite, int numSamples) override
     {
         if (ok)
         {

--- a/modules/juce_audio_formats/codecs/juce_OggVorbisAudioFormat.cpp
+++ b/modules/juce_audio_formats/codecs/juce_OggVorbisAudioFormat.cpp
@@ -30,7 +30,8 @@ namespace OggVorbisNamespace
 #if JUCE_INCLUDE_OGGVORBIS_CODE || ! defined (JUCE_INCLUDE_OGGVORBIS_CODE)
  JUCE_BEGIN_IGNORE_WARNINGS_MSVC (4267 4127 4244 4996 4100 4701 4702 4013 4133 4206 4305 4189 4706 4995 4365 4456 4457 4459)
 
- JUCE_BEGIN_IGNORE_WARNINGS_GCC_LIKE ("-Wconversion",
+ JUCE_BEGIN_IGNORE_WARNINGS_GCC_LIKE ("-Wcast-qual",
+                                      "-Wconversion",
                                       "-Wshadow",
                                       "-Wfloat-conversion",
                                       "-Wdeprecated-register",

--- a/modules/juce_audio_formats/codecs/juce_WavAudioFormat.cpp
+++ b/modules/juce_audio_formats/codecs/juce_WavAudioFormat.cpp
@@ -287,7 +287,7 @@ namespace WavFileHelpers
 
             for (int i = 0; i < (int) numSampleLoops; ++i)
             {
-                if ((uint8*) (loops + (i + 1)) > ((uint8*) this) + totalSize)
+                if ((const uint8*) (loops + (i + 1)) > ((const uint8*) this) + totalSize)
                     break;
 
                 setValue (values, i, "Identifier", loops[i].identifier);
@@ -426,7 +426,7 @@ namespace WavFileHelpers
 
             for (int i = 0; i < (int) numCues; ++i)
             {
-                if ((uint8*) (cues + (i + 1)) > ((uint8*) this) + totalSize)
+                if ((const uint8*) (cues + (i + 1)) > ((const uint8*) this) + totalSize)
                     break;
 
                 setValue (values, i, "Identifier",  cues[i].identifier);

--- a/modules/juce_audio_formats/codecs/juce_WavAudioFormat.cpp
+++ b/modules/juce_audio_formats/codecs/juce_WavAudioFormat.cpp
@@ -1324,7 +1324,7 @@ public:
     }
 
     //==============================================================================
-    bool write (const int** data, int numSamples) override
+    bool write (const int* const* data, int numSamples) override
     {
         jassert (numSamples >= 0);
         jassert (data != nullptr && *data != nullptr); // the input must contain at least one channel!

--- a/modules/juce_audio_formats/format/juce_AudioFormatReader.cpp
+++ b/modules/juce_audio_formats/format/juce_AudioFormatReader.cpp
@@ -426,7 +426,7 @@ static int memoryReadDummyVariable; // used to force the compiler not to optimis
 void MemoryMappedAudioFormatReader::touchSample (int64 sample) const noexcept
 {
     if (map != nullptr && mappedSection.contains (sample))
-        memoryReadDummyVariable += *(char*) sampleToPointer (sample);
+        memoryReadDummyVariable += *(const char*) sampleToPointer (sample);
     else
         jassertfalse; // you must make sure that the window contains all the samples you're going to attempt to read.
 }

--- a/modules/juce_audio_formats/format/juce_AudioFormatWriter.cpp
+++ b/modules/juce_audio_formats/format/juce_AudioFormatWriter.cpp
@@ -146,7 +146,7 @@ bool AudioFormatWriter::writeFromFloatArrays (const float* const* channels, int 
         return true;
 
     if (isFloatingPoint())
-        return write ((const int**) channels, numSamples);
+        return write ((const int* const*) channels, numSamples);
 
     int* chans[256];
     int scratch[4096];
@@ -167,7 +167,7 @@ bool AudioFormatWriter::writeFromFloatArrays (const float* const* channels, int 
         for (int i = 0; i < numSourceChannels; ++i)
             convertFloatsToInts (chans[i], channels[i] + startSample, numToDo);
 
-        if (! write ((const int**) chans, numToDo))
+        if (! write (chans, numToDo))
             return false;
 
         startSample += numToDo;

--- a/modules/juce_audio_formats/format/juce_AudioFormatWriter.h
+++ b/modules/juce_audio_formats/format/juce_AudioFormatWriter.h
@@ -106,7 +106,7 @@ public:
                                 to pass it into the method.
         @param numSamples       the number of samples to write
     */
-    virtual bool write (const int** samplesToWrite, int numSamples) = 0;
+    virtual bool write (const int* const* samplesToWrite, int numSamples) = 0;
 
     /** Some formats may support a flush operation that makes sure the file is in a
         valid state before carrying on.

--- a/modules/juce_blocks_basics/blocks/juce_Block.h
+++ b/modules/juce_blocks_basics/blocks/juce_Block.h
@@ -377,7 +377,7 @@ public:
                         bool active,
                         const char* itemName,
                         ConfigType itemType,
-                        const char* options[ConfigMetaData::numOptionNames],
+                        const char* const (&options)[ConfigMetaData::numOptionNames],
                         const char* groupName)
           : item (itemIndex),
             value (itemValue),

--- a/modules/juce_blocks_basics/blocks/juce_BlockConfigManager.h
+++ b/modules/juce_blocks_basics/blocks/juce_BlockConfigManager.h
@@ -53,7 +53,7 @@ struct BlockConfigManager
 
         Block::ConfigMetaData toConfigMetaData() const
         {
-            return Block::ConfigMetaData ((uint32) item, value, { min, max }, isActive, name, type, (const char**) optionNames, group);
+            return Block::ConfigMetaData ((uint32) item, value, { min, max }, isActive, name, type, optionNames, group);
         }
     };
 

--- a/modules/juce_box2d/box2d/Collision/b2Distance.cpp
+++ b/modules/juce_box2d/box2d/Collision/b2Distance.cpp
@@ -31,7 +31,7 @@ void b2DistanceProxy::Set(const b2Shape* shape, int32 index)
 	{
 	case b2Shape::e_circle:
 		{
-			const b2CircleShape* circle = (b2CircleShape*)shape;
+			const b2CircleShape* circle = (const b2CircleShape*)shape;
 			m_vertices = &circle->m_p;
 			m_count = 1;
 			m_radius = circle->m_radius;
@@ -40,7 +40,7 @@ void b2DistanceProxy::Set(const b2Shape* shape, int32 index)
 
 	case b2Shape::e_polygon:
 		{
-			const b2PolygonShape* polygon = (b2PolygonShape*)shape;
+			const b2PolygonShape* polygon = (const b2PolygonShape*)shape;
 			m_vertices = polygon->m_vertices;
 			m_count = polygon->m_vertexCount;
 			m_radius = polygon->m_radius;
@@ -49,7 +49,7 @@ void b2DistanceProxy::Set(const b2Shape* shape, int32 index)
 
 	case b2Shape::e_chain:
 		{
-			const b2ChainShape* chain = (b2ChainShape*)shape;
+			const b2ChainShape* chain = (const b2ChainShape*)shape;
 			b2Assert(0 <= index && index < chain->m_count);
 
 			m_buffer[0] = chain->m_vertices[index];
@@ -70,7 +70,7 @@ void b2DistanceProxy::Set(const b2Shape* shape, int32 index)
 
 	case b2Shape::e_edge:
 		{
-			const b2EdgeShape* edge = (b2EdgeShape*)shape;
+			const b2EdgeShape* edge = (const b2EdgeShape*)shape;
 			m_vertices = &edge->m_vertex1;
 			m_count = 2;
 			m_radius = edge->m_radius;

--- a/modules/juce_box2d/box2d/Dynamics/Joints/b2Joint.cpp
+++ b/modules/juce_box2d/box2d/Dynamics/Joints/b2Joint.cpp
@@ -42,70 +42,70 @@ b2Joint* b2Joint::Create(const b2JointDef* def, b2BlockAllocator* allocator)
 	case e_distanceJoint:
 		{
 			void* mem = allocator->Allocate(sizeof(b2DistanceJoint));
-			joint = new (mem) b2DistanceJoint((b2DistanceJointDef*)def);
+			joint = new (mem) b2DistanceJoint((const b2DistanceJointDef*)def);
 		}
 		break;
 
 	case e_mouseJoint:
 		{
 			void* mem = allocator->Allocate(sizeof(b2MouseJoint));
-			joint = new (mem) b2MouseJoint((b2MouseJointDef*)def);
+			joint = new (mem) b2MouseJoint((const b2MouseJointDef*)def);
 		}
 		break;
 
 	case e_prismaticJoint:
 		{
 			void* mem = allocator->Allocate(sizeof(b2PrismaticJoint));
-			joint = new (mem) b2PrismaticJoint((b2PrismaticJointDef*)def);
+			joint = new (mem) b2PrismaticJoint((const b2PrismaticJointDef*)def);
 		}
 		break;
 
 	case e_revoluteJoint:
 		{
 			void* mem = allocator->Allocate(sizeof(b2RevoluteJoint));
-			joint = new (mem) b2RevoluteJoint((b2RevoluteJointDef*)def);
+			joint = new (mem) b2RevoluteJoint((const b2RevoluteJointDef*)def);
 		}
 		break;
 
 	case e_pulleyJoint:
 		{
 			void* mem = allocator->Allocate(sizeof(b2PulleyJoint));
-			joint = new (mem) b2PulleyJoint((b2PulleyJointDef*)def);
+			joint = new (mem) b2PulleyJoint((const b2PulleyJointDef*)def);
 		}
 		break;
 
 	case e_gearJoint:
 		{
 			void* mem = allocator->Allocate(sizeof(b2GearJoint));
-			joint = new (mem) b2GearJoint((b2GearJointDef*)def);
+			joint = new (mem) b2GearJoint((const b2GearJointDef*)def);
 		}
 		break;
 
 	case e_wheelJoint:
 		{
 			void* mem = allocator->Allocate(sizeof(b2WheelJoint));
-			joint = new (mem) b2WheelJoint((b2WheelJointDef*)def);
+			joint = new (mem) b2WheelJoint((const b2WheelJointDef*)def);
 		}
 		break;
 
 	case e_weldJoint:
 		{
 			void* mem = allocator->Allocate(sizeof(b2WeldJoint));
-			joint = new (mem) b2WeldJoint((b2WeldJointDef*)def);
+			joint = new (mem) b2WeldJoint((const b2WeldJointDef*)def);
 		}
 		break;
 
 	case e_frictionJoint:
 		{
 			void* mem = allocator->Allocate(sizeof(b2FrictionJoint));
-			joint = new (mem) b2FrictionJoint((b2FrictionJointDef*)def);
+			joint = new (mem) b2FrictionJoint((const b2FrictionJointDef*)def);
 		}
 		break;
 
 	case e_ropeJoint:
 		{
 			void* mem = allocator->Allocate(sizeof(b2RopeJoint));
-			joint = new (mem) b2RopeJoint((b2RopeJointDef*)def);
+			joint = new (mem) b2RopeJoint((const b2RopeJointDef*)def);
 		}
 		break;
 

--- a/modules/juce_core/native/juce_win32_Files.cpp
+++ b/modules/juce_core/native/juce_win32_Files.cpp
@@ -679,7 +679,7 @@ String File::getVersion() const
         VS_FIXEDFILEINFO* vffi;
         UINT len = 0;
 
-        if (VerQueryValue (buffer, (LPTSTR) _T("\\"), (LPVOID*) &vffi, &len))
+        if (VerQueryValue (buffer, (LPCTSTR) _T("\\"), (LPVOID*) &vffi, &len))
         {
             result << (int) HIWORD (vffi->dwFileVersionMS) << '.'
                    << (int) LOWORD (vffi->dwFileVersionMS) << '.'

--- a/modules/juce_core/native/juce_win32_Network.cpp
+++ b/modules/juce_core/native/juce_win32_Network.cpp
@@ -609,15 +609,15 @@ bool JUCE_CALLTYPE Process::openEmailWithAttachments (const String& targetEmailA
         return false;
 
     MapiMessage message = { 0 };
-    message.lpszSubject = (LPSTR) emailSubject.toRawUTF8();
-    message.lpszNoteText = (LPSTR) bodyText.toRawUTF8();
+    message.lpszSubject = (LPSTR) const_cast<char*>(emailSubject.toRawUTF8());
+    message.lpszNoteText = (LPSTR) const_cast<char*>(bodyText.toRawUTF8());
 
     MapiRecipDesc recip = { 0 };
     recip.ulRecipClass = MAPI_TO;
     String targetEmailAddress_ (targetEmailAddress);
     if (targetEmailAddress_.isEmpty())
         targetEmailAddress_ = " "; // (Windows Mail can't deal with a blank address)
-    recip.lpszName = (LPSTR) targetEmailAddress_.toRawUTF8();
+    recip.lpszName = (LPSTR) const_cast<char*>(targetEmailAddress_.toRawUTF8());
     message.nRecipCount = 1;
     message.lpRecips = &recip;
 
@@ -630,7 +630,7 @@ bool JUCE_CALLTYPE Process::openEmailWithAttachments (const String& targetEmailA
     for (int i = 0; i < filesToAttach.size(); ++i)
     {
         files[i].nPosition = (ULONG) -1;
-        files[i].lpszPathName = (LPSTR) filesToAttach[i].toRawUTF8();
+        files[i].lpszPathName = (LPSTR) const_cast<char*>(filesToAttach[i].toRawUTF8());
     }
 
     return mapiSendMail (0, 0, &message, MAPI_DIALOG | MAPI_LOGON_UI, 0) == SUCCESS_SUCCESS;

--- a/modules/juce_core/native/juce_win32_Network.cpp
+++ b/modules/juce_core/native/juce_win32_Network.cpp
@@ -546,7 +546,7 @@ namespace MACAddressHelpers
 
     static IPAddress createAddress (const sockaddr_in* sa_in)
     {
-        return IPAddress ((uint8*) &sa_in->sin_addr.s_addr, false);
+        return IPAddress ((const uint8*) &sa_in->sin_addr.s_addr, false);
     }
 
     template <typename Type>

--- a/modules/juce_core/threads/juce_CriticalSection.h
+++ b/modules/juce_core/threads/juce_CriticalSection.h
@@ -106,9 +106,9 @@ private:
     // a block of memory here that's big enough to be used internally as a windows
     // CRITICAL_SECTION structure.
     #if JUCE_64BIT
-     uint8 lock[44];
+     mutable uint8 lock[44];
     #else
-     uint8 lock[24];
+     mutable uint8 lock[24];
     #endif
    #else
     mutable pthread_mutex_t lock;

--- a/modules/juce_core/zip/juce_GZIPDecompressorInputStream.cpp
+++ b/modules/juce_core/zip/juce_GZIPDecompressorInputStream.cpp
@@ -28,7 +28,8 @@ JUCE_BEGIN_IGNORE_WARNINGS_MSVC (4309 4305 4365)
 namespace zlibNamespace
 {
  #if JUCE_INCLUDE_ZLIB_CODE
-  JUCE_BEGIN_IGNORE_WARNINGS_GCC_LIKE ("-Wconversion",
+  JUCE_BEGIN_IGNORE_WARNINGS_GCC_LIKE ("-Wcast-qual",
+                                       "-Wconversion",
                                        "-Wsign-conversion",
                                        "-Wshadow",
                                        "-Wdeprecated-register",

--- a/modules/juce_core/zip/juce_ZipFile.cpp
+++ b/modules/juce_core/zip/juce_ZipFile.cpp
@@ -479,7 +479,7 @@ struct ZipFile::Builder::Item
 
             uncompressedSize = relativePath.length();
 
-            checksum = zlibNamespace::crc32 (0, (uint8_t*) relativePath.toRawUTF8(), (unsigned int) uncompressedSize);
+            checksum = zlibNamespace::crc32 (0, (const uint8_t*) relativePath.toRawUTF8(), (unsigned int) uncompressedSize);
             compressedData << relativePath;
         }
         else if (compressionLevel > 0)

--- a/modules/juce_dsp/native/juce_sse_SIMDNativeOps.h
+++ b/modules/juce_dsp/native/juce_sse_SIMDNativeOps.h
@@ -71,7 +71,7 @@ struct SIMDNativeOps<float>
     static forcedinline __m128 JUCE_VECTOR_CALLTYPE bit_or  (__m128 a, __m128 b) noexcept                { return _mm_or_ps  (a, b); }
     static forcedinline __m128 JUCE_VECTOR_CALLTYPE bit_xor (__m128 a, __m128 b) noexcept                { return _mm_xor_ps (a, b); }
     static forcedinline __m128 JUCE_VECTOR_CALLTYPE bit_notand (__m128 a, __m128 b) noexcept             { return _mm_andnot_ps (a, b); }
-    static forcedinline __m128 JUCE_VECTOR_CALLTYPE bit_not (__m128 a) noexcept                          { return bit_notand (a, _mm_loadu_ps ((float*) kAllBitsSet)); }
+    static forcedinline __m128 JUCE_VECTOR_CALLTYPE bit_not (__m128 a) noexcept                          { return bit_notand (a, _mm_loadu_ps ((const float*) kAllBitsSet)); }
     static forcedinline __m128 JUCE_VECTOR_CALLTYPE min (__m128 a, __m128 b) noexcept                    { return _mm_min_ps (a, b); }
     static forcedinline __m128 JUCE_VECTOR_CALLTYPE max (__m128 a, __m128 b) noexcept                    { return _mm_max_ps (a, b); }
     static forcedinline __m128 JUCE_VECTOR_CALLTYPE equal (__m128 a, __m128 b) noexcept                  { return _mm_cmpeq_ps (a, b); }
@@ -93,7 +93,7 @@ struct SIMDNativeOps<float>
     {
         __m128 rr_ir = mul (a, dupeven (b));
         __m128 ii_ri = mul (swapevenodd (a), dupodd (b));
-        return add (rr_ir, bit_xor (ii_ri, _mm_loadu_ps ((float*) kEvenHighBit)));
+        return add (rr_ir, bit_xor (ii_ri, _mm_loadu_ps ((const float*) kEvenHighBit)));
     }
 
     static forcedinline float JUCE_VECTOR_CALLTYPE sum (__m128 a) noexcept

--- a/modules/juce_graphics/image_formats/juce_JPEGLoader.cpp
+++ b/modules/juce_graphics/image_formats/juce_JPEGLoader.cpp
@@ -339,7 +339,7 @@ Image JPEGImageFormat::decodeImage (InputStream& in)
                     if (! hasFailed)
                         jpeg_finish_decompress (&jpegDecompStruct);
 
-                    in.setPosition (((char*) jpegDecompStruct.src->next_input_byte) - (char*) mb.getData());
+                    in.setPosition (((const char*) jpegDecompStruct.src->next_input_byte) - (const char*) mb.getData());
                 }
             }
         }

--- a/modules/juce_graphics/native/juce_win32_Fonts.cpp
+++ b/modules/juce_graphics/native/juce_win32_Fonts.cpp
@@ -405,7 +405,7 @@ public:
             auto scaleX = 1.0f / tm.tmHeight;
             auto scaleY = -scaleX;
 
-            while ((char*) pheader < data + bufSize)
+            while ((const char*) pheader < data + bufSize)
             {
                 glyphPath.startNewSubPath (scaleX * pheader->pfxStart.x.value,
                                            scaleY * pheader->pfxStart.y.value);


### PR DESCRIPTION
* in most cases the c-style casts were just missing the `const`, so the fix was straightforward
* a non-const overload for `MidiMessage::getData` was added to fix const-correctness 
* the warning was explicitly disabled for third party code that has already warnings disabled (e.g. flac, OggVorbis, zlib)
* the signature of `AudioFormatWriter::write` was changed to elide const casts (`const int**` --> `const int* const*`)
* the signature of `ConfigMetaData::ConfigMetaData` was changed to elide const casts and to correctly detect the array size
* a member of `CriticalSection` was made `mutable` to elide const casts. This fits the non-Windows implementation where the member is already `mutable`
* in some cases casting away the constness was actually necessary for calling windows api functions so explicit `const_cast`s where added to make this clear (`juce_win32_Midi.cpp` and `juce_win32_Network.cpp`)
