### PR TITLE
Added conical gradient pattern.

### DIFF
--- a/modules/juce_graphics/colour/juce_ColourGradient.cpp
+++ b/modules/juce_graphics/colour/juce_ColourGradient.cpp
@@ -26,7 +26,7 @@
 namespace juce
 {
 
-ColourGradient::ColourGradient() noexcept  : isRadial (false)
+ColourGradient::ColourGradient() noexcept  : gradientType (Linear)
 {
    #if JUCE_DEBUG
     point1.setX (987654.0f);
@@ -37,21 +37,20 @@ ColourGradient::ColourGradient() noexcept  : isRadial (false)
 }
 
 ColourGradient::ColourGradient (const ColourGradient& other)
-    : point1 (other.point1), point2 (other.point2), isRadial (other.isRadial),
-      isConical (other.isConical), colours (other.colours)
+    : point1 (other.point1), point2 (other.point2),
+      gradientType (other.gradientType), colours (other.colours)
 {}
 
 ColourGradient::ColourGradient (ColourGradient&& other) noexcept
-    : point1 (other.point1), point2 (other.point2), isRadial (other.isRadial),
-      isConical (other.isConical), colours (std::move (other.colours))
+    : point1 (other.point1), point2 (other.point2),
+      gradientType (other.gradientType), colours (std::move (other.colours))
 {}
 
 ColourGradient& ColourGradient::operator= (const ColourGradient& other)
 {
     point1 = other.point1;
     point2 = other.point2;
-    isRadial = other.isRadial;
-    isConical = other.isConical;
+    gradientType = other.gradientType;
     colours = other.colours;
     return *this;
 }
@@ -60,55 +59,65 @@ ColourGradient& ColourGradient::operator= (ColourGradient&& other) noexcept
 {
     point1 = other.point1;
     point2 = other.point2;
-    isRadial = other.isRadial;
-    isConical = other.isConical;
+    gradientType = other.gradientType;
     colours = std::move (other.colours);
     return *this;
 }
 
 ColourGradient::ColourGradient (Colour colour1, float x1, float y1,
                                 Colour colour2, float x2, float y2,
-                                bool radial, bool conical)
+                                GradientType type)
     : ColourGradient (colour1, Point<float> (x1, y1),
                       colour2, Point<float> (x2, y2),
-                      radial, conical)
+                      type)
 {
 }
 
 ColourGradient::ColourGradient (Colour colour1, Point<float> p1,
                                 Colour colour2, Point<float> p2,
-                                bool radial, bool conical)
+                                GradientType type)
     : point1 (p1),
       point2 (p2),
-      isRadial (radial),
-      isConical (conical)
+      gradientType (type),
+      isRadial (gradientType == Radial)
 {
-    /** A gradient can't be radial AND conical.
-        Either isRadial or isConical can be set to true (or neither) but not
-        both!
-    */
-    jassert(!(isRadial && isConical));
-
     colours.add (ColourPoint { 0.0, colour1 },
                  ColourPoint { 1.0, colour2 });
+}
+
+ColourGradient::ColourGradient (Colour colour1, float x1, float y1,
+                                Colour colour2, float x2, float y2,
+                                bool radial)
+    : ColourGradient (colour1, Point<float> (x1, y1),
+                      colour2, Point<float> (x2, y2),
+                      radial ? GradientType::Radial : GradientType::Linear)
+{
+}
+
+ColourGradient::ColourGradient (Colour colour1, Point<float> p1,
+                                Colour colour2, Point<float> p2,
+                                bool radial)
+    : ColourGradient (colour1, p1, colour2, p2,
+                      radial ? GradientType::Radial : GradientType::Linear)
+{
 }
 
 ColourGradient::~ColourGradient() {}
 
 ColourGradient ColourGradient::vertical (Colour c1, float y1, Colour c2, float y2)
 {
-    return { c1, 0, y1, c2, 0, y2, false };
+    return { c1, 0, y1, c2, 0, y2, Linear };
 }
 
 ColourGradient ColourGradient::horizontal (Colour c1, float x1, Colour c2, float x2)
 {
-    return { c1, x1, 0, c2, x2, 0, false };
+    return { c1, x1, 0, c2, x2, 0, Linear };
 }
 
 bool ColourGradient::operator== (const ColourGradient& other) const noexcept
 {
     return point1 == other.point1 && point2 == other.point2
-            && isRadial == other.isRadial
+            && gradientType == other.gradientType
             && colours == other.colours;
 }
 

