### PR TITLE
Fix AUv3 indexed parameter automation issues

### DIFF
--- a/modules/juce_audio_plugin_client/AU/juce_AUv3_Wrapper.mm
+++ b/modules/juce_audio_plugin_client/AU/juce_AUv3_Wrapper.mm
@@ -1410,8 +1410,10 @@ private:
                 {
                     const AUParameterEvent& paramEvent = event->parameter;
 
-                    if (auto* p = getJuceParameterForAUAddress (paramEvent.parameterAddress))
-                        setAudioProcessorParameter (p, paramEvent.value);
+                    if (auto* p = getJuceParameterForAUAddress (paramEvent.parameterAddress)) {
+                        auto normalisedValue = paramEvent.value / getMaximumParameterValue (p);
+                        setAudioProcessorParameter (p, normalisedValue);
+                    }
                 }
                 break;
 


### PR DESCRIPTION
Parameter automation in AUv3 wrapper is missing a normalisation step, leading to a choice parameter reaching its maximum value at 1 instead of getMaximumParameterValue().