### PR TITLE
Fixed crash due to null render target in juce::TextLayout::createNativeLayout() on Windows

### DIFF
--- a/modules/juce_graphics/native/juce_win32_DirectWriteTypeLayout.cpp
+++ b/modules/juce_graphics/native/juce_win32_DirectWriteTypeLayout.cpp
@@ -440,7 +440,7 @@ bool TextLayout::createNativeLayout (const AttributedString& text)
 
     SharedResourcePointer<Direct2DFactories> factories;
 
-    if (factories->d2dFactory != nullptr && factories->systemFonts != nullptr)
+    if (factories->d2dFactory != nullptr && factories->systemFonts != nullptr && factories->directWriteRenderTarget != nullptr)
     {
         DirectWriteTypeLayout::createLayout (*this, text,
                                              *factories->directWriteFactory,


### PR DESCRIPTION
One of our users reported a crash when showing a JUCE component on Windows. The crash dump showed that the crash was occurring in juce::DirectWriteTypeLayout::addAttributedRange() due to the renderTarget parameter being invalid (ID2D1RenderTarget& renderTarget).

The DirectWrite render target is created in juce::Direct2DFactories::Direct2DFactories(). For reasons that are still unclear, the call to CreateDCRenderTarget() was failing for this particular user. All other Direct2D/DirectWrite objects appeared to be created successfully.

The crash happened on a recent build of Windows 10. We asked the user to send us a dxdiag report, but it didn't highlight any issues. Their graphics driver is up to date. The only other clue was that the PC is quite old (2011).

Regardless, the crash can be avoided by checking factories->directWriteRenderTarget in juce::TextLayout::createNativeLayout() and returning false if it's null - in which case juce::TextLayout::createLayout() will fallback to calling createStandardLayout() instead.