### PR TITLE
fix WebBrowserComponent file:// support for sandboxed apple apps

### DIFF
--- a/modules/juce_gui_extra/native/juce_mac_WebBrowserComponent.mm
+++ b/modules/juce_gui_extra/native/juce_mac_WebBrowserComponent.mm
@@ -319,6 +319,18 @@ public:
             [webView evaluateJavaScript: juceStringToNS (url.fromFirstOccurrenceOf (":", false, false))
                      completionHandler: nil];
         }
+        else if (url.trimStart().startsWithIgnoreCase ("file:"))
+        {
+            // URL::getLocalFile() handles unescaping the file path and normalising the
+            // number of leading slashes
+            auto file = URL(url).getLocalFile();
+
+            NSURL *nsUrl = [NSURL fileURLWithPath: juceStringToNS(file.getFullPathName())];
+
+            // setting allowingReadAccessToURL is required to access local files from
+            // a sandboxed app.
+            [webView loadFileURL: nsUrl allowingReadAccessToURL: nsUrl];
+        }
         else if (NSMutableURLRequest* request = getRequestForURL (url, headers, postData))
         {
             [webView loadRequest: request];


### PR DESCRIPTION
this allows sandboxed apps on macos/ios to open `file://` urls in a `WebBrowserComponent` with `WkWebView`, see [here](https://stackoverflow.com/questions/24882834/wkwebview-not-loading-local-files-under-ios-8/26054170) for background. 