### PR TITLE
Fix crash on quit in WaveLab 10 on OS X.

### DIFF
--- a/modules/juce_audio_plugin_client/VST3/juce_VST3_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/VST3/juce_VST3_Wrapper.cpp
@@ -3072,6 +3072,10 @@ struct JucePluginFactory  : public IPluginFactory3
 
     tresult PLUGIN_API setHostContext (FUnknown* context) override
     {
+        // WaveLab 10 on OS X (and maybe other WaveLabs): if the context object gets smart referenced here,
+        // a crash happens on shutdown in case multiple instances were active.
+        if (getHostType().isWavelab()) return kNotImplemented;
+        
         host.loadFrom (context);
 
         if (host != nullptr)


### PR DESCRIPTION
A crash happens if multiple instances of the same JUCE vst3 plugins are active and WaveLab 10 is quit.

Lots of details in my monologue on the forum:

https://forum.juce.com/t/wavelab-10-crash-on-quit-inside-vst3-wrapper/39067/5