### PR TITLE
JucePlugin_AAXRequiresChunkCallsOnMainThread

### DIFF
--- a/modules/juce_audio_plugin_client/AAX/juce_AAX_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/AAX/juce_AAX_Wrapper.cpp
@@ -2320,6 +2320,12 @@ namespace AAXClasses
         check (descriptor.AddProcPtr ((void*) JuceAAX_GUI::Create,        kAAX_ProcPtrID_Create_EffectGUI));
         check (descriptor.AddProcPtr ((void*) JuceAAX_Processor::Create,  kAAX_ProcPtrID_Create_EffectParameters));
 
+      #ifdef JucePlugin_AAXRequiresChunkCallsOnMainThread
+        AAX_IPropertyMap *properties = descriptor.NewPropertyMap();
+        properties->AddProperty(AAX_eProperty_RequiresChunkCallsOnMainThread, 1);
+        descriptor.SetProperties(properties);
+      #endif
+      
         Array<int32> pluginIds;
        #if JucePlugin_IsMidiEffect
         // MIDI effect plug-ins do not support any audio channels


### PR DESCRIPTION
Add option "JucePlugin_AAXRequiresChunkCallsOnMainThread"

Prevents crashes while loading sessions in Protools.
It explicitly asks Protools to use message thread for chunk calls which improves code safety.