### PR TITLE
Correct compatibility of the preprocessor value named JucePlugin_CFBundleIdentifier during Projucer and CMake.

### DIFF
--- a/extras/Build/CMake/JUCEUtils.cmake
+++ b/extras/Build/CMake/JUCEUtils.cmake
@@ -1560,7 +1560,7 @@ function(_juce_configure_plugin_targets target)
         JucePlugin_AUExportPrefix=$<TARGET_PROPERTY:${target},JUCE_AU_EXPORT_PREFIX>
         JucePlugin_AUExportPrefixQuoted="$<TARGET_PROPERTY:${target},JUCE_AU_EXPORT_PREFIX>"
         JucePlugin_AUManufacturerCode=JucePlugin_ManufacturerCode
-        JucePlugin_CFBundleIdentifier="$<TARGET_PROPERTY:${target},JUCE_BUNDLE_ID>"
+        JucePlugin_CFBundleIdentifier=$<TARGET_PROPERTY:${target},JUCE_BUNDLE_ID>
         JucePlugin_AAXIdentifier=$<TARGET_PROPERTY:${target},JUCE_AAX_IDENTIFIER>
         JucePlugin_AAXManufacturerCode=JucePlugin_ManufacturerCode
         JucePlugin_AAXProductId=JucePlugin_PluginCode


### PR DESCRIPTION
As shown below, there is a difference in the definition of JucePlugin_CFBundleIdentifier between using Projucer and using CMake.

With the current CMake value setting, the JucePlugin_CFBundleIdentifier preprocessed as JucePlugin_CFBundleIdentifier="com.yourcompany.MyPlugin".
In the above case, the following idioms traditionally implemented in JUCE applications will cause problems.
```
String bundleId = JUCE_STRINGIFY (JucePlugin_CFBundleIdentifier);
DBG(bundleId) >> \"com.yourcompany.MyPlugin\"
```
Because of the inclusion of double quotations, it observed that an attempt to Stringify the string resulted in the `"`(double quotation) being converted to a `\"`(double quotation with escape sequence).


In addition, in AppConfig.h(on JUCE 5) or JucePluginDefines.h(on JUCE 6) generated by Projucer, the JucePlugin_CFBundleIdentifier is defined as follows by the Projucer.
```
(in AppConfig.h(on JUCE 5) or JucePluginDefines.h(on JUCE 6) )
...
#define JucePlugin_CFBundleIdentifier     com.yourcompany.MyPlugin
```
It is not enclosed in double quotations.
It preprocessed as JucePlugin_CFBundleIdentifier=com.yourcompany.MyPlugin.