--- a/modules/juce_graphics/colour/juce_ColourGradient.cpp
+++ b/modules/juce_graphics/colour/juce_ColourGradient.cpp
@@ -37,12 +37,13 @@ ColourGradient::ColourGradient() noexcept  : isRadial (false)
 }
 
 ColourGradient::ColourGradient (const ColourGradient& other)
-    : point1 (other.point1), point2 (other.point2), isRadial (other.isRadial), colours (other.colours)
+    : point1 (other.point1), point2 (other.point2), isRadial (other.isRadial),
+      isConical (other.isConical), colours (other.colours)
 {}
 
 ColourGradient::ColourGradient (ColourGradient&& other) noexcept
     : point1 (other.point1), point2 (other.point2), isRadial (other.isRadial),
-      colours (std::move (other.colours))
+      isConical (other.isConical), colours (std::move (other.colours))
 {}
 
 ColourGradient& ColourGradient::operator= (const ColourGradient& other)
@@ -50,6 +51,7 @@ ColourGradient& ColourGradient::operator= (const ColourGradient& other)
     point1 = other.point1;
     point2 = other.point2;
     isRadial = other.isRadial;
+    isConical = other.isConical;
     colours = other.colours;
     return *this;
 }
@@ -59,23 +61,34 @@ ColourGradient& ColourGradient::operator= (ColourGradient&& other) noexcept
     point1 = other.point1;
     point2 = other.point2;
     isRadial = other.isRadial;
+    isConical = other.isConical;
     colours = std::move (other.colours);
     return *this;
 }
 
 ColourGradient::ColourGradient (Colour colour1, float x1, float y1,
-                                Colour colour2, float x2, float y2, bool radial)
+                                Colour colour2, float x2, float y2,
+                                bool radial, bool conical)
     : ColourGradient (colour1, Point<float> (x1, y1),
-                      colour2, Point<float> (x2, y2), radial)
+                      colour2, Point<float> (x2, y2),
+                      radial, conical)
 {
 }
 
 ColourGradient::ColourGradient (Colour colour1, Point<float> p1,
-                                Colour colour2, Point<float> p2, bool radial)
+                                Colour colour2, Point<float> p2,
+                                bool radial, bool conical)
     : point1 (p1),
       point2 (p2),
-      isRadial (radial)
+      isRadial (radial),
+      isConical (conical)
 {
+    /** A gradient can't be radial AND conical.
+        Either isRadial or isConical can be set to true (or neither) but not
+        both!
+    */
+    jassert(!(isRadial && isConical));
+
     colours.add (ColourPoint { 0.0, colour1 },
                  ColourPoint { 1.0, colour2 });
 }

