### PR TITLE
Update juce_Array.h

### DIFF
--- a/modules/juce_core/containers/juce_Array.h
+++ b/modules/juce_core/containers/juce_Array.h
@@ -31,7 +31,7 @@ namespace juce
 
     The Array class can be used to hold simple, non-polymorphic objects as well as primitive types - to
     do so, the class must fulfill these requirements:
-    - it must have a copy constructor and assignment operator
+    - it must have a default constructor, a copy constructor, and an assignment operator
     - it must be able to be relocated in memory by a memcpy without this causing any problems - so
       objects whose functionality relies on external pointers or references to themselves can not be used.
 


### PR DESCRIPTION
Several methods of Array call ElementType(), or call methods in ArrayBase that in turn call ElementType(). So a default constructor is a requirement. Among other effects, this prevents the ElementType object from having a reference as one of its members.