### PR TITLE
Fix hidpi scaling on Linux

### DIFF
--- a/modules/juce_audio_plugin_client/VST/juce_VST_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/VST/juce_VST_Wrapper.cpp
@@ -913,7 +913,7 @@ public:
             if (auto* ed = processor->createEditorIfNeeded())
             {
                 setHasEditorFlag (true);
-                editorComp.reset (new EditorCompWrapper (*this, *ed));
+                editorComp.reset (new EditorCompWrapper (*this, *ed, lastScaleFactorReceived));
             }
             else
             {
@@ -1037,11 +1037,14 @@ public:
                               , public Timer
                              #endif
     {
-        EditorCompWrapper (JuceVSTWrapper& w, AudioProcessorEditor& editor)
-            : wrapper (w)
+        EditorCompWrapper (JuceVSTWrapper& w, AudioProcessorEditor& editor, float scaleFactor)
+            : wrapper (w),
+              editorScaleFactor (scaleFactor)
         {
             editor.setOpaque (true);
             editor.setVisible (true);
+            editor.setScaleFactor (scaleFactor);
+
             setOpaque (true);
 
             setTopLeftPosition (editor.getPosition());
@@ -1075,6 +1078,24 @@ public:
         {
             auto b = getSizeToContainChild();
             bounds = convertToHostBounds ({ 0, 0, (int16) b.getHeight(), (int16) b.getWidth() });
+
+           #if JUCE_LINUX
+            if (auto* ed = getEditorComp())
+            {
+                if (auto* peer = ed->getPeer())
+                {
+                    auto scale = (float) peer->getPlatformScaleFactor();
+
+                    if (approximatelyEqual (scale, 1.0f))
+                        return;
+
+                    bounds.upper     *= scale;
+                    bounds.leftmost  *= scale;
+                    bounds.lower     *= scale;
+                    bounds.rightmost *= scale;
+                }
+            }
+           #endif
         }
 
         void attachToHost (VstOpCodeArguments args)
@@ -1183,9 +1204,9 @@ public:
                         setTopLeftPosition (0, getHeight() - pos.getHeight());
                    #endif
 
+                   #if ! JUCE_LINUX // setSize() on linux causes renoise and energyxt to fail.
                     resizeHostWindow (pos.getWidth(), pos.getHeight());
 
-                   #if ! JUCE_LINUX // setSize() on linux causes renoise and energyxt to fail.
                     if (! resizeEditor) // this is needed to prevent an infinite resizing loop due to coordinate rounding
                         shouldResizeEditor = false;
 
@@ -1199,6 +1220,9 @@ public:
 
                     if (auto* peer = ed->getPeer())
                         scale *= (float) peer->getPlatformScaleFactor();
+
+                    resizeHostWindow (roundToInt (pos.getWidth() * scale),
+                                      roundToInt (pos.getHeight() * scale));
 
                     X11Symbols::getInstance()->xResizeWindow (display, (Window) getWindowHandle(),
                                                               static_cast<unsigned int> (roundToInt (pos.getWidth()  * scale)),

--- a/modules/juce_audio_plugin_client/VST3/juce_VST3_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/VST3/juce_VST3_Wrapper.cpp
@@ -1180,8 +1180,26 @@ private:
             if (size != nullptr && component != nullptr)
             {
                 auto editorBounds = component->getSizeToContainChild();
+                auto width = editorBounds.getWidth();
+                auto height = editorBounds.getHeight();
 
-                *size = convertToHostBounds ({ 0, 0, editorBounds.getWidth(), editorBounds.getHeight() });
+               #if JUCE_LINUX
+                if (component != nullptr)
+                {
+                    if (auto* peer = component->getPeer())
+                    {
+                        auto scale = (float) peer->getPlatformScaleFactor();
+
+                        if (! approximatelyEqual (scale, 1.0f))
+                        {
+                            width  *= scale;
+                            height *= scale;
+                        }
+                    }
+                }
+               #endif
+
+                *size = convertToHostBounds ({ 0, 0, width, height });
                 return kResultTrue;
             }
 
@@ -1476,7 +1494,19 @@ private:
 
                     if (owner.plugFrame != nullptr)
                     {
-                        auto newSize = convertToHostBounds ({ 0, 0, b.getWidth(), b.getHeight() });
+                       #if JUCE_LINUX
+                        if (auto* peer = getPeer())
+                        {
+                            auto scale = (float) peer->getPlatformScaleFactor();
+
+                            if (! approximatelyEqual (scale, 1.0f))
+                            {
+                                w *= scale;
+                                h *= scale;
+                            }
+                        }
+                       #endif
+                        auto newSize = convertToHostBounds ({ 0, 0, w, h });
 
                         {
                             const ScopedValueSetter<bool> resizingParentSetter (resizingParent, true);


### PR DESCRIPTION
@falkTX and I were trying to figure out why a VST (Pianoteq) was not displaying correctly on Carla as well as Reaper or even jalv (https://gitlab.com/drobilla/jalv) on my setup (https://github.com/falkTX/Carla/issues/932)  and we found the problem:

I'm on Xorg with gnome-shell and a hidpi screen (2560x1440) so  `getDisplayScale()` from https://github.com/juce-framework/JUCE/blob/juce6/modules/juce_gui_basics/native/x11/juce_linux_XWindowSystem.cpp#L909 returns 2. JUCE then scales the plugin accordingly but the problem is it's not notifying the host about it. 
So, what happened was only 1/4 of a plugin UI would be shown.
I could reproduce this with Pianoteq 6 and CHOW (https://github.com/jatinchowdhury18/CHOW) but it probably impacts all the plugins built with JUCE5/6

Once those commits are applied, the VST2/3 will need to be rebuilt and will in turn correctly work on hidpi (we tested it and confirmed working with CHOW).