--- a/modules/juce_graphics/colour/juce_ColourGradient.cpp
+++ b/modules/juce_graphics/colour/juce_ColourGradient.cpp
@@ -26,7 +26,7 @@
 namespace juce
 {
 
-ColourGradient::ColourGradient() noexcept  : gradientType (Linear)
+ColourGradient::ColourGradient() noexcept
 {
    #if JUCE_DEBUG
     point1.setX (987654.0f);

--- a/modules/juce_graphics/colour/juce_ColourGradient.h
+++ b/modules/juce_graphics/colour/juce_ColourGradient.h
@@ -215,7 +215,7 @@ public:
     Point<float> point1, point2;
 
     /** Defines which of the available gradient types should be used. */
-    GradientType gradientType;
+    GradientType gradientType = GradientType::Linear;
 
     /** isRadial has been deprecated in favour of the gradientType property.
         See ColourGradient::GradientType.

--- a/modules/juce_graphics/colour/juce_ColourGradient.h
+++ b/modules/juce_graphics/colour/juce_ColourGradient.h
@@ -37,6 +37,16 @@ namespace juce
 class JUCE_API  ColourGradient  final
 {
 public:
+    //==============================================================================
+    /** The available gradient types. */
+    enum GradientType
+    {
+        Linear, // Colours transition along a straight line.
+        Radial, // Colours radiate from an origin.
+        Conical // Colours rotate around a centre point.
+    };
+
+    //==============================================================================
     /** Creates an uninitialised gradient.
 
         If you use this constructor instead of the other one, be sure to set all the
@@ -51,52 +61,56 @@ public:
 
     //==============================================================================
     /** Creates a gradient object.
-
+        
         (x1, y1) is the location to draw with colour1. Likewise (x2, y2) is where
-        colour2 should be. In between them there's a gradient.
+        colour2 should be. In between them there's a gradient of the type specified
+        by typeOfGradientToUse.
 
-        If isRadial is true, the colours form a circular gradient with (x1, y1) at
-        its centre.
+        The alpha transparencies of the colours are used, so note that if you blend
+        from transparent to a solid colour, the RGB of the transparent colour will
+        become visible in parts of the gradient. e.g. blending from
+        Colour::transparentBlack to Colours::white will produce a muddy grey colour
+        midway, but Colour::transparentWhite to Colours::white will be white all
+        the way across.
 
-        If instead isConical is true, the colours form a conical gradient with
-        (x1, y1) at its centre and (x2, y2) as the start/end position.
-
-        The alpha transparencies of the colours are used, so note that
-        if you blend from transparent to a solid colour, the RGB of the transparent
-        colour will become visible in parts of the gradient. e.g. blending
-        from Colour::transparentBlack to Colours::white will produce a
-        muddy grey colour midway, but Colour::transparentWhite to Colours::white
-        will be white all the way across.
-
-        @see ColourGradient
+        @see ColourGradient, GradientType
     */
     ColourGradient (Colour colour1, float x1, float y1,
                     Colour colour2, float x2, float y2,
-                    bool isRadial, bool isConical = false);
+                    GradientType typeOfGradientToUse);
 
     /** Creates a gradient object.
 
         point1 is the location to draw with colour1. Likewise point2 is where
-        colour2 should be. In between them there's a gradient.
+        colour2 should be. In between them there's a gradient of the type specified
+        by typeOfGradientToUse.
 
-        If isRadial is true, the colours form a circular gradient with point1 at
-        its centre.
+        The alpha transparencies of the colours are used, so note that if you blend
+        from transparent to a solid colour, the RGB of the transparent colour will
+        become visible in parts of the gradient. e.g. blending from
+        Colour::transparentBlack to Colours::white will produce a muddy grey colour
+        midway, but Colour::transparentWhite to Colours::white will be white all
+        the way across.
 
-        If instead isConical is true, the colours form a conical gradient with
-        point1 at its centre and point2 as the start/end position.
-
-        The alpha transparencies of the colours are used, so note that
-        if you blend from transparent to a solid colour, the RGB of the transparent
-        colour will become visible in parts of the gradient. e.g. blending
-        from Colour::transparentBlack to Colours::white will produce a
-        muddy grey colour midway, but Colour::transparentWhite to Colours::white
-        will be white all the way across.
-
-        @see ColourGradient
+        @see ColourGradient, GradientType
     */
     ColourGradient (Colour colour1, Point<float> point1,
                     Colour colour2, Point<float> point2,
-                    bool isRadial, bool isConical = false);
+                    GradientType typeOfGradientToUse);
+
+    /** The isRadial boolean argument is no longer used in favour of the
+        GradientType argument for defining the type of gradient to use.
+    */
+    JUCE_DEPRECATED (ColourGradient (Colour colour1, float x1, float y1,
+                                     Colour colour2, float x2, float y2,
+                                     bool isRadial);)
+
+    /** The isRadial boolean argument is no longer used in favour of the
+        GradientType argument for defining the type of gradient to use.
+    */
+    JUCE_DEPRECATED (ColourGradient (Colour colour1, Point<float> point1,
+                                     Colour colour2, Point<float> point2,
+                                     bool isRadial);)
 
     //==============================================================================
     /** Creates a vertical linear gradient between two Y coordinates */
@@ -200,21 +214,13 @@ public:
     //==============================================================================
     Point<float> point1, point2;
 
-    /** If true, the gradient should be filled circularly, centred around
-        point1, with point2 defining a point on the circumference.
+    /** Defines which of the available gradient types should be used. */
+    GradientType gradientType;
 
-        If false and isConical is also false, the gradient is linear between the
-        two points.
+    /** isRadial has been deprecated in favour of the gradientType property.
+        See ColourGradient::GradientType.
     */
-    bool isRadial;
-
-    /** If true, the gradient should be filled conically, centred around point1,
-        with point2 defining the start/end position.
-
-        If false and isRadial is also false, the gradient is linear between the
-        two points.
-    */
-    bool isConical;
+    JUCE_DEPRECATED (bool isRadial;)
 
     bool operator== (const ColourGradient&) const noexcept;
     bool operator!= (const ColourGradient&) const noexcept;

