### PR TITLE
Fixed the PopupMenu to use the colours set in the ComboBox, if used there

### DIFF
--- a/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel.cpp
+++ b/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel.cpp
@@ -87,6 +87,14 @@ Colour LookAndFeel::findColour (int colourID) const noexcept
     return Colours::black;
 }
 
+Colour LookAndFeel::findColour (int colourId, Component* targetComponent) const noexcept
+{
+    if (targetComponent)
+        return targetComponent->findColour (colourId);
+
+    return findColour (colourId);
+}
+
 void LookAndFeel::setColour (int colourID, Colour newColour) noexcept
 {
     const ColourSetting c = { colourID, newColour };

--- a/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel.h
+++ b/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel.h
@@ -153,6 +153,15 @@ public:
     */
     Colour findColour (int colourId) const noexcept;
 
+    /** Looks for a colour that has been registered with the given colour ID number.
+
+        If a targetComponent is given (e.g. for a PopupMenu), the colour will be looked up.
+        Otherwise the normal findColour() method will be used.
+
+        @see Component::findColour()
+     */
+    Colour findColour (int colourId, Component* targetComponent) const noexcept;
+
     /** Registers a colour to be used for a particular purpose.
         For more details, see the comments for findColour().
         @see findColour, Component::findColour, Component::setColour

--- a/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel_V1.cpp
+++ b/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel_V1.cpp
@@ -294,9 +294,9 @@ ImageEffectFilter* LookAndFeel_V1::getScrollbarEffect()
 
 
 //==============================================================================
-void LookAndFeel_V1::drawPopupMenuBackground (Graphics& g, int width, int height)
+void LookAndFeel_V1::drawPopupMenuBackground (Graphics& g, int width, int height, Component* targetComponent)
 {
-    g.fillAll (findColour (PopupMenu::backgroundColourId));
+    g.fillAll (findColour (PopupMenu::backgroundColourId, targetComponent));
 
     g.setColour (Colours::black.withAlpha (0.6f));
     g.drawRect (0, 0, width, height);

--- a/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel_V1.h
+++ b/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel_V1.h
@@ -69,7 +69,7 @@ public:
     void drawTextEditorOutline (Graphics&, int width, int height, TextEditor&) override;
 
     //==============================================================================
-    void drawPopupMenuBackground (Graphics&, int width, int height) override;
+    void drawPopupMenuBackground (Graphics&, int width, int height, Component* targetComponent) override;
     void drawMenuBarBackground (Graphics&, int width, int height, bool isMouseOverBar, MenuBarComponent&) override;
 
     //==============================================================================

--- a/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel_V2.cpp
+++ b/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel_V2.cpp
@@ -888,9 +888,9 @@ void LookAndFeel_V2::getIdealPopupMenuItemSize (const String& text, const bool i
     }
 }
 
-void LookAndFeel_V2::drawPopupMenuBackground (Graphics& g, int width, int height)
+void LookAndFeel_V2::drawPopupMenuBackground (Graphics& g, int width, int height, Component* targetComponent)
 {
-    auto background = findColour (PopupMenu::backgroundColourId);
+    auto background = findColour (PopupMenu::backgroundColourId, targetComponent);
 
     g.fillAll (background);
     g.setColour (background.overlaidWith (Colour (0x2badd8e6)));
@@ -899,14 +899,14 @@ void LookAndFeel_V2::drawPopupMenuBackground (Graphics& g, int width, int height
         g.fillRect (0, i, width, 1);
 
    #if ! JUCE_MAC
-    g.setColour (findColour (PopupMenu::textColourId).withAlpha (0.6f));
+    g.setColour (findColour (PopupMenu::textColourId, targetComponent).withAlpha (0.6f));
     g.drawRect (0, 0, width, height);
    #endif
 }
 
-void LookAndFeel_V2::drawPopupMenuUpDownArrow (Graphics& g, int width, int height, bool isScrollUpArrow)
+void LookAndFeel_V2::drawPopupMenuUpDownArrow (Graphics& g, int width, int height, bool isScrollUpArrow, Component* targetComponent)
 {
-    auto background = findColour (PopupMenu::backgroundColourId);
+    auto background = findColour (PopupMenu::backgroundColourId, targetComponent);
 
     g.setGradientFill (ColourGradient (background, 0.0f, height * 0.5f,
                                        background.withAlpha (0.0f),
@@ -925,7 +925,7 @@ void LookAndFeel_V2::drawPopupMenuUpDownArrow (Graphics& g, int width, int heigh
                    hw + arrowW, y1,
                    hw, y2);
 
-    g.setColour (findColour (PopupMenu::textColourId).withAlpha (0.5f));
+    g.setColour (findColour (PopupMenu::textColourId, targetComponent).withAlpha (0.5f));
     g.fillPath (p);
 }
 
@@ -934,7 +934,8 @@ void LookAndFeel_V2::drawPopupMenuItem (Graphics& g, const Rectangle<int>& area,
                                         const bool isHighlighted, const bool isTicked,
                                         const bool hasSubMenu, const String& text,
                                         const String& shortcutKeyText,
-                                        const Drawable* icon, const Colour* const textColourToUse)
+                                        const Drawable* icon, const Colour* const textColourToUse,
+                                        Component* targetComponent)
 {
     if (isSeparator)
     {
@@ -949,7 +950,7 @@ void LookAndFeel_V2::drawPopupMenuItem (Graphics& g, const Rectangle<int>& area,
     }
     else
     {
-        auto textColour = findColour (PopupMenu::textColourId);
+        auto textColour = findColour (PopupMenu::textColourId, targetComponent);
 
         if (textColourToUse != nullptr)
             textColour = *textColourToUse;
@@ -958,10 +959,10 @@ void LookAndFeel_V2::drawPopupMenuItem (Graphics& g, const Rectangle<int>& area,
 
         if (isHighlighted)
         {
-            g.setColour (findColour (PopupMenu::highlightedBackgroundColourId));
+            g.setColour (findColour (PopupMenu::highlightedBackgroundColourId, targetComponent));
             g.fillRect (r);
 
-            g.setColour (findColour (PopupMenu::highlightedTextColourId));
+            g.setColour (findColour (PopupMenu::highlightedTextColourId, targetComponent));
         }
         else
         {
@@ -1022,10 +1023,10 @@ void LookAndFeel_V2::drawPopupMenuItem (Graphics& g, const Rectangle<int>& area,
     }
 }
 
-void LookAndFeel_V2::drawPopupMenuSectionHeader (Graphics& g, const Rectangle<int>& area, const String& sectionName)
+void LookAndFeel_V2::drawPopupMenuSectionHeader (Graphics& g, const Rectangle<int>& area, const String& sectionName, Component* targetComponent)
 {
     g.setFont (getPopupMenuFont().boldened());
-    g.setColour (findColour (PopupMenu::headerTextColourId));
+    g.setColour (findColour (PopupMenu::headerTextColourId, targetComponent));
 
     g.drawFittedText (sectionName,
                       area.getX() + 12, area.getY(), area.getWidth() - 16, (int) (area.getHeight() * 0.8f),

--- a/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel_V2.h
+++ b/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel_V2.h
@@ -155,19 +155,19 @@ public:
     void drawLasso (Graphics&, Component&) override;
 
     //==============================================================================
-    void drawPopupMenuBackground (Graphics&, int width, int height) override;
+    void drawPopupMenuBackground (Graphics&, int width, int height, Component* targetComponent) override;
 
     void drawPopupMenuItem (Graphics&, const Rectangle<int>& area,
                             bool isSeparator, bool isActive, bool isHighlighted, bool isTicked, bool hasSubMenu,
                             const String& text, const String& shortcutKeyText,
-                            const Drawable* icon, const Colour* textColour) override;
+                            const Drawable* icon, const Colour* textColour, Component* targetComponent) override;
 
     void drawPopupMenuSectionHeader (Graphics&, const Rectangle<int>& area,
-                                     const String& sectionName) override;
+                                     const String& sectionName, Component* targetComponent) override;
 
     Font getPopupMenuFont() override;
 
-    void drawPopupMenuUpDownArrow (Graphics&, int width, int height, bool isScrollUpArrow) override;
+    void drawPopupMenuUpDownArrow (Graphics&, int width, int height, bool isScrollUpArrow, Component* targetComponent) override;
 
     void getIdealPopupMenuItemSize (const String& text, bool isSeparator, int standardMenuItemHeight,
                                     int& idealWidth, int& idealHeight) override;

--- a/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel_V3.cpp
+++ b/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel_V3.cpp
@@ -460,9 +460,9 @@ void LookAndFeel_V3::drawLinearSliderBackground (Graphics& g, int x, int y, int 
     g.strokePath (indent, PathStrokeType (0.5f));
 }
 
-void LookAndFeel_V3::drawPopupMenuBackground (Graphics& g, int width, int height)
+void LookAndFeel_V3::drawPopupMenuBackground (Graphics& g, int width, int height, Component* targetComponent)
 {
-    g.fillAll (findColour (PopupMenu::backgroundColourId));
+    g.fillAll (findColour (PopupMenu::backgroundColourId, targetComponent));
     ignoreUnused (width, height);
 
    #if ! JUCE_MAC

--- a/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel_V3.h
+++ b/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel_V3.h
@@ -58,7 +58,7 @@ public:
 
     void drawKeymapChangeButton (Graphics&, int width, int height, Button& button, const String& keyDescription) override;
 
-    void drawPopupMenuBackground (Graphics&, int width, int height) override;
+    void drawPopupMenuBackground (Graphics&, int width, int height, Component* targetComponent) override;
     void drawMenuBarBackground (Graphics&, int width, int height, bool, MenuBarComponent&) override;
 
     int getTabButtonOverlap (int tabDepth) override;

--- a/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel_V4.cpp
+++ b/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel_V4.cpp
@@ -766,29 +766,30 @@ void LookAndFeel_V4::drawPopupMenuItem (Graphics& g, const Rectangle<int>& area,
                                         const bool isHighlighted, const bool isTicked,
                                         const bool hasSubMenu, const String& text,
                                         const String& shortcutKeyText,
-                                        const Drawable* icon, const Colour* const textColourToUse)
+                                        const Drawable* icon, const Colour* const textColourToUse,
+                                        Component* targetComponent)
 {
     if (isSeparator)
     {
         auto r  = area.reduced (5, 0);
         r.removeFromTop (roundToInt ((r.getHeight() * 0.5f) - 0.5f));
 
-        g.setColour (findColour (PopupMenu::textColourId).withAlpha (0.3f));
+        g.setColour (findColour (PopupMenu::textColourId, targetComponent).withAlpha (0.3f));
         g.fillRect (r.removeFromTop (1));
     }
     else
     {
-        auto textColour = (textColourToUse == nullptr ? findColour (PopupMenu::textColourId)
+        auto textColour = (textColourToUse == nullptr ? findColour (PopupMenu::textColourId, targetComponent)
                                                       : *textColourToUse);
 
         auto r  = area.reduced (1);
 
         if (isHighlighted && isActive)
         {
-            g.setColour (findColour (PopupMenu::highlightedBackgroundColourId));
+            g.setColour (findColour (PopupMenu::highlightedBackgroundColourId, targetComponent));
             g.fillRect (r);
 
-            g.setColour (findColour (PopupMenu::highlightedTextColourId));
+            g.setColour (findColour (PopupMenu::highlightedTextColourId, targetComponent));
         }
         else
         {

--- a/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel_V4.h
+++ b/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel_V4.h
@@ -177,7 +177,7 @@ public:
     void drawPopupMenuItem (Graphics&, const Rectangle<int>& area,
                             bool isSeparator, bool isActive, bool isHighlighted, bool isTicked, bool hasSubMenu,
                             const String& text, const String& shortcutKeyText,
-                            const Drawable* icon, const Colour* textColour) override;
+                            const Drawable* icon, const Colour* textColour, Component* targetComponent) override;
 
     void getIdealPopupMenuItemSize (const String& text, bool isSeparator, int standardMenuItemHeight,
                                     int& idealWidth, int& idealHeight) override;

--- a/modules/juce_gui_basics/menus/juce_BurgerMenuComponent.cpp
+++ b/modules/juce_gui_basics/menus/juce_BurgerMenuComponent.cpp
@@ -148,7 +148,7 @@ int BurgerMenuComponent::getNumRows()
 
 void BurgerMenuComponent::paint (Graphics& g)
 {
-    getLookAndFeel().drawPopupMenuBackground (g, getWidth(), getHeight());
+    getLookAndFeel().drawPopupMenuBackground (g, getWidth(), getHeight(), nullptr);
 }
 
 void BurgerMenuComponent::paintListBoxItem (int rowIndex, Graphics& g, int w, int h, bool highlight)
@@ -163,7 +163,7 @@ void BurgerMenuComponent::paintListBoxItem (int rowIndex, Graphics& g, int w, in
 
     if (row.isMenuHeader)
     {
-        lf.drawPopupMenuSectionHeader (g, r.reduced (20, 0), row.item.text);
+        lf.drawPopupMenuSectionHeader (g, r.reduced (20, 0), row.item.text, nullptr);
         g.setColour (Colours::grey);
         g.fillRect (r.withHeight (1));
     }
@@ -182,7 +182,8 @@ void BurgerMenuComponent::paintListBoxItem (int rowIndex, Graphics& g, int w, in
                                   item.text,
                                   item.shortcutKeyDescription,
                                   item.image.get(),
-                                  colour);
+                                  colour,
+                                  nullptr);
     }
 }
 

--- a/modules/juce_gui_basics/menus/juce_PopupMenu.h
+++ b/modules/juce_gui_basics/menus/juce_PopupMenu.h
@@ -754,7 +754,7 @@ public:
         virtual ~LookAndFeelMethods() = default;
 
         /** Fills the background of a popup menu component. */
-        virtual void drawPopupMenuBackground (Graphics&, int width, int height) = 0;
+        virtual void drawPopupMenuBackground (Graphics&, int width, int height, Component* targetComponent) = 0;
 
         /** Draws one of the items in a popup menu. */
         virtual void drawPopupMenuItem (Graphics&, const Rectangle<int>& area,
@@ -763,17 +763,20 @@ public:
                                         const String& text,
                                         const String& shortcutKeyText,
                                         const Drawable* icon,
-                                        const Colour* textColour) = 0;
+                                        const Colour* textColour,
+                                        Component* targetComponent) = 0;
 
         virtual void drawPopupMenuSectionHeader (Graphics&, const Rectangle<int>& area,
-                                                 const String& sectionName) = 0;
+                                                 const String& sectionName,
+                                                 Component* targetComponent) = 0;
 
         /** Returns the size and style of font to use in popup menus. */
         virtual Font getPopupMenuFont() = 0;
 
         virtual void drawPopupMenuUpDownArrow (Graphics&,
                                                int width, int height,
-                                               bool isScrollUpArrow) = 0;
+                                               bool isScrollUpArrow,
+                                               Component* targetComponent) = 0;
 
         /** Finds the best size for an item in a popup menu. */
         virtual void getIdealPopupMenuItemSize (const String& text,


### PR DESCRIPTION
This commit adds a SafePointer to the PopupMenu, so it can use the colours of a targetComponent, as supplied by PopupMenu::Options::getTargetComponent().