### PR TITLE
GUI: FileBrowserComponent's go up button will now not disappear after a look and feel change

### DIFF
--- a/modules/juce_gui_basics/filebrowser/juce_FileBrowserComponent.cpp
+++ b/modules/juce_gui_basics/filebrowser/juce_FileBrowserComponent.cpp
@@ -117,10 +117,6 @@ FileBrowserComponent::FileBrowserComponent (int flags_,
 
     lookAndFeelChanged();
 
-    addAndMakeVisible (goUpButton.get());
-    goUpButton->onClick = [this] { goUp(); };
-    goUpButton->setTooltip (TRANS ("Go up to parent directory"));
-
     setRoot (currentRoot);
 
     if (filename.isNotEmpty())
@@ -358,6 +354,9 @@ void FileBrowserComponent::resized()
 void FileBrowserComponent::lookAndFeelChanged()
 {
     goUpButton.reset (getLookAndFeel().createFileBrowserGoUpButton());
+    addAndMakeVisible (goUpButton.get());
+    goUpButton->onClick = [this] { goUp(); };
+    goUpButton->setTooltip (TRANS ("Go up to parent directory"));
 
     currentPathBox.setColour (ComboBox::backgroundColourId,    findColour (currentPathBoxBackgroundColourId));
     currentPathBox.setColour (ComboBox::textColourId,          findColour (currentPathBoxTextColourId));


### PR DESCRIPTION
After being replaced in lookAndFeelChanged(), goUpButton has no parent, or tooltip, or onClick callback. As the constructor already calls lookAndFeelChanged(), these lines are moved.