### PR TITLE
Set truncated thread name if name to long

### DIFF
--- a/modules/juce_core/native/juce_posix_SharedCode.h
+++ b/modules/juce_core/native/juce_posix_SharedCode.h
@@ -931,7 +931,8 @@ void JUCE_CALLTYPE Thread::setCurrentThreadName (const String& name)
    #elif JUCE_LINUX || JUCE_ANDROID
     #if ((JUCE_LINUX && (__GLIBC__ * 1000 + __GLIBC_MINOR__) >= 2012) \
           || JUCE_ANDROID && __ANDROID_API__ >= 9)
-     pthread_setname_np (pthread_self(), name.toRawUTF8());
+     if (ERANGE == pthread_setname_np (pthread_self(), name.toRawUTF8()))
+         pthread_setname_np (pthread_self(), name.substring(0, 15).toRawUTF8());
     #else
      prctl (PR_SET_NAME, name.toRawUTF8(), 0, 0, 0);
     #endif


### PR DESCRIPTION
Problem: When debugging my application on Linux, there were often many unnamed threads.

Sollution:

In file `modules/juce_core/native/juce_posix_SharedCode.h`:
`pthread_setname_np` can return `ERANGE` if the thread name is to long,
so retry with name truncated to 15 characters.