### PR TITLE
ComponentAnimator: Fix component incorrectly changing alpha or bounds.

### DIFF
--- a/modules/juce_gui_basics/layout/juce_ComponentAnimator.cpp
+++ b/modules/juce_gui_basics/layout/juce_ComponentAnimator.cpp
@@ -136,8 +136,10 @@ public:
         if (component != nullptr)
         {
             const WeakReference<AnimationTask> weakRef (this);
-            component->setAlpha ((float) destAlpha);
-            component->setBounds (destination);
+            if (isChangingAlpha)
+                component->setAlpha ((float) destAlpha);
+            if (isMoving)
+                component->setBounds (destination);
 
             if (! weakRef.wasObjectDeleted())
                 if (proxy != nullptr)


### PR DESCRIPTION
When animating a component, and passing in component->getBounds() or component->getAlpha() for the final destination and alpha respectively, the animator correctly sets isMoving and isChangingAlpha to the correct value. 

However at the completion of the animation, in the call to moveToFinalDestination(), the bounds and alpha were set regardless of isMoving and isChangingAlpha. This would generally be fine unless of course the parent component's bounds are also being animated!