--- a/modules/juce_graphics/colour/juce_ColourGradient.h
+++ b/modules/juce_graphics/colour/juce_ColourGradient.h
@@ -58,6 +58,9 @@ public:
         If isRadial is true, the colours form a circular gradient with (x1, y1) at
         its centre.
 
+        If instead isConical is true, the colours form a conical gradient with
+        (x1, y1) at its centre and (x2, y2) as the start/end position.
+
         The alpha transparencies of the colours are used, so note that
         if you blend from transparent to a solid colour, the RGB of the transparent
         colour will become visible in parts of the gradient. e.g. blending
@@ -69,7 +72,7 @@ public:
     */
     ColourGradient (Colour colour1, float x1, float y1,
                     Colour colour2, float x2, float y2,
-                    bool isRadial);
+                    bool isRadial, bool isConical = false);
 
     /** Creates a gradient object.
 
@@ -78,6 +81,9 @@ public:
 
         If isRadial is true, the colours form a circular gradient with point1 at
         its centre.
+
+        If instead isConical is true, the colours form a conical gradient with
+        point1 at its centre and point2 as the start/end position.
 
         The alpha transparencies of the colours are used, so note that
         if you blend from transparent to a solid colour, the RGB of the transparent
@@ -90,7 +96,7 @@ public:
     */
     ColourGradient (Colour colour1, Point<float> point1,
                     Colour colour2, Point<float> point2,
-                    bool isRadial);
+                    bool isRadial, bool isConical = false);
 
     //==============================================================================
     /** Creates a vertical linear gradient between two Y coordinates */
@@ -197,9 +203,18 @@ public:
     /** If true, the gradient should be filled circularly, centred around
         point1, with point2 defining a point on the circumference.
 
-        If false, the gradient is linear between the two points.
+        If false and isConical is also false, the gradient is linear between the
+        two points.
     */
     bool isRadial;
+
+    /** If true, the gradient should be filled conically, centred around point1,
+        with point2 defining the start/end position.
+
+        If false and isRadial is also false, the gradient is linear between the
+        two points.
+    */
+    bool isConical;
 
     bool operator== (const ColourGradient&) const noexcept;
     bool operator!= (const ColourGradient&) const noexcept;

