### PR TITLE
fix for Plugin Host incompatibility 

### DIFF
--- a/extras/AudioPluginHost/Source/Plugins/InternalPlugins.cpp
+++ b/extras/AudioPluginHost/Source/Plugins/InternalPlugins.cpp
@@ -402,7 +402,7 @@ std::unique_ptr<AudioPluginInstance> InternalPluginFormat::InternalPluginFactory
     const auto begin = descriptions.begin();
     const auto it = std::find_if (begin,
                                   descriptions.end(),
-                                  [&] (const PluginDescription& desc) { return name == desc.name; });
+                                  [&] (const PluginDescription& desc) { return name.equalsIgnoreCase(desc.name); });
 
     if (it == descriptions.end())
         return nullptr;


### PR DESCRIPTION
Earlier JUCE Versions use 'Midi Input' instead 'MIDI Input' (uppercase) as internal plugin name, so older Plugin-Host documents are incompatible. Less strict equalsIgnoreCase solves this problem