### PR TITLE
Do not use relative paths to perform cross-module includes

### DIFF
--- a/modules/juce_audio_formats/codecs/juce_CoreAudioFormat.cpp
+++ b/modules/juce_audio_formats/codecs/juce_CoreAudioFormat.cpp
@@ -26,7 +26,7 @@
 
 #if JUCE_MAC || JUCE_IOS
 
-#include "../../juce_audio_basics/native/juce_mac_CoreAudioLayouts.h"
+#include <juce_audio_basics/native/juce_mac_CoreAudioLayouts.h>
 
 namespace juce
 {

--- a/modules/juce_audio_plugin_client/AAX/juce_AAX_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/AAX/juce_AAX_Wrapper.cpp
@@ -24,7 +24,7 @@
   ==============================================================================
 */
 
-#include "../../juce_core/system/juce_TargetPlatform.h"
+#include <juce_core/system/juce_TargetPlatform.h>
 #include "../utility/juce_CheckSettingMacros.h"
 
 #if JucePlugin_Build_AAX && (JUCE_INCLUDED_AAX_IN_MM || defined (_WIN32) || defined (_WIN64))
@@ -34,7 +34,7 @@
 #include "../utility/juce_WindowsHooks.h"
 #include "../utility/juce_FakeMouseMoveGenerator.h"
 
-#include "../../juce_audio_processors/format_types/juce_LegacyAudioParameter.cpp"
+#include <juce_audio_processors/format_types/juce_LegacyAudioParameter.cpp>
 
 #ifdef __clang__
  #pragma clang diagnostic push

--- a/modules/juce_audio_plugin_client/AU/CoreAudioUtilityClasses/AUBase.h
+++ b/modules/juce_audio_plugin_client/AU/CoreAudioUtilityClasses/AUBase.h
@@ -50,7 +50,7 @@
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 
 #include <TargetConditionals.h>
-#include "../../../juce_core/native/juce_mac_ClangBugWorkaround.h"
+#include <juce_core/native/juce_mac_ClangBugWorkaround.h>
 
 #if TARGET_OS_MAC
 	#include <pthread.h>

--- a/modules/juce_audio_plugin_client/AU/CoreAudioUtilityClasses/AUBuffer.h
+++ b/modules/juce_audio_plugin_client/AU/CoreAudioUtilityClasses/AUBuffer.h
@@ -47,7 +47,7 @@
 #ifndef __AUBuffer_h__
 #define __AUBuffer_h__
 
-#include "../../../juce_core/native/juce_mac_ClangBugWorkaround.h"
+#include <juce_core/native/juce_mac_ClangBugWorkaround.h>
 
 #include <TargetConditionals.h>
 #if !defined(__COREAUDIO_USE_FLAT_INCLUDES__)

--- a/modules/juce_audio_plugin_client/AU/CoreAudioUtilityClasses/AUCarbonViewBase.h
+++ b/modules/juce_audio_plugin_client/AU/CoreAudioUtilityClasses/AUCarbonViewBase.h
@@ -48,7 +48,7 @@
 #define __AUCarbonViewBase_h__
 
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#include "../../../juce_core/native/juce_mac_ClangBugWorkaround.h"
+#include <juce_core/native/juce_mac_ClangBugWorkaround.h>
 
 #include <vector>
 #include "AUCarbonViewControl.h"

--- a/modules/juce_audio_plugin_client/AU/CoreAudioUtilityClasses/AUCarbonViewControl.h
+++ b/modules/juce_audio_plugin_client/AU/CoreAudioUtilityClasses/AUCarbonViewControl.h
@@ -47,7 +47,7 @@
 #ifndef __AUCarbonViewControl_h__
 #define __AUCarbonViewControl_h__
 
-#include "../../../juce_core/native/juce_mac_ClangBugWorkaround.h"
+#include <juce_core/native/juce_mac_ClangBugWorkaround.h>
 #include <Carbon/Carbon.h>
 #include <AudioUnit/AudioUnitCarbonView.h>
 #include <AudioToolbox/AudioUnitUtilities.h>

--- a/modules/juce_audio_plugin_client/AU/CoreAudioUtilityClasses/AUOutputElement.cpp
+++ b/modules/juce_audio_plugin_client/AU/CoreAudioUtilityClasses/AUOutputElement.cpp
@@ -45,7 +45,7 @@
 
 */
 
-#include "../../../juce_core/native/juce_mac_ClangBugWorkaround.h"
+#include <juce_core/native/juce_mac_ClangBugWorkaround.h>
 #include "AUOutputElement.h"
 #include "AUBase.h"
 

--- a/modules/juce_audio_plugin_client/AU/CoreAudioUtilityClasses/AUScopeElement.cpp
+++ b/modules/juce_audio_plugin_client/AU/CoreAudioUtilityClasses/AUScopeElement.cpp
@@ -45,7 +45,7 @@
 
 */
 
-#include "../../../juce_core/native/juce_mac_ClangBugWorkaround.h"
+#include <juce_core/native/juce_mac_ClangBugWorkaround.h>
 #include "AUScopeElement.h"
 #include "AUBase.h"
 

--- a/modules/juce_audio_plugin_client/AU/CoreAudioUtilityClasses/CAAUParameter.cpp
+++ b/modules/juce_audio_plugin_client/AU/CoreAudioUtilityClasses/CAAUParameter.cpp
@@ -45,7 +45,7 @@
 
 */
 
-#include "../../../juce_core/native/juce_mac_ClangBugWorkaround.h"
+#include <juce_core/native/juce_mac_ClangBugWorkaround.h>
 #include "CAAUParameter.h"
 
 CAAUParameter::CAAUParameter()

--- a/modules/juce_audio_plugin_client/AU/CoreAudioUtilityClasses/CADebugMacros.h
+++ b/modules/juce_audio_plugin_client/AU/CoreAudioUtilityClasses/CADebugMacros.h
@@ -48,7 +48,7 @@
 #define __CADebugMacros_h__
 
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#include "../../../juce_core/native/juce_mac_ClangBugWorkaround.h"
+#include <juce_core/native/juce_mac_ClangBugWorkaround.h>
 
 
 //=============================================================================

--- a/modules/juce_audio_plugin_client/AU/CoreAudioUtilityClasses/CarbonEventHandler.cpp
+++ b/modules/juce_audio_plugin_client/AU/CoreAudioUtilityClasses/CarbonEventHandler.cpp
@@ -45,7 +45,7 @@
 
 */
 
-#include "../../../juce_core/native/juce_mac_ClangBugWorkaround.h"
+#include <juce_core/native/juce_mac_ClangBugWorkaround.h>
 #include "CarbonEventHandler.h"
 
 static pascal OSStatus TheEventHandler(EventHandlerCallRef inHandlerRef, EventRef inEvent, void *inUserData)

--- a/modules/juce_audio_plugin_client/AU/juce_AU_Wrapper.mm
+++ b/modules/juce_audio_plugin_client/AU/juce_AU_Wrapper.mm
@@ -23,7 +23,7 @@
 
   ==============================================================================
 */
-#include "../../juce_core/system/juce_TargetPlatform.h"
+#include <juce_core/system/juce_TargetPlatform.h>
 #include "../utility/juce_CheckSettingMacros.h"
 
 #if JucePlugin_Build_AU
@@ -89,9 +89,9 @@
 #include "../utility/juce_FakeMouseMoveGenerator.h"
 #include "../utility/juce_CarbonVisibility.h"
 
-#include "../../juce_audio_basics/native/juce_mac_CoreAudioLayouts.h"
-#include "../../juce_audio_processors/format_types/juce_LegacyAudioParameter.cpp"
-#include "../../juce_audio_processors/format_types/juce_AU_Shared.h"
+#include <juce_audio_basics/native/juce_mac_CoreAudioLayouts.h>
+#include <juce_audio_processors/format_types/juce_LegacyAudioParameter.cpp>
+#include <juce_audio_processors/format_types/juce_AU_Shared.h>
 
 //==============================================================================
 using namespace juce;

--- a/modules/juce_audio_plugin_client/AU/juce_AUv3_Wrapper.mm
+++ b/modules/juce_audio_plugin_client/AU/juce_AUv3_Wrapper.mm
@@ -24,7 +24,7 @@
   ==============================================================================
 */
 
-#include "../../juce_core/system/juce_TargetPlatform.h"
+#include <juce_core/system/juce_TargetPlatform.h>
 #include "../utility/juce_CheckSettingMacros.h"
 
 #if JucePlugin_Build_AUv3
@@ -62,10 +62,10 @@
 #import <AudioToolbox/AudioToolbox.h>
 #import <AVFoundation/AVFoundation.h>
 
-#include "../../juce_graphics/native/juce_mac_CoreGraphicsHelpers.h"
-#include "../../juce_audio_basics/native/juce_mac_CoreAudioLayouts.h"
-#include "../../juce_audio_processors/format_types/juce_LegacyAudioParameter.cpp"
-#include "../../juce_audio_processors/format_types/juce_AU_Shared.h"
+#include <juce_graphics/native/juce_mac_CoreGraphicsHelpers.h>
+#include <juce_audio_basics/native/juce_mac_CoreAudioLayouts.h>
+#include <juce_audio_processors/format_types/juce_LegacyAudioParameter.cpp>
+#include <juce_audio_processors/format_types/juce_AU_Shared.h>
 
 #define JUCE_VIEWCONTROLLER_OBJC_NAME(x) JUCE_JOIN_MACRO (x, FactoryAUv3)
 

--- a/modules/juce_audio_plugin_client/RTAS/juce_RTAS_DigiCode1.cpp
+++ b/modules/juce_audio_plugin_client/RTAS/juce_RTAS_DigiCode1.cpp
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include "../../juce_core/system/juce_TargetPlatform.h"
+#include <juce_core/system/juce_TargetPlatform.h>
 #include "../utility/juce_CheckSettingMacros.h"
 
 #if JucePlugin_Build_RTAS

--- a/modules/juce_audio_plugin_client/RTAS/juce_RTAS_DigiCode2.cpp
+++ b/modules/juce_audio_plugin_client/RTAS/juce_RTAS_DigiCode2.cpp
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include "../../juce_core/system/juce_TargetPlatform.h"
+#include <juce_core/system/juce_TargetPlatform.h>
 #include "../utility/juce_CheckSettingMacros.h"
 
 #if JucePlugin_Build_RTAS

--- a/modules/juce_audio_plugin_client/RTAS/juce_RTAS_DigiCode3.cpp
+++ b/modules/juce_audio_plugin_client/RTAS/juce_RTAS_DigiCode3.cpp
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include "../../juce_core/system/juce_TargetPlatform.h"
+#include <juce_core/system/juce_TargetPlatform.h>
 #include "../utility/juce_CheckSettingMacros.h"
 
 #if JucePlugin_Build_RTAS

--- a/modules/juce_audio_plugin_client/RTAS/juce_RTAS_MacUtilities.mm
+++ b/modules/juce_audio_plugin_client/RTAS/juce_RTAS_MacUtilities.mm
@@ -24,7 +24,7 @@
   ==============================================================================
 */
 
-#include "../../juce_core/system/juce_TargetPlatform.h"
+#include <juce_core/system/juce_TargetPlatform.h>
 #include "../utility/juce_CheckSettingMacros.h"
 
 #if JucePlugin_Build_RTAS

--- a/modules/juce_audio_plugin_client/RTAS/juce_RTAS_WinUtilities.cpp
+++ b/modules/juce_audio_plugin_client/RTAS/juce_RTAS_WinUtilities.cpp
@@ -24,7 +24,7 @@
   ==============================================================================
 */
 
-#include "../../juce_core/system/juce_TargetPlatform.h"
+#include <juce_core/system/juce_TargetPlatform.h>
 #include "../utility/juce_CheckSettingMacros.h"
 
 #if JucePlugin_Build_RTAS

--- a/modules/juce_audio_plugin_client/RTAS/juce_RTAS_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/RTAS/juce_RTAS_Wrapper.cpp
@@ -24,7 +24,7 @@
   ==============================================================================
 */
 
-#include "../../juce_core/system/juce_TargetPlatform.h"
+#include <juce_core/system/juce_TargetPlatform.h>
 #include "../utility/juce_CheckSettingMacros.h"
 
 #if JucePlugin_Build_RTAS

--- a/modules/juce_audio_plugin_client/Standalone/juce_StandaloneFilterApp.cpp
+++ b/modules/juce_audio_plugin_client/Standalone/juce_StandaloneFilterApp.cpp
@@ -24,7 +24,7 @@
   ==============================================================================
 */
 
-#include "../../juce_core/system/juce_TargetPlatform.h"
+#include <juce_core/system/juce_TargetPlatform.h>
 #include "../utility/juce_CheckSettingMacros.h"
 
 #include "../utility/juce_IncludeSystemHeaders.h"

--- a/modules/juce_audio_plugin_client/Unity/juce_Unity_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/Unity/juce_Unity_Wrapper.cpp
@@ -26,9 +26,9 @@
 
 #if JucePlugin_Build_Unity
 
-#include "../../juce_core/system/juce_TargetPlatform.h"
+#include <juce_core/system/juce_TargetPlatform.h>
 #include "../utility/juce_IncludeModuleHeaders.h"
-#include "../../juce_audio_processors/format_types/juce_LegacyAudioParameter.cpp"
+#include <juce_audio_processors/format_types/juce_LegacyAudioParameter.cpp>
 
 #if JUCE_WINDOWS
  #include "../utility/juce_IncludeSystemHeaders.h"

--- a/modules/juce_audio_plugin_client/VST/juce_VST_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/VST/juce_VST_Wrapper.cpp
@@ -24,7 +24,7 @@
   ==============================================================================
 */
 
-#include "../../juce_core/system/juce_TargetPlatform.h"
+#include <juce_core/system/juce_TargetPlatform.h>
 #include "../utility/juce_CheckSettingMacros.h"
 
 #if JucePlugin_Build_VST
@@ -130,8 +130,8 @@ using namespace juce;
 #include "../utility/juce_FakeMouseMoveGenerator.h"
 #include "../utility/juce_WindowsHooks.h"
 
-#include "../../juce_audio_processors/format_types/juce_LegacyAudioParameter.cpp"
-#include "../../juce_audio_processors/format_types/juce_VSTCommon.h"
+#include <juce_audio_processors/format_types/juce_LegacyAudioParameter.cpp>
+#include <juce_audio_processors/format_types/juce_VSTCommon.h>
 
 #if JUCE_BIG_ENDIAN
  #define JUCE_MULTICHAR_CONSTANT(a, b, c, d) (a | (((uint32) b) << 8) | (((uint32) c) << 16) | (((uint32) d) << 24))

--- a/modules/juce_audio_plugin_client/VST/juce_VST_Wrapper.mm
+++ b/modules/juce_audio_plugin_client/VST/juce_VST_Wrapper.mm
@@ -24,7 +24,7 @@
   ==============================================================================
 */
 
-#include "../../juce_core/system/juce_TargetPlatform.h"
+#include <juce_core/system/juce_TargetPlatform.h>
 
 #if JUCE_MAC
 

--- a/modules/juce_audio_plugin_client/VST3/juce_VST3_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/VST3/juce_VST3_Wrapper.cpp
@@ -24,7 +24,7 @@
   ==============================================================================
 */
 
-#include "../../juce_core/system/juce_TargetPlatform.h"
+#include <juce_core/system/juce_TargetPlatform.h>
 
 //==============================================================================
 #if JucePlugin_Build_VST3 && (__APPLE_CPP__ || __APPLE_CC__ || _WIN32 || _WIN64)
@@ -34,7 +34,7 @@
  #define JUCE_VST3HEADERS_INCLUDE_HEADERS_ONLY 1
 #endif
 
-#include "../../juce_audio_processors/format_types/juce_VST3Headers.h"
+#include <juce_audio_processors/format_types/juce_VST3Headers.h>
 
 #undef JUCE_VST3HEADERS_INCLUDE_HEADERS_ONLY
 
@@ -42,8 +42,8 @@
 #include "../utility/juce_IncludeModuleHeaders.h"
 #include "../utility/juce_WindowsHooks.h"
 #include "../utility/juce_FakeMouseMoveGenerator.h"
-#include "../../juce_audio_processors/format_types/juce_LegacyAudioParameter.cpp"
-#include "../../juce_audio_processors/format_types/juce_VST3Common.h"
+#include <juce_audio_processors/format_types/juce_LegacyAudioParameter.cpp>
+#include <juce_audio_processors/format_types/juce_VST3Common.h>
 
 #ifndef JUCE_VST3_CAN_REPLACE_VST2
  #define JUCE_VST3_CAN_REPLACE_VST2 1

--- a/modules/juce_audio_plugin_client/utility/juce_PluginUtilities.cpp
+++ b/modules/juce_audio_plugin_client/utility/juce_PluginUtilities.cpp
@@ -28,7 +28,7 @@
  #include <windows.h>
 #endif
 
-#include "../../juce_core/system/juce_TargetPlatform.h"
+#include <juce_core/system/juce_TargetPlatform.h>
 #include "../utility/juce_CheckSettingMacros.h"
 #include "juce_IncludeModuleHeaders.h"
 

--- a/modules/juce_audio_processors/format_types/juce_AudioUnitPluginFormat.mm
+++ b/modules/juce_audio_processors/format_types/juce_AudioUnitPluginFormat.mm
@@ -52,8 +52,8 @@
  #include <CoreAudioKit/AUViewController.h>
 #endif
 
-#include "../../juce_audio_basics/native/juce_mac_CoreAudioLayouts.h"
-#include "../../juce_audio_devices/native/juce_MidiDataConcatenator.h"
+#include <juce_audio_basics/native/juce_mac_CoreAudioLayouts.h>
+#include <juce_audio_devices/native/juce_MidiDataConcatenator.h>
 #include "juce_AU_Shared.h"
 
 namespace juce

--- a/modules/juce_audio_processors/juce_audio_processors.cpp
+++ b/modules/juce_audio_processors/juce_audio_processors.cpp
@@ -43,7 +43,7 @@
 #if JUCE_MAC
  #if JUCE_SUPPORT_CARBON && (JUCE_PLUGINHOST_VST || JUCE_PLUGINHOST_AU)
   #include <Carbon/Carbon.h>
-  #include "../juce_gui_extra/native/juce_mac_CarbonViewWrapperComponent.h"
+  #include <juce_gui_extra/native/juce_mac_CarbonViewWrapperComponent.h>
  #endif
 #endif
 

--- a/modules/juce_graphics/image_formats/juce_PNGLoader.cpp
+++ b/modules/juce_graphics/image_formats/juce_PNGLoader.cpp
@@ -40,7 +40,7 @@ namespace zlibNamespace
 #if JUCE_INCLUDE_ZLIB_CODE
   #undef OS_CODE
   #undef fdopen
-  #include "../../juce_core/zip/zlib/zlib.h"
+  #include <juce_core/zip/zlib/zlib.h>
   #undef OS_CODE
 #else
   #include JUCE_ZLIB_INCLUDE_PATH


### PR DESCRIPTION
This PR addresses the issue reported in https://forum.juce.com/t/juce-module-include-paths-issue-with-copy-module-for-some-modules/39223.

@ed95 this is quite similar to #658.
@reuk FYI, you might be interested as well.