--- a/modules/juce_graphics/effects/juce_DropShadowEffect.cpp
+++ b/modules/juce_graphics/effects/juce_DropShadowEffect.cpp
@@ -120,7 +120,7 @@ static void drawShadowSection (Graphics& g, ColourGradient& cg, Rectangle<float>
 {
     cg.point1 = area.getRelativePoint (centreX, centreY);
     cg.point2 = area.getRelativePoint (edgeX, edgeY);
-    cg.isRadial = isCorner;
+    cg.gradientType = isCorner ? ColourGradient::Radial : ColourGradient::Linear;
 
     g.setGradientFill (cg);
     g.fillRect (area);
@@ -128,7 +128,7 @@ static void drawShadowSection (Graphics& g, ColourGradient& cg, Rectangle<float>
 
 void DropShadow::drawForRectangle (Graphics& g, const Rectangle<int>& targetArea) const
 {
-    ColourGradient cg (colour, 0, 0, colour.withAlpha (0.0f), 0, 0, false);
+    ColourGradient cg (colour, 0, 0, colour.withAlpha (0.0f), 0, 0, ColourGradient::Linear);
 
     for (float i = 0.05f; i < 1.0f; i += 0.1f)
         cg.addColour (1.0 - i, colour.withMultipliedAlpha (i * i));

--- a/modules/juce_graphics/native/juce_RenderingHelpers.h
+++ b/modules/juce_graphics/native/juce_RenderingHelpers.h
@@ -746,10 +746,10 @@ namespace EdgeTableFillers
         {
         }
 
-        forcedinline void setEdgeTableYPos (int y) noexcept
+        forcedinline void setEdgeTableYPos (int newY) noexcept
         {
-            linePixels = (PixelType*) destData.getLinePointer (y);
-            GradientType::setY (y);
+            linePixels = (PixelType*) destData.getLinePointer (newY);
+            GradientType::setY (newY);
         }
 
         forcedinline void handleEdgeTablePixel (int x, int alphaLevel) const noexcept
@@ -1605,7 +1605,12 @@ namespace EdgeTableFillers
     void renderGradient (Iterator& iter, const Image::BitmapData& destData, const ColourGradient& g, const AffineTransform& transform,
                          const PixelARGB* lookupTable, int numLookupEntries, bool isIdentity, DestPixelType*)
     {
-        if (g.isRadial)
+        if (g.gradientType == ColourGradient::Linear)
+        {
+            EdgeTableFillers::Gradient<DestPixelType, GradientPixelIterators::Linear> renderer (destData, g, transform, lookupTable, numLookupEntries);
+            iter.iterate (renderer);
+        }
+        else if (g.gradientType == ColourGradient::Radial)
         {
             if (isIdentity)
             {
@@ -1618,15 +1623,17 @@ namespace EdgeTableFillers
                 iter.iterate (renderer);
             }
         }
-        else if (g.isConical)
+        else if (g.gradientType == ColourGradient::Conical)
         {
             EdgeTableFillers::Gradient<DestPixelType, GradientPixelIterators::Conical> renderer (destData, g, transform, lookupTable, numLookupEntries);
             iter.iterate (renderer);
         }
         else
         {
-            EdgeTableFillers::Gradient<DestPixelType, GradientPixelIterators::Linear> renderer (destData, g, transform, lookupTable, numLookupEntries);
-            iter.iterate (renderer);
+            /** The GradientType of the given ColourGradient has an unsupported
+                value.
+            */
+            jassertfalse;
         }
     }
 }

--- a/modules/juce_gui_basics/drawables/juce_SVGParser.cpp
+++ b/modules/juce_gui_basics/drawables/juce_SVGParser.cpp
@@ -887,7 +887,8 @@ private:
 
         jassert (gradient.getNumColours() > 0);
 
-        gradient.isRadial = fillXml->hasTagNameIgnoringNamespace ("radialGradient");
+        gradient.gradientType = fillXml->hasTagNameIgnoringNamespace ("radialGradient") ? ColourGradient::Radial :
+                                                                                          ColourGradient::Linear;
 
         float gradientWidth = viewBoxW;
         float gradientHeight = viewBoxH;
@@ -905,7 +906,7 @@ private:
             gradientHeight = bounds.getHeight();
         }
 
-        if (gradient.isRadial)
+        if (gradient.gradientType == ColourGradient::Radial)
         {
             if (userSpace)
                 gradient.point1.setXY (dx + getCoordLength (fillXml->getStringAttribute ("cx", "50%"), gradientWidth),
@@ -946,7 +947,7 @@ private:
 
         auto gradientTransform = parseTransform (fillXml->getStringAttribute ("gradientTransform"));
 
-        if (gradient.isRadial)
+        if (gradient.gradientType == ColourGradient::Radial)
         {
             type.transform = gradientTransform;
         }

--- a/modules/juce_gui_basics/layout/juce_SidePanel.cpp
+++ b/modules/juce_gui_basics/layout/juce_SidePanel.cpp
@@ -148,7 +148,8 @@ void SidePanel::paint (Graphics& g)
     g.setGradientFill (ColourGradient (shadowColour.withAlpha (0.7f), (isOnLeft ? shadowArea.getTopLeft()
                                                                                 : shadowArea.getTopRight()).toFloat(),
                                        shadowColour.withAlpha (0.0f), (isOnLeft ? shadowArea.getTopRight()
-                                                                                : shadowArea.getTopLeft()).toFloat(), false));
+                                                                                : shadowArea.getTopLeft()).toFloat(),
+                                       ColourGradient::Linear));
     g.fillRect (shadowArea);
 
     g.excludeClipRegion (shadowArea);

--- a/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel_V2.cpp
+++ b/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel_V2.cpp
@@ -752,7 +752,8 @@ void LookAndFeel_V2::drawScrollbar (Graphics& g,
     }
 
     g.setGradientFill (ColourGradient (trackColour1, gx1, gy1,
-                                       trackColour2, gx2, gy2, false));
+                                       trackColour2, gx2, gy2,
+                                       ColourGradient::Linear));
     g.fillPath (slotPath);
 
     if (isScrollbarVertical)
