### PR TITLE
List all files of juce_audio_plugin_client in Visual Studio projects

### DIFF
--- a/extras/Projucer/Source/ProjectSaving/jucer_ProjectExport_MSVC.h
+++ b/extras/Projucer/Source/ProjectSaving/jucer_ProjectExport_MSVC.h
@@ -745,7 +745,7 @@ public:
                     addFilesToCompile (projectItem.getChild (i), cpps, headers, otherFiles);
             }
             else if (projectItem.shouldBeAddedToTargetProject() && projectItem.shouldBeAddedToTargetExporter (getOwner())
-                     && getOwner().getProject().getTargetTypeFromFilePath (projectItem.getFile(), true) == targetType)
+                     && (targetType == SharedCodeTarget || getOwner().getProject().getTargetTypeFromFilePath (projectItem.getFile(), true) == targetType))
             {
                 RelativePath path (projectItem.getFile(), getOwner().getTargetFolder(), RelativePath::buildTargetFolder);
 
@@ -842,8 +842,8 @@ public:
 
                 jassert (relativePath.getRoot() == RelativePath::buildTargetFolder);
 
-                if (getOwner().getProject().getTargetTypeFromFilePath (projectItem.getFile(), true) == targetType
-                    && (targetType == SharedCodeTarget || projectItem.shouldBeCompiled()))
+                if (targetType == SharedCodeTarget
+                    || (getOwner().getProject().getTargetTypeFromFilePath (projectItem.getFile(), true) == targetType && projectItem.shouldBeCompiled()))
                 {
                     addFileToFilter (relativePath, path.upToLastOccurrenceOf ("\\", false, false), cpps, headers, otherFiles);
                     return true;


### PR DESCRIPTION
Discussed on this forum thread: https://forum.juce.com/t/not-all-files-added-to-visual-studio-browser/39440

Before: 

![image](https://user-images.githubusercontent.com/747995/82546151-f601e200-9b57-11ea-9051-204ca0878234.png)


After:

![image](https://user-images.githubusercontent.com/747995/82546185-044ffe00-9b58-11ea-8929-f2949764dd79.png)
