### PR TITLE
fix some doxygen warnings in juce_LadderFilter.h

### DIFF
--- a/modules/juce_dsp/widgets/juce_LadderFilter.h
+++ b/modules/juce_dsp/widgets/juce_LadderFilter.h
@@ -63,15 +63,15 @@ public:
     void reset() noexcept;
 
     /** Sets the cutoff frequency of the filter.
-        @param newValue cutoff frequency in Hz */
+        @param newCutoff cutoff frequency in Hz */
     void setCutoffFrequencyHz (SampleType newCutoff) noexcept;
 
     /** Sets the resonance of the filter.
-        @param newValue a value between 0 and 1; higher values increase the resonance and can result in self oscillation! */
+        @param newResonance a value between 0 and 1; higher values increase the resonance and can result in self oscillation! */
     void setResonance (SampleType newResonance) noexcept;
 
     /** Sets the amount of saturation in the filter.
-        @param newValue saturation amount; it can be any number greater than or equal to one. Higher values result in more distortion.*/
+        @param newDrive saturation amount; it can be any number greater than or equal to one. Higher values result in more distortion.*/
     void setDrive (SampleType newDrive) noexcept;
 
     //==============================================================================


### PR DESCRIPTION
this fixes
```
/Users/jon/git/juce-docset/JUCE/docs/doxygen/build/juce_dsp/widgets/juce_LadderFilter.h:67: warning: argument 'newValue' of command @param is not found in the argument list of dsp::LadderFilter< SampleType >::setCutoffFrequencyHz(SampleType newCutoff)
/Users/jon/git/juce-docset/JUCE/docs/doxygen/build/juce_dsp/widgets/juce_LadderFilter.h:68: warning: The following parameter of dsp::LadderFilter::setCutoffFrequencyHz(SampleType newCutoff) is not documented:
  parameter 'newCutoff'
/Users/jon/git/juce-docset/JUCE/docs/doxygen/build/juce_dsp/widgets/juce_LadderFilter.h:71: warning: argument 'newValue' of command @param is not found in the argument list of dsp::LadderFilter< SampleType >::setResonance(SampleType newResonance)
/Users/jon/git/juce-docset/JUCE/docs/doxygen/build/juce_dsp/widgets/juce_LadderFilter.h:72: warning: The following parameter of dsp::LadderFilter::setResonance(SampleType newResonance) is not documented:
  parameter 'newResonance'
/Users/jon/git/juce-docset/JUCE/docs/doxygen/build/juce_dsp/widgets/juce_LadderFilter.h:75: warning: argument 'newValue' of command @param is not found in the argument list of dsp::LadderFilter< SampleType >::setDrive(SampleType newDrive)
/Users/jon/git/juce-docset/JUCE/docs/doxygen/build/juce_dsp/widgets/juce_LadderFilter.h:76: warning: The following parameter of dsp::LadderFilter::setDrive(SampleType newDrive) is not documented:
  parameter 'newDrive'
```