### PR TITLE
Fixes: Undefined symbol juce_iOSMain for standalone iOS application

### DIFF
--- a/modules/juce_events/messages/juce_ApplicationBase.cpp
+++ b/modules/juce_events/messages/juce_ApplicationBase.cpp
@@ -175,7 +175,7 @@ StringArray JUCE_CALLTYPE JUCEApplicationBase::getCommandLineParameterArray()
 
 #else
 
-#if JUCE_IOS
+#if JUCE_IOS && JUCE_MODULE_AVAILABLE_juce_gui_basics
  extern int juce_iOSMain (int argc, const char* argv[], void* classPtr);
 #endif
 
@@ -233,7 +233,7 @@ int JUCEApplicationBase::main (int argc, const char* argv[])
             return juce_gtkWebkitMain (argc, argv);
        #endif
 
-       #if JUCE_IOS
+       #if JUCE_IOS && JUCE_MODULE_AVAILABLE_juce_gui_basics
         return juce_iOSMain (argc, argv, iOSCustomDelegate);
        #else
 


### PR DESCRIPTION
Fixes: Implements the proposed solution in juce-framework/JUCE/#708

Adds `JUCE_MODULE_AVAILABLE_juce_gui_basics` check to ensure that no linker errors occur if the `juce_gui_basics` module is not included in a standalone iOS application.

