### PR TITLE
Change Mac goToURL behaviour to only call stop() if we load a new URL

### DIFF
--- a/modules/juce_gui_extra/native/juce_mac_WebBrowserComponent.mm
+++ b/modules/juce_gui_extra/native/juce_mac_WebBrowserComponent.mm
@@ -312,8 +312,6 @@ public:
                   const StringArray* headers,
                   const MemoryBlock* postData)
     {
-        stop();
-
         if (url.trimStart().startsWithIgnoreCase ("javascript:"))
         {
             [webView evaluateJavaScript: juceStringToNS (url.fromFirstOccurrenceOf (":", false, false))
@@ -321,6 +319,7 @@ public:
         }
         else if (NSMutableURLRequest* request = getRequestForURL (url, headers, postData))
         {
+            stop();
             [webView loadRequest: request];
         }
     }


### PR DESCRIPTION
Calling `stop` before evaluating Javascript will interrupt any assets loading on the current page, which is not the desired behaviour (it will result in e.g. images being half loaded, which if the Javascript does not result in loading a new page, can break the web content)