@@ -767,14 +768,14 @@ void LookAndFeel_V2::drawScrollbar (Graphics& g,
     }
 
     g.setGradientFill (ColourGradient (Colours::transparentBlack,gx1, gy1,
-                       Colour (0x19000000), gx2, gy2, false));
+                       Colour (0x19000000), gx2, gy2, ColourGradient::Linear));
     g.fillPath (slotPath);
 
     g.setColour (thumbColour);
     g.fillPath (thumbPath);
 
     g.setGradientFill (ColourGradient (Colour (0x10000000), gx1, gy1,
-                       Colours::transparentBlack, gx2, gy2, false));
+                       Colours::transparentBlack, gx2, gy2, ColourGradient::Linear));
 
     {
         Graphics::ScopedSaveState ss (g);
@@ -913,7 +914,7 @@ void LookAndFeel_V2::drawPopupMenuUpDownArrow (Graphics& g, int width, int heigh
     g.setGradientFill (ColourGradient (background, 0.0f, (float) height * 0.5f,
                                        background.withAlpha (0.0f),
                                        0.0f, isScrollUpArrow ? ((float) height) : 0.0f,
-                                       false));
+                                       ColourGradient::Linear));
 
     g.fillRect (1, 1, width - 2, height - 2);
 
@@ -1868,7 +1869,8 @@ public:
         diam *= 0.9f;
 
         g.setGradientFill (ColourGradient (Colour::greyLevel (0.9f).withAlpha (alpha), 0, y + diam,
-                                           Colour::greyLevel (0.6f).withAlpha (alpha), 0, y, false));
+                                           Colour::greyLevel (0.6f).withAlpha (alpha), 0, y,
+                                           ColourGradient::Linear));
         g.fillEllipse (x, y, diam, diam);
 
         x += 2.0f;
@@ -1997,7 +1999,7 @@ void LookAndFeel_V2::drawStretchableLayoutResizerBar (Graphics& g, int w, int h,
 
     g.setGradientFill (ColourGradient (Colours::white.withAlpha (alpha), cx + cr * 0.1f, cy + cr,
                                        Colours::black.withAlpha (alpha), cx, cy - cr * 4.0f,
-                                       true));
+                                       ColourGradient::Radial));
 
     g.fillEllipse (cx - cr, cy - cr, cr * 2.0f, cr * 2.0f);
 }
@@ -2273,7 +2275,7 @@ void LookAndFeel_V2::drawTabAreaBehindFrontButton (TabbedButtonBar& bar, Graphic
 
     Rectangle<int> shadowRect, line;
     ColourGradient gradient (Colours::black.withAlpha (bar.isEnabled() ? 0.25f : 0.15f), 0, 0,
-                             Colours::transparentBlack, 0, 0, false);
+                             Colours::transparentBlack, 0, 0, ColourGradient::Linear);
 
     switch (bar.getOrientation())
     {
@@ -2366,7 +2368,7 @@ void LookAndFeel_V2::drawTableHeaderBackground (Graphics& g, TableHeaderComponen
                                        0.0f, (float) area.getY(),
                                        backgroundColour.withMultipliedSaturation (.5f),
                                        0.0f, (float) area.getBottom(),
-                                       false));
+                                       ColourGradient::Linear));
     g.fillRect (area);
 
     g.setColour (header.findColour (TableHeaderComponent::outlineColourId));
@@ -2427,7 +2429,7 @@ void LookAndFeel_V2::paintToolbarBackground (Graphics& g, int w, int h, Toolbar&
                                        background.darker (0.1f),
                                        toolbar.isVertical() ? (float) w - 1.0f : 0.0f,
                                        toolbar.isVertical() ? 0.0f : (float) h - 1.0f,
-                                       false));
+                                       ColourGradient::Linear));
     g.fillAll();
 }
 
@@ -2898,7 +2900,7 @@ void LookAndFeel_V2::drawShinyButtonShape (Graphics& g, float x, float y, float 
 
     ColourGradient cg (baseColour, 0.0f, y,
                        baseColour.overlaidWith (Colour (0x070000ff)), 0.0f, y + h,
-                       false);
+                       ColourGradient::Linear);
 
     cg.addColour (0.5,  baseColour.overlaidWith (Colour (0x33ffffff)));
     cg.addColour (0.51, baseColour.overlaidWith (Colour (0x110000ff)));
