### PR TITLE
fix: JUCE_SYNC_VIDEO_VOLUME_WITH_OS_MEDIA_VOLUME

### DIFF
--- a/modules/juce_video/playback/juce_VideoComponent.h
+++ b/modules/juce_video/playback/juce_VideoComponent.h
@@ -154,7 +154,7 @@ public:
     */
     float getAudioVolume() const;
 
-   #if JUCE_SYNC_VIDEO_VOLUME_WITH_OS_MEDIA_VOLUME
+   #ifdef JUCE_SYNC_VIDEO_VOLUME_WITH_OS_MEDIA_VOLUME
     /** Set this callback to be notified whenever OS global media volume changes.
         Currently used on Android only.
      */


### PR DESCRIPTION
we found #if check creating issues as it is not a flag but a true define
Therefore, changed to #ifdef 