### PR TITLE
Adding MouseInterceptor class for better AAX/VST3 menu handling

### DIFF
--- a/modules/juce_audio_plugin_client/AAX/juce_AAX_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/AAX/juce_AAX_Wrapper.cpp
@@ -568,6 +568,7 @@ namespace AAXClasses
 
         //==============================================================================
         struct ContentWrapperComponent  : public Component
+                                        , public MouseInterceptor
         {
             ContentWrapperComponent (JuceAAX_GUI& gui, AudioProcessor& plugin)
                 : owner (gui)
@@ -582,7 +583,7 @@ namespace AAXClasses
                 {
                     lastValidSize = pluginEditor->getLocalBounds();
                     setBounds (lastValidSize);
-                    pluginEditor->addMouseListener (this, true);
+                    pluginEditor->addMouseInterceptor (this, true);
                 }
 
                 ignoreUnused (fakeMouseGenerator);
@@ -604,7 +605,7 @@ namespace AAXClasses
             }
 
             template <typename MethodType>
-            void callMouseMethod (const MouseEvent& e, MethodType method)
+            bool callMouseMethod (const MouseEvent& e, MethodType method)
             {
                 if (auto* vc = owner.GetViewContainer())
                 {
@@ -615,14 +616,21 @@ namespace AAXClasses
                         uint32_t mods = 0;
                         vc->GetModifiers (&mods);
 
-                        (vc->*method) (aaxParamID, mods);
+                        // This fixes an issue with GetModifiers() which doesn't
+                        // handle the right mouse button for some reason.
+                        if (e.mods.isRightButtonDown())
+                            mods |= AAX_eModifiers_SecondaryButton;
+
+                        return (vc->*method) (aaxParamID, mods) == AAX_SUCCESS;
                     }
                 }
+
+                return false;
             }
 
-            void mouseDown (const MouseEvent& e) override  { callMouseMethod (e, &AAX_IViewContainer::HandleParameterMouseDown); }
-            void mouseUp   (const MouseEvent& e) override  { callMouseMethod (e, &AAX_IViewContainer::HandleParameterMouseUp); }
-            void mouseDrag (const MouseEvent& e) override  { callMouseMethod (e, &AAX_IViewContainer::HandleParameterMouseDrag); }
+            bool interceptMouseDown (const MouseEvent& e) override  { return interceptedMouseDown = callMouseMethod (e, &AAX_IViewContainer::HandleParameterMouseDown); }
+            bool interceptMouseUp   (const MouseEvent& e) override  { return interceptedMouseDown || callMouseMethod (e, &AAX_IViewContainer::HandleParameterMouseUp); }
+            bool interceptMouseDrag (const MouseEvent& e) override  { return interceptedMouseDown || callMouseMethod (e, &AAX_IViewContainer::HandleParameterMouseDrag); }
 
             void parentSizeChanged() override
             {
@@ -667,6 +675,8 @@ namespace AAXClasses
            #endif
             FakeMouseMoveGenerator fakeMouseGenerator;
             juce::Rectangle<int> lastValidSize;
+
+            bool interceptedMouseDown = false;
 
             JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (ContentWrapperComponent)
         };

--- a/modules/juce_audio_plugin_client/VST3/juce_VST3_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/VST3/juce_VST3_Wrapper.cpp
@@ -1361,6 +1361,7 @@ private:
 
         //==============================================================================
         struct ContentWrapperComponent  : public Component
+                                        , public MouseInterceptor
                                        #if JUCE_WINDOWS && JUCE_WIN_PER_MONITOR_DPI_AWARE
                                         , public Timer
                                        #endif
@@ -1390,6 +1391,7 @@ private:
                 {
                     addAndMakeVisible (pluginEditor.get());
                     pluginEditor->setTopLeftPosition (0, 0);
+                    pluginEditor->addMouseInterceptor (this, true);
 
                     lastBounds = getSizeToContainChild();
 
@@ -1531,13 +1533,68 @@ private:
             }
            #endif
 
