### PR TITLE
fix lookAndFeelChanged being not called when adding Components to a parent

### DIFF
--- a/modules/juce_gui_basics/components/juce_Component.cpp
+++ b/modules/juce_gui_basics/components/juce_Component.cpp
@@ -1446,6 +1446,8 @@ void Component::addChildComponent (Component& child, int zOrder)
 
         child.internalHierarchyChanged();
         internalChildrenChanged();
+      
+        child.lookAndFeelChanged();
     }
 }
 


### PR DESCRIPTION
I would expect that "lookAndFeelChanged()" is called whenever the LookAndFeel changes. When adding Components to a parent, lookAndFeelChanged() is currently not called even though the LookAndFeel actually changes.