### PR TITLE
Write correct format of icon

### DIFF
--- a/extras/Projucer/Source/ProjectSaving/jucer_ProjectExport_CodeBlocks.h
+++ b/extras/Projucer/Source/ProjectSaving/jucer_ProjectExport_CodeBlocks.h
@@ -783,7 +783,7 @@ private:
             const auto iconFile = getTargetFolder().getChildFile ("icon.ico");
 
             if (! build_tools::asArray (getIcons()).isEmpty())
-                build_tools::writeMacIcon (getIcons(), iconFile);
+                build_tools::writeWinIcon (getIcons(), iconFile);
 
             auto rcFile = getTargetFolder().getChildFile ("resources.rc");
             MSVCProjectExporterBase::createRCFile (project, iconFile, rcFile);


### PR DESCRIPTION
@ed95 @reuk when looking at 450ac8ade557c60fe2f47ea862018118fc6d6c2f (_Projucer:  Don't assert when no icons are specified in Code::Blocks exporter_), I saw "icon.ico" next to "Mac", which didn't make sense. I found out that this was wrong since the beginning of the `juce6` branch.