### PR TITLE
Added a way to browse JUCE module sources in all projects

### DIFF
--- a/extras/Build/CMake/JUCEReflectModuleSources.cmake
+++ b/extras/Build/CMake/JUCEReflectModuleSources.cmake
@@ -1,0 +1,42 @@
+#filters out the part that needs to compile from the module sources:
+function(_juce_clean_sources_list sourceList cleanList moduleName)
+    foreach (source IN LISTS sourceList)
+        get_filename_component(fileName ${source} NAME)
+
+        if (NOT fileName MATCHES ${moduleName}*)
+            list(APPEND localCleanList ${source})
+            set_source_files_properties(${source} PROPERTIES HEADER_FILE_ONLY TRUE)
+        endif ()
+    endforeach ()
+
+    set(${cleanList} "${localCleanList}" PARENT_SCOPE)
+endfunction()
+
+#A bit of a hack: Becuase CMake can't 'hold on' to the target properties here
+#We're only storing them in a few properties so we can reflect on them later:
+function(_juce_add_module_sources moduleName containingPath)
+    get_property(ModuleNames GLOBAL PROPERTY juce_module_names)
+    list(APPEND ModuleNames ${moduleName})
+    set_property(GLOBAL PROPERTY juce_module_names ${ModuleNames})
+    set_property(GLOBAL PROPERTY ${moduleName}_containing_path ${containingPath})
+    file(GLOB_RECURSE browsable_files "${containingPath}/${moduleName}/*")
+    _juce_clean_sources_list("${browsable_files}" clean_list ${moduleName})
+    set_property(GLOBAL PROPERTY ${moduleName}_source_files ${clean_list})
+endfunction()
+
+function(_juce_reflect_module_sources moduleName)
+    get_property(path GLOBAL PROPERTY ${moduleName}_containing_path)
+    get_property(sourceFiles GLOBAL PROPERTY ${moduleName}_source_files)
+    source_group(TREE ${path} PREFIX "JUCE Modules" FILES ${sourceFiles})
+    set_source_files_properties(${sourceFiles} PROPERTIES HEADER_FILE_ONLY TRUE)
+    target_sources(${moduleName} INTERFACE ${sourceFiles})
+endfunction()
+
+#Call this when you add a target to update all the sources targets
+function(_juce_reflect_sources)
+    get_property(ModuleNames GLOBAL PROPERTY juce_module_names)
+
+    foreach(moduleName ${ModuleNames})
+        _juce_reflect_module_sources(${moduleName})
+    endforeach()
+endfunction()

--- a/extras/Build/CMake/JUCEReflectModuleSources.cmake
+++ b/extras/Build/CMake/JUCEReflectModuleSources.cmake
@@ -22,14 +22,14 @@ function(_juce_add_module_sources moduleName containingPath)
     file(GLOB_RECURSE browsable_files "${containingPath}/${moduleName}/*")
     _juce_clean_sources_list("${browsable_files}" clean_list ${moduleName})
     set_property(GLOBAL PROPERTY ${moduleName}_source_files ${clean_list})
+    target_sources(${moduleName} INTERFACE ${clean_list})
 endfunction()
 
 function(_juce_reflect_module_sources moduleName)
-    get_property(path GLOBAL PROPERTY ${moduleName}_containing_path)
     get_property(sourceFiles GLOBAL PROPERTY ${moduleName}_source_files)
+    get_property(path GLOBAL PROPERTY ${moduleName}_containing_path)
     source_group(TREE ${path} PREFIX "JUCE Modules" FILES ${sourceFiles})
     set_source_files_properties(${sourceFiles} PROPERTIES HEADER_FILE_ONLY TRUE)
-    target_sources(${moduleName} INTERFACE ${sourceFiles})
 endfunction()
 
 #Call this when you add a target to update all the sources targets

--- a/extras/Build/CMake/JUCEUtils.cmake
+++ b/extras/Build/CMake/JUCEUtils.cmake
@@ -123,6 +123,7 @@ set(JUCE_CMAKE_UTILS_DIR ${CMAKE_CURRENT_LIST_DIR}
     CACHE INTERNAL "The path to the folder holding this file and other resources")
 
 include("${JUCE_CMAKE_UTILS_DIR}/JUCEHelperTargets.cmake")
+include("${JUCE_CMAKE_UTILS_DIR}/JUCEReflectModuleSources.cmake")
 include("${JUCE_CMAKE_UTILS_DIR}/JUCECheckAtomic.cmake")
 
 _juce_create_atomic_target(juce_atomic_wrapper)
@@ -529,6 +530,7 @@ function(juce_add_module module_path)
     endif()
 
     _juce_add_interface_library(${module_name} ${all_module_sources})
+    _juce_add_module_sources(${module_name} ${module_parent_path})
 
     if(${module_name} STREQUAL "juce_core")
         _juce_add_standard_defs(${module_name})
@@ -1863,6 +1865,8 @@ endfunction()
 # ==================================================================================================
 
 function(_juce_initialise_target target)
+    _juce_reflect_sources()
+
     set(one_value_args
         VERSION
         PRODUCT_NAME


### PR DESCRIPTION
Even though the PR probably needs some adjustments and cleanup - this is (IMO) a much more comfortable way to browse sources in the IDE (XCode, Visual Studio, etc).

This is done without adding any additional targets, and only shows the module sources that are linked with a particular target. Works just as well with built in JUCE modules and custom modules.

Looking forward to your review!
Eyal
<img width="478" alt="Screen Shot 2021-01-18 at 2 55 07 AM" src="https://user-images.githubusercontent.com/21240489/104861455-98b56f00-5938-11eb-8c99-4ee6c0bdcf4f.png">
