### PR TITLE
[Bugfix] Fix varArrayToNSArray and varObjectToNSDictionary

### DIFF
--- a/modules/juce_core/native/juce_ObjCHelpers_mac.h
+++ b/modules/juce_core/native/juce_ObjCHelpers_mac.h
@@ -102,17 +102,17 @@ inline NSDictionary* varObjectToNSDictionary (const var& varToParse)
 
             const var& valueVar = properties.getValueAt (i);
 
-            if (valueVar.isObject())
-            {
-                auto* valueDictionary = varObjectToNSDictionary (valueVar);
-
-                [dictionary setObject: valueDictionary forKey: keyString];
-            }
-            else if (valueVar.isArray())
+            if (valueVar.isArray())
             {
                 auto* valueArray = varArrayToNSArray (valueVar);
 
                 [dictionary setObject: valueArray forKey: keyString];
+            }
+            else if (valueVar.isObject())
+            {
+                auto* valueDictionary = varObjectToNSDictionary (valueVar);
+
+                [dictionary setObject: valueDictionary forKey: keyString];
             }
             else
             {
@@ -139,17 +139,17 @@ inline NSArray* varArrayToNSArray (const var& varToParse)
 
     for (const auto& aVar : *varArray)
     {
-        if (aVar.isObject())
-        {
-            auto* valueDictionary = varObjectToNSDictionary (aVar);
-
-            [array addObject: valueDictionary];
-        }
-        else if (aVar.isArray())
+        if (aVar.isArray())
         {
             auto* valueArray = varArrayToNSArray (aVar);
 
             [array addObject: valueArray];
+        }
+        else if (aVar.isObject())
+        {
+            auto* valueDictionary = varObjectToNSDictionary (aVar);
+
+            [array addObject: valueDictionary];
         }
         else
         {


### PR DESCRIPTION
Fix `varArrayToNSArray` and `varObjectToNSDictionary` handling of nested arrays.

`var::isObject()` returns `true` for array variants, so it must be tested after `var::isArray()`.