### PR TITLE
Update juce_MemoryAudioSource.cpp

### DIFF
--- a/modules/juce_audio_basics/sources/juce_MemoryAudioSource.cpp
+++ b/modules/juce_audio_basics/sources/juce_MemoryAudioSource.cpp
@@ -67,7 +67,7 @@ void MemoryAudioSource::getNextAudioBlock (const AudioSourceChannelInfo& bufferT
     if (pos < m)
         dst.clear (bufferToFill.startSample + pos, m - pos);
 
-    position = (i % n);
+    position = i);
 }
 
 //==============================================================================


### PR DESCRIPTION
The clamping forces the sample to loop indefinitely, because the above condition (i < n || isCurrentlyLooping) is always satisfied.