@@ -2923,7 +2925,8 @@ void LookAndFeel_V2::drawGlassSphere (Graphics& g, const float x, const float y,
 
     {
         ColourGradient cg (Colours::white.overlaidWith (colour.withMultipliedAlpha (0.3f)), 0, y,
-                           Colours::white.overlaidWith (colour.withMultipliedAlpha (0.3f)), 0, y + diameter, false);
+                           Colours::white.overlaidWith (colour.withMultipliedAlpha (0.3f)), 0, y + diameter,
+                           ColourGradient::Linear);
 
         cg.addColour (0.4, Colours::white.overlaidWith (colour));
 
@@ -2932,13 +2935,14 @@ void LookAndFeel_V2::drawGlassSphere (Graphics& g, const float x, const float y,
     }
 
     g.setGradientFill (ColourGradient (Colours::white, 0, y + diameter * 0.06f,
-                                       Colours::transparentWhite, 0, y + diameter * 0.3f, false));
+                                       Colours::transparentWhite, 0, y + diameter * 0.3f,
+                                       ColourGradient::Linear));
     g.fillEllipse (x + diameter * 0.2f, y + diameter * 0.05f, diameter * 0.6f, diameter * 0.4f);
 
     ColourGradient cg (Colours::transparentBlack,
                        x + diameter * 0.5f, y + diameter * 0.5f,
                        Colours::black.withAlpha (0.5f * outlineThickness * colour.getFloatAlpha()),
-                       x, y + diameter * 0.5f, true);
+                       x, y + diameter * 0.5f, ColourGradient::Radial);
 
     cg.addColour (0.7, Colours::transparentBlack);
     cg.addColour (0.8, Colours::black.withAlpha (0.1f * outlineThickness));
@@ -2973,7 +2977,8 @@ void LookAndFeel_V2::drawGlassPointer (Graphics& g,
 
     {
         ColourGradient cg (Colours::white.overlaidWith (colour.withMultipliedAlpha (0.3f)), 0, y,
-                           Colours::white.overlaidWith (colour.withMultipliedAlpha (0.3f)), 0, y + diameter, false);
+                           Colours::white.overlaidWith (colour.withMultipliedAlpha (0.3f)), 0, y + diameter,
+                           ColourGradient::Linear);
 
         cg.addColour (0.4, Colours::white.overlaidWith (colour));
 
@@ -2984,7 +2989,7 @@ void LookAndFeel_V2::drawGlassPointer (Graphics& g,
     ColourGradient cg (Colours::transparentBlack,
                        x + diameter * 0.5f, y + diameter * 0.5f,
                        Colours::black.withAlpha (0.5f * outlineThickness * colour.getFloatAlpha()),
-                       x - diameter * 0.2f, y + diameter * 0.5f, true);
+                       x - diameter * 0.2f, y + diameter * 0.5f, ColourGradient::Radial);
 
     cg.addColour (0.5, Colours::transparentBlack);
     cg.addColour (0.7, Colours::black.withAlpha (0.07f * outlineThickness));
@@ -3023,7 +3028,8 @@ void LookAndFeel_V2::drawGlassLozenge (Graphics& g,
 
     {
         ColourGradient cg (colour.darker (0.2f), 0, y,
-                           colour.darker (0.2f), 0, y + height, false);
+                           colour.darker (0.2f), 0, y + height,
+                           ColourGradient::Linear);
 
         cg.addColour (0.03, colour.withMultipliedAlpha (0.3f));
         cg.addColour (0.4, colour);
@@ -3034,7 +3040,7 @@ void LookAndFeel_V2::drawGlassLozenge (Graphics& g,
     }
 
     ColourGradient cg (Colours::transparentBlack, x + edgeBlurRadius, y + height * 0.5f,
-                       colour.darker (0.2f), x, y + height * 0.5f, true);
+                       colour.darker (0.2f), x, y + height * 0.5f, ColourGradient::Radial);
 
     cg.addColour (jlimit (0.0, 1.0, 1.0 - (cs * 0.5f) / edgeBlurRadius), Colours::transparentBlack);
     cg.addColour (jlimit (0.0, 1.0, 1.0 - (cs * 0.25f) / edgeBlurRadius), colour.darker (0.2f).withMultipliedAlpha (0.3f));
@@ -3077,7 +3083,8 @@ void LookAndFeel_V2::drawGlassLozenge (Graphics& g,
                                        ! (flatOnRight || flatOnBottom));
 
         g.setGradientFill (ColourGradient (colour.brighter (10.0f), 0, y + height * 0.06f,
-                                           Colours::transparentWhite, 0, y + height * 0.4f, false));
+                                           Colours::transparentWhite, 0, y + height * 0.4f,
+                                           ColourGradient::Linear));
         g.fillPath (highlight);
     }
 

