### PR TITLE
Reset MPEInstrument dimension values when setting zone layout

### DIFF
--- a/modules/juce_audio_basics/mpe/juce_MPEInstrument.cpp
+++ b/modules/juce_audio_basics/mpe/juce_MPEInstrument.cpp
@@ -65,6 +65,10 @@ void MPEInstrument::setZoneLayout (MPEZoneLayout newLayout)
     const ScopedLock sl (lock);
     legacyMode.isEnabled = false;
     zoneLayout = newLayout;
+
+    std::fill_n (pressureDimension.lastValueReceivedOnChannel, 16, MPEValue::minValue());
+    std::fill_n (pitchbendDimension.lastValueReceivedOnChannel, 16, MPEValue::centreValue());
+    std::fill_n (timbreDimension.lastValueReceivedOnChannel, 16, MPEValue::centreValue());
 }
 
 //==============================================================================


### PR DESCRIPTION
When mpe mode is enabled, the values get reset on note offs. That doesn't happen in legacy mode which can result in the dimensions being `stuck` e.g. after pitchbending some notes and changing the mode from legacy to mpe straight after. Resetting these values when setting the zone layout after releasing all active notes prevents that from happening.