### PR TITLE
 VST3 Program parameter is not updated when the loaded program changed and updateHostDisplay() is called

### DIFF
--- a/modules/juce_audio_plugin_client/VST3/juce_VST3_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/VST3/juce_VST3_Wrapper.cpp
@@ -918,20 +918,18 @@ public:
 
         if (auto* pluginInstance = getPluginInstance())
         {
-            auto newNumPrograms = pluginInstance->getNumPrograms();
+            auto numPrograms = pluginInstance->getNumPrograms();
 
-            if (newNumPrograms != lastNumPrograms)
+            if (numPrograms > 1)
             {
-                if (newNumPrograms > 1)
-                {
-                    auto paramValue = static_cast<Vst::ParamValue> (pluginInstance->getCurrentProgram())
-                                      / static_cast<Vst::ParamValue> (pluginInstance->getNumPrograms() - 1);
+                auto paramValue = static_cast<Vst::ParamValue> (pluginInstance->getCurrentProgram())
+                                    / static_cast<Vst::ParamValue> (pluginInstance->getNumPrograms() - 1);
 
-                    EditController::setParamNormalized (JuceAudioProcessor::paramPreset, paramValue);
+                if (paramValue != EditController::getParamNormalized(JuceAudioProcessor::paramPreset))
+                {
+                    EditController::setParamNormalized(JuceAudioProcessor::paramPreset, paramValue);
                     flags |= Vst::kParamValuesChanged;
                 }
-
-                lastNumPrograms = newNumPrograms;
             }
 
             auto newLatencySamples = pluginInstance->getLatencySamples();
@@ -990,7 +988,7 @@ private:
     std::atomic<bool> vst3IsPlaying     { false },
                       inSetupProcessing { false };
 
-    int lastNumPrograms = 0, lastLatencySamples = 0;
+    int lastLatencySamples = 0;
 
    #if ! JUCE_MAC
     float lastScaleFactorReceived = 1.0f;


### PR DESCRIPTION
Since commit #51fe471461f75fcfd72f7d0749382cbc149eef37 the VST3 Program parameter is not updated when the loaded program changed and updateHostDisplay() is called.