--- a/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel_V3.cpp
+++ b/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel_V3.cpp
@@ -214,7 +214,8 @@ void LookAndFeel_V3::drawTabButton (TabBarButton& button, Graphics& g, bool isMo
         }
 
         g.setGradientFill (ColourGradient (bkg.brighter (0.2f), p1.toFloat(),
-                                           bkg.darker (0.1f),   p2.toFloat(), false));
+                                           bkg.darker (0.1f),   p2.toFloat(),
+                                           ColourGradient::Linear));
     }
 
     g.fillRect (activeArea);
@@ -275,7 +276,7 @@ void LookAndFeel_V3::drawTabAreaBehindFrontButton (TabbedButtonBar& bar, Graphic
 
     Rectangle<int> shadowRect, line;
     ColourGradient gradient (Colours::black.withAlpha (bar.isEnabled() ? 0.08f : 0.04f), 0, 0,
-                             Colours::transparentBlack, 0, 0, false);
+                             Colours::transparentBlack, 0, 0, ColourGradient::Linear);
 
     switch (bar.getOrientation())
     {

--- a/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel_V4.cpp
+++ b/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel_V4.cpp
@@ -1209,7 +1209,7 @@ void LookAndFeel_V4::paintToolbarBackground (Graphics& g, int w, int h, Toolbar&
                          background.darker (0.2f),
                          toolbar.isVertical() ? (float) w - 1.0f : 0.0f,
                          toolbar.isVertical() ? 0.0f : (float) h - 1.0f,
-                         false });
+                         ColourGradient::Linear });
     g.fillAll();
 }
 

--- a/modules/juce_gui_basics/misc/juce_JUCESplashScreen.cpp
+++ b/modules/juce_gui_basics/misc/juce_JUCESplashScreen.cpp
@@ -132,7 +132,7 @@ void JUCESplashScreen::paint (Graphics& g)
 
     ColourGradient cg (Colour (0x00000000), Line<float> (0.0f, r.getHeight(), r.getWidth(), 0.0f)
                                               .findNearestPointTo (bottomRight),
-                       Colour (0xff000000), bottomRight, false);
+                       Colour (0xff000000), bottomRight, ColourGradient::Linear);
     cg.addColour (0.25f, Colour (0x10000000));
     cg.addColour (0.50f, Colour (0x30000000));
     cg.addColour (0.75f, Colour (0x70000000));


### PR DESCRIPTION
### Added a conical gradient pattern to the `ColourGradient` class.

The conical gradient can be used by setting the `isConical` flag to true. The gradient will then be calculated using the angle clockwise from the start/end position (provided by `point2`) around a full 360 degrees back to the start/end position. `point1` is used as the centre of the cone.

### Example usage:
```
void MainComponent::paint (juce::Graphics& g)
{
    const auto centre = getLocalBounds().toFloat().getCentre();
    const auto pi = juce::MathConstants<float>::pi;

    juce::ColourGradient gradient (juce::Colours::purple, centre,
                                   juce::Colours::yellow, centre.withY (centre.y + 100.f),
                                   false, // We don't want a radial pattern
                                   true); // We DO want a conical pattern
    gradient.addColour (0.125, juce::Colours::purple);
    gradient.addColour (0.875, juce::Colours::yellow);
    g.setGradientFill (gradient);

    juce::Path p;
    p.addCentredArc (centre.x, centre.y, 100.f, 100.f, 0.f, -pi * 0.75f, pi * 0.75f, true);
    g.strokePath (p, juce::PathStrokeType (50.f));
}
```

> [Result of the above example.](https://i.imgur.com/jGFZyMa.png)

Setting both `isRadial` and `isConical` to true in the constructor will trigger an assertion warning that only one of the flags can be set to true at a time. If both flags are set to two after the object is constructed, the radial pattern takes presidence and the conical pattern will not be used.

The `isConical` argument added to the `ColourGradient` constructor is set to false by default so as to ensure backwards compatibility with existing code.

### Known issues:
- The closer `point2` is to `point1`, the less precise the gradient is which results in aliasing of the colours where distinct bands of colours can be seen. This can be avoided by ensuring the points are far enough apart (at least 50px seems to work well), however that may not be an obvious solution for some.
[Example where `point2` is just 3px below `point1`](https://i.imgur.com/PTcaUAS.png).

- The start/end boundary where the first and last colours meet is aliased which may be undesirable for many applications.
[Example showing aliasing where the colour wraps back around to the start colour](https://i.imgur.com/H5qEpOF.png).