### PR TITLE
fix generating API docs for OS without a generic "python" binary

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ offline docs, see below.
 ## Dependencies
 
 - doxygen
-- python
+- python (version 3.x)
 - make
 - graphviz (to generate inheritance diagrams)
 

--- a/docs/doxygen/Makefile
+++ b/docs/doxygen/Makefile
@@ -8,7 +8,7 @@ doc/index.html: build/juce_modules.dox Doxyfile
 	doxygen
 
 build/juce_modules.dox: process_source_files.py $(SOURCE_FILES)
-	python $< ../../modules build
+	python3 $< ../../modules build
 
 clean:
 	rm -rf build doc

--- a/docs/doxygen/make.bat
+++ b/docs/doxygen/make.bat
@@ -1,2 +1,2 @@
-python process_source_files.py ..\..\modules build
+python3 process_source_files.py ..\..\modules build
 doxygen

--- a/docs/doxygen/process_source_files.py
+++ b/docs/doxygen/process_source_files.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import shutil


### PR DESCRIPTION
Some Debian-based Linux OS do not provide generic "python" binaries anymore. This breaks generation of JUCE's documentation files and is fixed by this simple PR.

Note: I haven't used Python on Windows for a while, but I think you could always call `python3` in order to specifically execute Python 3. Please verify this before accepting my PR.