### PR TITLE
ValueTree::SetPropertyAction is inconsistent between perform and undo

### DIFF
--- a/modules/juce_data_structures/values/juce_ValueTree.cpp
+++ b/modules/juce_data_structures/values/juce_ValueTree.cpp
@@ -428,7 +428,8 @@ public:
                 target->removeProperty (name, nullptr);
             else
                 target->setProperty (name, newValue, nullptr, excludeListener);
-
+            // only exclude on first invocation
+            excludeListener = nullptr;
             return true;
         }
 


### PR DESCRIPTION
Hi,

when SetPropertyActions are created with a non null excludeListener :
SetPropertyAction::undo will call setProperty with a null excludeListener
SetPropertyAction::perform will call setProperty with the actual excludeListener

not sure to understand why operation should different,
but, one can assume that after the first perform (usually triggered by setPropertyExcludingListener from user code, the undo manager will be responsible for subsequent calls, this PR assume that once the undoManager is in charge, the excludedListener can be set to null because action is triggered from outside (UndoManager)

Obviously, I may have missed a specific goal of the original design, let me know