+            void showContextMenu (Vst::IComponentHandler* handler, IPlugView* view, const Vst::ParamID* id, UCoord x, UCoord y)
+            {
+                if (handler == nullptr || view == nullptr)
+                    return;
+
+                FUnknownPtr<Vst::IComponentHandler3> h (handler);
+                if (h == nullptr)
+                    return;
+
+                auto* menu = h->createContextMenu (view, id);
+                if (menu != nullptr)
+                {
+                    menu->popup (x, y);
+                    menu->release();
+                }
+            }
+
+            bool interceptMouseDown (const MouseEvent& e) override
+            {
+                interceptedMouseDown = false;
+
+                if (pluginEditor != nullptr && (e.mods.isRightButtonDown() || (e.mods.isLeftButtonDown() && e.mods.isCtrlDown())))
+                {
+                    const auto parameterIndex = pluginEditor->getControlParameterIndex (*e.eventComponent);
+
+                    if (parameterIndex != -1)
+                    {
+                        if (auto* peer = ComponentPeer::getPeerFor (this))
+                        {
+                            interceptedMouseDown = true;
+                            auto position = e.getScreenPosition() - peer->localToGlobal (Point<int> (0, 0));
+
+                            auto vstParamID = static_cast<Vst::ParamID> (parameterIndex);
+
+                            if (owner.owner != nullptr)
+                                vstParamID = owner.owner->audioProcessor->getVSTParamIDForIndex (parameterIndex);
+
+                            showContextMenu (owner.getController()->getComponentHandler(), &owner, &vstParamID, position.getX(), position.getY());
+                        }
+                    }
+                }
+
+                return interceptedMouseDown;
+            }
+
+            bool interceptMouseDrag (const MouseEvent& e) override
+            {
+                return interceptedMouseDown;
+            }
+
+            bool interceptMouseUp (const MouseEvent& e) override
+            {
+                return interceptedMouseDown;
+            }
+
             std::unique_ptr<AudioProcessorEditor> pluginEditor;
 
         private:
             JuceVST3Editor& owner;
             FakeMouseMoveGenerator fakeMouseGenerator;
             Rectangle<int> lastBounds;
-            bool resizingChild = false, resizingParent = false;
+            bool resizingChild = false, resizingParent = false, interceptedMouseDown = false;
 
             JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (ContentWrapperComponent)
         };

--- a/modules/juce_gui_basics/components/juce_Component.cpp
+++ b/modules/juce_gui_basics/components/juce_Component.cpp
@@ -158,6 +158,145 @@ private:
     JUCE_DECLARE_NON_COPYABLE (MouseListenerList)
 };
 
