### PR TITLE
[BUG] URL issue removing get parameters and adding them to post data

### DIFF
--- a/extras/Projucer/Source/Application/UserAccount/jucer_LicenseQueryThread.h
+++ b/extras/Projucer/Source/Application/UserAccount/jucer_LicenseQueryThread.h
@@ -322,7 +322,7 @@ private:
             return cancelledError;
 
         int statusCode = 0;
-        auto urlStream = url.createInputStream (isPOST, nullptr, nullptr,
+        auto urlStream = url.createInputStream (isPOST, nullptr,
                                                 accountEnquiryTask->getExtraHeaders(),
                                                 5000, nullptr, &statusCode);
 

--- a/extras/Projucer/Source/Utility/Helpers/jucer_VersionInfo.cpp
+++ b/extras/Projucer/Source/Utility/Helpers/jucer_VersionInfo.cpp
@@ -48,7 +48,7 @@ std::unique_ptr<InputStream> VersionInfo::createInputStreamForAsset (const Asset
     URL downloadUrl (asset.url);
     StringPairArray responseHeaders;
 
-    return std::unique_ptr<InputStream> (downloadUrl.createInputStream (false, nullptr, nullptr,
+    return std::unique_ptr<InputStream> (downloadUrl.createInputStream (false, nullptr,
                                                                         "Accept: application/octet-stream",
                                                                         5000, &responseHeaders, &statusCode, 1));
 }
@@ -76,7 +76,7 @@ bool VersionInfo::isNewerVersionThanCurrent()
 std::unique_ptr<VersionInfo> VersionInfo::fetch (const String& endpoint)
 {
     URL latestVersionURL ("https://api.github.com/repos/juce-framework/JUCE/releases/" + endpoint);
-    std::unique_ptr<InputStream> inStream (latestVersionURL.createInputStream (false, nullptr, nullptr, {}, 5000));
+    std::unique_ptr<InputStream> inStream (latestVersionURL.createInputStream (false, nullptr, {}, 5000));
 
     if (inStream == nullptr)
         return nullptr;

--- a/modules/juce_core/native/juce_android_Network.cpp
+++ b/modules/juce_core/native/juce_android_Network.cpp
@@ -373,7 +373,7 @@ public:
         }
         else
         {
-            String address = url.toString (! isPost);
+            String address = url.toString (true);
 
             if (! address.contains ("://"))
                 address = "http://" + address;

--- a/modules/juce_core/native/juce_curl_Network.cpp
+++ b/modules/juce_core/native/juce_curl_Network.cpp
@@ -220,7 +220,7 @@ public:
     //==============================================================================
     bool setOptions()
     {
-        auto address = url.toString (! isPost);
+        auto address = url.toString (true);
 
         curl_version_info_data* data = symbols->curl_version_info (CURLVERSION_NOW);
         jassert (data != nullptr);

--- a/modules/juce_core/native/juce_mac_Network.mm
+++ b/modules/juce_core/native/juce_mac_Network.mm
@@ -1101,7 +1101,7 @@ private:
     {
         jassert (connection == nullptr);
 
-        if (NSURL* nsURL = [NSURL URLWithString: juceStringToNS (url.toString (! isPost))])
+        if (NSURL* nsURL = [NSURL URLWithString: juceStringToNS (url.toString (true))])
         {
             if (NSMutableURLRequest* req = [NSMutableURLRequest requestWithURL: nsURL
                                                                    cachePolicy: NSURLRequestReloadIgnoringLocalCacheData

--- a/modules/juce_core/native/juce_win32_Network.cpp
+++ b/modules/juce_core/native/juce_win32_Network.cpp
@@ -75,7 +75,7 @@ public:
                 return false;
         }
 
-        String address = url.toString (! isPost);
+        String address = url.toString (true);
 
         while (numRedirectsToFollow-- >= 0)
         {

--- a/modules/juce_core/network/juce_URL.h
+++ b/modules/juce_core/network/juce_URL.h
@@ -296,7 +296,7 @@ public:
         It allows your app to receive progress updates during a lengthy POST operation. If you
         want to continue the operation, this should return true, or false to abort.
     */
-    using OpenStreamProgressCallback = bool (void* context, int bytesSent, int totalBytes);
+    using OpenStreamProgressCallback = std::function<bool(int bytesSent, int totalBytes)>;
 
     /** Attempts to open a stream that can read from this URL.
 
@@ -321,8 +321,6 @@ public:
         @param progressCallback  if this is not a nullptr, it lets you supply a callback function
                                  to keep track of the operation's progress. This can be useful
                                  for lengthy POST operations, so that you can provide user feedback.
-        @param progressCallbackContext  if a callback is specified, this value will be passed to
-                                 the function
         @param extraHeaders      if not empty, this string is appended onto the headers that
                                  are used for the request. It must therefore be a valid set of HTML
                                  header directives, separated by newlines.
@@ -340,8 +338,7 @@ public:
         @returns    a valid input stream, or nullptr if there was an error trying to open it.
      */
     std::unique_ptr<InputStream> createInputStream (bool doPostLikeRequest,
-                                                    OpenStreamProgressCallback* progressCallback = nullptr,
-                                                    void* progressCallbackContext = nullptr,
+                                                    OpenStreamProgressCallback progressCallback = nullptr,
                                                     String extraHeaders = {},
                                                     int connectionTimeOutMs = 0,
                                                     StringPairArray* responseHeaders = nullptr,


### PR DESCRIPTION
This fixes a **bug** in JUCE where it removes URL parameters from the endpoint and appends them to the body when POST data is used.

This also changes `createInputStream` to take a `std::function` for the progress callback instead of a function pointer and void* context.

This is a re-creation of PR #707. 