### PR TITLE
Allowing single-click defaulting of Sliders without having to have double-click defaulting

### DIFF
--- a/modules/juce_gui_basics/widgets/juce_Slider.cpp
+++ b/modules/juce_gui_basics/widgets/juce_Slider.cpp
@@ -831,9 +831,9 @@ public:
                 showPopupMenu();
             }
             else if (canDoubleClickToValue()
-                     && (singleClickModifiers != ModifierKeys() && e.mods.withoutMouseButtons() == singleClickModifiers))
+                     || (singleClickModifiers != ModifierKeys() && e.mods.withoutMouseButtons() == singleClickModifiers))
             {
-                mouseDoubleClick();
+                setDoubleClickValue();
             }
             else if (normRange.end > normRange.start)
             {
@@ -1041,10 +1041,13 @@ public:
     void mouseDoubleClick()
     {
         if (canDoubleClickToValue())
-        {
-            DragInProgress drag (*this);
-            setValue (doubleClickReturnValue, sendNotificationSync);
-        }
+            setDoubleClickValue();
+    }
+
+    void setDoubleClickValue()
+    {
+        DragInProgress drag (*this);
+        setValue (doubleClickReturnValue, sendNotificationSync);
     }
 
     double getMouseWheelDelta (double value, double wheelAmount)


### PR DESCRIPTION
This allows for single-click-with-mods defaulting (e.g. alt-click) without being forced to also allow double-click defaulting:

`slider.setDoubleClickReturnValue (false, myDefaultValue, juce::ModifierKeys::altModifier);`