### PR TITLE
Fix compiling juce_win32_FileChooser.cpp with MinGW

### DIFF
--- a/modules/juce_core/native/juce_BasicNativeHeaders.h
+++ b/modules/juce_core/native/juce_BasicNativeHeaders.h
@@ -132,7 +132,7 @@
  #define STRICT 1
  #define WIN32_LEAN_AND_MEAN 1
  #if JUCE_MINGW
-  #define _WIN32_WINNT 0x0501
+  #define _WIN32_WINNT 0x0600
  #else
   #define _WIN32_WINNT 0x0602
  #endif


### PR DESCRIPTION
Compiling `juce_gui_basics/native/juce_win32_FileChooser.cpp` stopped working with MinGW in 994ba04 because `IFileDialog` requires Windows Vista (or Windows Server 2008) (see https://docs.microsoft.com/en-us/windows/win32/api/shobjidl_core/nn-shobjidl_core-ifiledialog#requirements).

Setting `_WIN32_WINNT` to `0x501` means targeting Windows XP (and Windows Server 2003), while setting it to `0x600` means targeting Windows Vista (and Windows Server 2008) (see https://docs.microsoft.com/en-us/windows/win32/winprog/using-the-windows-headers).

I encountered that issue in https://github.com/McMartin/FRUT/pull/654 (see https://ci.appveyor.com/project/McMartin/frut/builds/35943608/job/2pladryb7syqt0uf#L605 for the compiler errors).

@reuk: please have a look, thanks!