### PR TITLE
Change JUCEUtils.cmake to support clang on Windows

### DIFF
--- a/extras/Build/CMake/JUCEUtils.cmake
+++ b/extras/Build/CMake/JUCEUtils.cmake
@@ -571,7 +571,7 @@ function(juce_add_module module_path)
 
         _juce_link_libs_from_metadata("${module_name}" "${metadata_dict}" linuxLibs)
     elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-        if((CMAKE_CXX_COMPILER_ID STREQUAL "MSVC") OR (CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC"))
+        if((CMAKE_CXX_COMPILER_ID STREQUAL "MSVC") OR (CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC") AND NOT (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "clang"))
             if(module_name STREQUAL "juce_gui_basics")
                 target_compile_options(${module_name} INTERFACE /bigobj)
             endif()
@@ -583,6 +583,8 @@ function(juce_add_module module_path)
             endif()
 
             _juce_link_libs_from_metadata("${module_name}" "${metadata_dict}" mingwLibs)
+        elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "clang")
+             _juce_link_libs_from_metadata("${module_name}" "${metadata_dict}" windowsLibs)
         endif()
     endif()
 


### PR DESCRIPTION
This updates JUCEUtils.cmake to support using the GNU-style clang frontend on Windows.
This allows for the option to use either clang frontend as well as the already supported options of GCC and MSVC.

The reason this is needed is GNU-style clang can't accept MSVC-style "/XYZTHING" options, and the MSVC-style clang ignores the /bigobj flag anyway, as clang automatically implicitly does bigobj whenever necessary.

This might not be the best way to implement this change (I'm far from a cmake expert), but hopefully this gets the idea across!