### PR TITLE
Correctly forward MIDI channel pressure (0xd) as Steinberg::Vst::kAfterTouch event

### DIFF
--- a/modules/juce_audio_processors/format_types/juce_VST3Common.h
+++ b/modules/juce_audio_processors/format_types/juce_VST3Common.h
@@ -742,7 +742,7 @@ private:
 
         if      (msg.isController())        result = { (Steinberg::Vst::CtrlNumber) msg.getControllerNumber(), msg.getControllerValue() / 127.0};
         else if (msg.isPitchWheel())        result = { Steinberg::Vst::kPitchBend, msg.getPitchWheelValue() / 16383.0};
-        else if (msg.isAftertouch())        result = { Steinberg::Vst::kAfterTouch, msg.getAfterTouchValue() / 127.0};
+        else if (msg.isChannelPressure())   result = { Steinberg::Vst::kAfterTouch, msg.getChannelPressureValue() / 127.0};
 
         return (result.controllerNumber != -1);
     }


### PR DESCRIPTION
Channel pressure MIDI CC messages (0xd) should be mapped as VST3 events of type `Steinberg::Vst::kAfterTouch`. 