+class Component::MouseInterceptorList
+{
+public:
+    MouseInterceptorList() noexcept {}
+
+    void addListener (MouseInterceptor* newListener, bool wantsEventsForAllNestedChildComponents)
+    {
+        if (! listeners.contains (newListener))
+        {
+            if (wantsEventsForAllNestedChildComponents)
+            {
+                listeners.insert (0, newListener);
+                ++numDeepMouseInterceptors;
+            }
+            else
+            {
+                listeners.add (newListener);
+            }
+        }
+    }
+
+    void removeListener (MouseInterceptor* listenerToRemove)
+    {
+        auto index = listeners.indexOf (listenerToRemove);
+
+        if (index >= 0)
+        {
+            if (index < numDeepMouseInterceptors)
+                --numDeepMouseInterceptors;
+
+            listeners.remove (index);
+        }
+    }
+
+    // g++ 4.8 cannot deduce the parameter pack inside the function pointer when it has more than one element
+   #if defined(__GNUC__) && __GNUC__ < 5 && ! defined(__clang__)
+    template <typename... Params>
+    static bool sendMouseEvent (Component& comp, Component::BailOutChecker& checker,
+                                bool (MouseInterceptor::*eventMethod) (const MouseEvent&),
+                                Params... params)
+    {
+        return sendMouseEvent <decltype (eventMethod), Params...> (comp, checker, eventMethod, params...);
+    }
+
+    template <typename... Params>
+    static bool sendMouseEvent (Component& comp, Component::BailOutChecker& checker,
+                                bool (MouseInterceptor::*eventMethod) (const MouseEvent&, const MouseWheelDetails&),
+                                Params... params)
+    {
+        return sendMouseEvent <decltype (eventMethod), Params...> (comp, checker, eventMethod, params...);
+    }
+
+    template <typename... Params>
+    static bool sendMouseEvent (Component& comp, Component::BailOutChecker& checker,
+                                bool (MouseInterceptor::*eventMethod) (const MouseEvent&, float),
+                                Params... params)
+    {
+        return sendMouseEvent <decltype (eventMethod), Params...> (comp, checker, eventMethod, params...);
+    }
+
+    template <typename EventMethod, typename... Params>
+    static bool sendMouseEvent (Component& comp, Component::BailOutChecker& checker,
+                                EventMethod eventMethod,
+                                Params... params)
+   #else
+    template <typename... Params>
+    static bool sendMouseEvent (Component& comp, Component::BailOutChecker& checker,
+                                bool (MouseInterceptor::*eventMethod) (Params...),
+                                Params... params)
+   #endif
+    {
+        if (checker.shouldBailOut())
+            return true;
+
+        if (auto* list = comp.mouseInterceptors.get())
+        {
+            for (int i = list->listeners.size(); --i >= 0;)
+            {
+                if ((list->listeners.getUnchecked (i)->*eventMethod) (params...))
+                    return true;
+
+                if (checker.shouldBailOut())
+                    return true;
+
+                i = jmin (i, list->listeners.size());
+            }
+        }
+
+        for (Component* p = comp.parentComponent; p != nullptr; p = p->parentComponent)
+        {
+            if (auto* list = p->mouseInterceptors.get())
+            {
+                if (list->numDeepMouseInterceptors > 0)
+                {
+                    BailOutChecker2 checker2 (checker, p);
+
+                    for (int i = list->numDeepMouseInterceptors; --i >= 0;)
+                    {
+                        if ((list->listeners.getUnchecked (i)->*eventMethod) (params...))
+                            return true;
+
+                        if (checker2.shouldBailOut())
+                            return true;
+
+                        i = jmin (i, list->numDeepMouseInterceptors);
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+private:
+    Array<MouseInterceptor*> listeners;
+    int numDeepMouseInterceptors = 0;
+
+    struct BailOutChecker2
+    {
+        BailOutChecker2 (Component::BailOutChecker& boc, Component* comp)
+            : checker (boc), safePointer (comp)
+        {
+        }
+
+        bool shouldBailOut() const noexcept
+        {
+            return checker.shouldBailOut() || safePointer == nullptr;
+        }
+
+    private:
+        Component::BailOutChecker& checker;
+        const WeakReference<Component> safePointer;
+
+        JUCE_DECLARE_NON_COPYABLE (BailOutChecker2)
+    };
+
+    JUCE_DECLARE_NON_COPYABLE (MouseInterceptorList)
+};
+
 //==============================================================================
 struct FocusRestorer
 {
@@ -2284,6 +2423,29 @@ void Component::removeMouseListener (MouseListener* listenerToRemove)
         mouseListeners->removeListener (listenerToRemove);
 }
 
+void Component::addMouseInterceptor (MouseInterceptor* newInterceptor,
+                                     bool wantsEventsForAllNestedChildComponents)
+{
+    // if component methods are being called from threads other than the message
+    // thread, you'll need to use a MessageManagerLock object to make sure it's thread-safe.
+    JUCE_ASSERT_MESSAGE_MANAGER_IS_LOCKED
+
+    if (mouseInterceptors == nullptr)
+        mouseInterceptors.reset (new MouseInterceptorList());
+
+    mouseInterceptors->addListener (newInterceptor, wantsEventsForAllNestedChildComponents);
+}
+
+void Component::removeMouseInterceptor (MouseInterceptor* interceptorToRemove)
+{
+    // if component methods are being called from threads other than the message
+    // thread, you'll need to use a MessageManagerLock object to make sure it's thread-safe.
+    JUCE_ASSERT_MESSAGE_MANAGER_IS_LOCKED
+
+    if (mouseInterceptors != nullptr)
+        mouseInterceptors->removeListener (interceptorToRemove);
+}
+
 //==============================================================================
 void Component::internalMouseEnter (MouseInputSource source, Point<float> relativePos, Time time)
 {
@@ -2397,6 +2559,10 @@ void Component::internalMouseDown (MouseInputSource source, Point<float> relativ
     const MouseEvent me (source, relativePos, source.getCurrentModifiers(), pressure,
                          orientation, rotation, tiltX, tiltY, this, this, time, relativePos,
                          time, source.getNumberOfMultipleClicks(), false);
+
+    if (MouseInterceptorList::template sendMouseEvent<const MouseEvent&> (*this, checker, &MouseInterceptor::interceptMouseDown, me))
+        return;
+
     mouseDown (me);
 
     if (checker.shouldBailOut())
@@ -2424,6 +2590,10 @@ void Component::internalMouseUp (MouseInputSource source, Point<float> relativeP
                          source.getLastMouseDownTime(),
                          source.getNumberOfMultipleClicks(),
                          source.isLongPressOrDrag());
+
+    if (MouseInterceptorList::template sendMouseEvent<const MouseEvent&> (*this, checker, &MouseInterceptor::interceptMouseUp, me))
+        return;
+
     mouseUp (me);
 
     if (checker.shouldBailOut())
@@ -2463,6 +2633,10 @@ void Component::internalMouseDrag (MouseInputSource source, Point<float> relativ
                              source.getLastMouseDownTime(),
                              source.getNumberOfMultipleClicks(),
                              source.isLongPressOrDrag());
+
+        if (MouseInterceptorList::template sendMouseEvent<const MouseEvent&> (*this, checker, &MouseInterceptor::interceptMouseDrag, me))
+            return;
+
         mouseDrag (me);
 
         if (checker.shouldBailOut())

--- a/modules/juce_gui_basics/components/juce_Component.h
+++ b/modules/juce_gui_basics/components/juce_Component.h
@@ -1651,6 +1651,19 @@ public:
     */
     void removeMouseListener (MouseListener* listenerToRemove);
 
+    /** Registers a listener to be told when mouse events occur in this component,
+        before that component gets them so that they can be blocked from entering
+        the target component.
+        @see removeMouseInterceptor, MouseInterceptor
+     */
+    void addMouseInterceptor (MouseInterceptor* newInterceptor,
+                              bool wantsEventsForAllNestedChildComponents);
+
+    /** Deregisters a mouse listener.
+        @see removeMouseInterceptor, MouseInterceptor
+    */
+    void removeMouseInterceptor (MouseInterceptor* interceptorToRemove);
+
     //==============================================================================
     /** Adds a listener that wants to hear about keypresses that this component receives.
 
@@ -2278,6 +2291,8 @@ private:
 
     class MouseListenerList;
     std::unique_ptr<MouseListenerList> mouseListeners;
+    class MouseInterceptorList;
+    std::unique_ptr<MouseInterceptorList> mouseInterceptors;
     std::unique_ptr<Array<KeyListener*>> keyListeners;
     ListenerList<ComponentListener> componentListeners;
     NamedValueSet properties;

--- a/modules/juce_gui_basics/juce_gui_basics.cpp
+++ b/modules/juce_gui_basics/juce_gui_basics.cpp
@@ -107,6 +107,7 @@ namespace juce
 #include "mouse/juce_MouseEvent.cpp"
 #include "mouse/juce_MouseInactivityDetector.cpp"
 #include "mouse/juce_MouseListener.cpp"
+#include "mouse/juce_MouseInterceptor.cpp"
 #include "keyboard/juce_CaretComponent.cpp"
 #include "keyboard/juce_KeyboardFocusTraverser.cpp"
 #include "keyboard/juce_KeyListener.cpp"

--- a/modules/juce_gui_basics/juce_gui_basics.h
+++ b/modules/juce_gui_basics/juce_gui_basics.h
@@ -155,6 +155,7 @@ namespace juce
 
 #include "mouse/juce_MouseCursor.h"
 #include "mouse/juce_MouseListener.h"
+#include "mouse/juce_MouseInterceptor.h"
 #include "keyboard/juce_ModifierKeys.h"
 #include "mouse/juce_MouseInputSource.h"
 #include "mouse/juce_MouseEvent.h"

--- a/modules/juce_gui_basics/mouse/juce_MouseInterceptor.cpp
+++ b/modules/juce_gui_basics/mouse/juce_MouseInterceptor.cpp
@@ -1,0 +1,26 @@
+/*
+  ==============================================================================
+
+   This file is part of the JUCE 6 technical preview.
+   Copyright (c) 2020 - Raw Material Software Limited
+
+   You may use this code under the terms of the GPL v3
+   (see www.gnu.org/licenses).
+
+   For this technical preview, this file is not subject to commercial licensing.
+
+   JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+namespace juce
+{
+
+    bool MouseInterceptor::interceptMouseDown (const MouseEvent&) { return false; }
+    bool MouseInterceptor::interceptMouseDrag (const MouseEvent&) { return false; }
+    bool MouseInterceptor::interceptMouseUp (const MouseEvent&) { return false; }
+
+} // namespace juce

--- a/modules/juce_gui_basics/mouse/juce_MouseInterceptor.h
+++ b/modules/juce_gui_basics/mouse/juce_MouseInterceptor.h
@@ -1,0 +1,81 @@
+/*
+  ==============================================================================
+
+   This file is part of the JUCE 6 technical preview.
+   Copyright (c) 2020 - Raw Material Software Limited
+
+   You may use this code under the terms of the GPL v3
+   (see www.gnu.org/licenses).
+
+   For this technical preview, this file is not subject to commercial licensing.
+
+   JUCE IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+namespace juce
+{
+
+//==============================================================================
+/**
+    A MouseInterceptor can be registered with a component to receive callbacks
+    about mouse events that happen to that component, and are able to prevent
+    those callbacks reaching their intended component.
+
+    @see Component::addMouseInterceptor, Component::removeMouseInterceptor
+
+    @tags{GUI}
+*/
+class JUCE_API MouseInterceptor
+{
+public:
+    /** Destructor. */
+    virtual ~MouseInterceptor() = default;
+
+    /** Called when a mouse button is pressed.
+
+        The MouseEvent object passed in contains lots of methods for finding out
+        which button was pressed, as well as which modifier keys (e.g. shift, ctrl)
+        were held down at the time.
+
+        Once a button is held down, the mouseDrag method will be called when the
+        mouse moves, until the button is released.
+
+        @param event  details about the position and status of the mouse event, including
+                      the source component in which it occurred
+        @see mouseUp, mouseDrag, mouseDoubleClick, contains
+    */
+    virtual bool interceptMouseDown (const MouseEvent& event);
+
+    /** Called when the mouse is moved while a button is held down.
+
+        When a mouse button is pressed inside a component, that component
+        receives mouseDrag callbacks each time the mouse moves, even if the
+        mouse strays outside the component's bounds.
+
+        @param event  details about the position and status of the mouse event, including
+                      the source component in which it occurred
+        @see mouseDown, mouseUp, mouseMove, contains, setDragRepeatInterval
+    */
+    virtual bool interceptMouseDrag (const MouseEvent& event);
+
+    /** Called when a mouse button is released.
+
+        A mouseUp callback is sent to the component in which a button was pressed
+        even if the mouse is actually over a different component when the
+        button is released.
+
+        The MouseEvent object passed in contains lots of methods for finding out
+        which buttons were down just before they were released.
+
+        @param event  details about the position and status of the mouse event, including
+                      the source component in which it occurred
+        @see mouseDown, mouseDrag, mouseDoubleClick, contains
+    */
+    virtual bool interceptMouseUp (const MouseEvent& event);
+};
+
+} // namespace juce


### PR DESCRIPTION
These changes are an example of how to implement a class which allows juce::MouseEvent calls to be intercepted and stolen by an external object.

This allows for the AAX wrapper to implement the expected behaviour when showing the parameter automation menu (i.e. mouseDown and mouseDrag events shouldn't be allowed to the target juce::Component when the keys are pressed);

Added a workaround for the missing AAX_eModifiers_SecondaryButton flag from GetModifiers function;

Added the parameter context menu to the VST3 wrapper using the same mechanism.

A couple of things:

There is a lot of duplication between the MouseListenerList and MouseInterceptorList classes which can probably be reduced;
I haven't compiled and tested the g++ 4.8 checks;
I've only implemented mouseDown, mouseDrag and mouseUp in this example because that's all that's needed for the parameter context menus, but we have examples where it's convienient for other mouse function calls to be intercepted for various reasons.