### PR TITLE
delete components which are marked as autoDelete in ModalComponentMana…

### DIFF
--- a/modules/juce_gui_basics/components/juce_ModalComponentManager.cpp
+++ b/modules/juce_gui_basics/components/juce_ModalComponentManager.cpp
@@ -89,6 +89,14 @@ ModalComponentManager::ModalComponentManager()
 
 ModalComponentManager::~ModalComponentManager()
 {
+    for (int i = stack.size(); --i >= 0;)
+    {
+         auto* item = stack.getUnchecked(i);
+         std::unique_ptr<ModalItem> deleter(stack.removeAndReturn(i));
+         Component::SafePointer<Component> compToDelete(item->autoDelete ? item->component : nullptr);
+         compToDelete.deleteAndZero();
+    }
+    
     stack.clear();
     clearSingletonInstance();
 }


### PR DESCRIPTION
…ger at shutdown. Fix possible crash on windows when plugin has a modal window (like AlertWindow/PopupMenu/CallOut Box) open while host shutdown the plugin