### PR TITLE
fix doxygen warnings in juce_ParameterAttachments.h

### DIFF
--- a/modules/juce_audio_processors/utilities/juce_ParameterAttachments.h
+++ b/modules/juce_audio_processors/utilities/juce_ParameterAttachments.h
@@ -45,7 +45,7 @@ public:
         @param parameter                  The parameter to which this attachment will listen
         @param parameterChangedCallback   The function that will be called on the message thread in response
                                           to parameter changes
-        @param uundoManager               The UndoManager that will be used to begin transactions when the UI
+        @param undoManager                The UndoManager that will be used to begin transactions when the UI
                                           requests a parameter change.
     */
     ParameterAttachment (RangedAudioParameter& parameter,
@@ -209,7 +209,7 @@ public:
     /** Creates a connection between a plug-in parameter and a Button.
 
         @param parameter     The parameter to use
-        @param combo         The Button to use
+        @param button        The Button to use
         @param undoManager   An optional UndoManager
     */
     ButtonParameterAttachment (RangedAudioParameter& parameter, Button& button,


### PR DESCRIPTION
this fixes:
```
/Users/jon/git/juce-docset/JUCE/docs/doxygen/build/juce_audio_processors/utilities/juce_ParameterAttachments.h:42: warning: argument 'uundoManager' of command @param is not found in the argument list of ParameterAttachment::ParameterAttachment(RangedAudioParameter &parameter, std::function< void(float)> parameterChangedCallback, UndoManager *undoManager=nullptr)
/Users/jon/git/juce-docset/JUCE/docs/doxygen/build/juce_audio_processors/utilities/juce_ParameterAttachments.h:52: warning: The following parameter of ParameterAttachment::ParameterAttachment(RangedAudioParameter &parameter, std::function< void(float)> parameterChangedCallback, UndoManager *undoManager=nullptr) is not documented:
  parameter 'undoManager'
/Users/jon/git/juce-docset/JUCE/docs/doxygen/build/juce_audio_processors/utilities/juce_ParameterAttachments.h:212: warning: argument 'combo' of command @param is not found in the argument list of ButtonParameterAttachment::ButtonParameterAttachment(RangedAudioParameter &parameter, Button &button, UndoManager *undoManager=nullptr)
/Users/jon/git/juce-docset/JUCE/docs/doxygen/build/juce_audio_processors/utilities/juce_ParameterAttachments.h:216: warning: The following parameter of ButtonParameterAttachment::ButtonParameterAttachment(RangedAudioParameter &parameter, Button &button, UndoManager *undoManager=nullptr) is not documented:
  parameter 'button'
```