### PR TITLE
Access to the last Core Audio callback timestamp (iOS)

### DIFF
--- a/extras/Projucer/Source/Project/UI/jucer_ProjectMessagesComponent.h
+++ b/extras/Projucer/Source/Project/UI/jucer_ProjectMessagesComponent.h
@@ -45,6 +45,7 @@ public:
         addAndMakeVisible (viewport);
         viewport.setScrollBarsShown (true, false);
         viewport.setViewedComponent (&messagesListComponent, false);
+        viewport.setWantsKeyboardFocus (false);
 
         setOpaque (true);
     }

--- a/extras/Projucer/Source/Project/jucer_Project.cpp
+++ b/extras/Projucer/Source/Project/jucer_Project.cpp
@@ -112,7 +112,7 @@ Project::Project (const File& f)
     updateJUCEPathWarning();
     getGlobalProperties().addChangeListener (this);
 
-    if (! app.isRunningCommandLine)
+    if (! app.isRunningCommandLine && app.isAutomaticVersionCheckingEnabled())
         LatestVersionCheckerAndUpdater::getInstance()->checkForNewVersion (true);
 }
 

--- a/modules/juce_audio_devices/native/juce_linux_Midi.cpp
+++ b/modules/juce_audio_devices/native/juce_linux_Midi.cpp
@@ -648,6 +648,8 @@ void MidiOutput::sendMessageNow (const MidiMessage& message)
 //==============================================================================
 #else
 
+class MidiInput::Pimpl {};
+
 // (These are just stub functions if ALSA is unavailable...)
 MidiInput::MidiInput (const String& deviceName, const String& deviceID)
     : deviceInfo (deviceName, deviceID)
@@ -664,6 +666,8 @@ std::unique_ptr<MidiInput> MidiInput::createNewDevice (const String&, MidiInputC
 StringArray MidiInput::getDevices()                                                       { return {}; }
 int MidiInput::getDefaultDeviceIndex()                                                    { return 0;}
 std::unique_ptr<MidiInput> MidiInput::openDevice (int, MidiInputCallback*)                { return {}; }
+
+class MidiOutput::Pimpl {};
 
 MidiOutput::~MidiOutput()                                                                 {}
 void MidiOutput::sendMessageNow (const MidiMessage&)                                      {}

--- a/modules/juce_audio_devices/native/juce_win32_WASAPI.cpp
+++ b/modules/juce_audio_devices/native/juce_win32_WASAPI.cpp
@@ -424,6 +424,9 @@ public:
         rates.addUsingDefaultSort (defaultSampleRate);
         mixFormatChannelMask = format.dwChannelMask;
 
+        if (isExclusiveMode (deviceMode))
+            findSupportedFormat (tempClient, defaultSampleRate, mixFormatChannelMask, format);
+
         querySupportedBufferSizes (format, tempClient);
         querySupportedSampleRates (format, tempClient);
     }


### PR DESCRIPTION
This is very useful while working with Ableton Link and external MIDI sync on iOS