### PR TITLE
Fixing bug; setChannelLayoutOfBus always returns false when disabling.

### DIFF
--- a/modules/juce_audio_processors/processors/juce_AudioProcessor.cpp
+++ b/modules/juce_audio_processors/processors/juce_AudioProcessor.cpp
@@ -191,7 +191,7 @@ bool AudioProcessor::setChannelLayoutOfBus (bool isInputBus, int busIndex, const
     {
         auto layouts = bus->getBusesLayoutForLayoutChangeOfBus (layout);
 
-        if (layouts.getChannelSet (isInputBus, busIndex) == layout)
+        if (layouts.getChannelSet (isInputBus, busIndex) == layout || layout.isDisabled())
             return applyBusLayouts (layouts);
 
         return false;


### PR DESCRIPTION
What's odd is that applyBusLayouts always returns true when disabling. This seems inconsistent; maybe the fix is instead to return true on line 197?

I noticed this when shutting down a JUCE VST3 plug-in; my call stack was:

    0. AudioProcessor::setChannelLayoutOfBus (true, 0, AudioChannelSet::disabled());
    1. AudioProcessor::Bus::setCurrentLayout (AudioChannelSet::disabled());
    2. AudioProcessor::Bus::enable (false);
    3. JuceVST3Component::activateBus (kAudio, kInput, 0, false);

At which point I return false (implying disabling is not supported, as per the setChannelLayoutOfBus docs.) 

Again, the easier fix might be to just return true if we end up in this block. I'm not 100% sure - either way applyBusLayouts() doesn't seem to be doing anything when disabling, though maybe I'm missing something. 