### PR TITLE
Reference to repository containing compiled apps with log for legacy users (not merge)

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,0 +1,2 @@
+https://github.com/AnonA2/Juce3LegacyPullRequestCompiled/tree/master
+This contains compiled legacy apps for OS X 10.7.


### PR DESCRIPTION
https://github.com/AnonA2/Juce3LegacyPullRequestCompiled/tree/master
OS X 10.7.5
See also log, there are some errors. IMO it always advised to provide at least basic support for OS X <10.7 and 10.8> separately. E.g. like mediahuman or other affiliates. 