### PR TITLE
Fix AUv3 multi-bus rendering bug

### DIFF
--- a/modules/juce_audio_plugin_client/AU/juce_AUv3_Wrapper.mm
+++ b/modules/juce_audio_plugin_client/AU/juce_AUv3_Wrapper.mm
@@ -1436,10 +1436,11 @@ private:
 
         // process params
         const int numParams = juceParameters.getNumParameters();
-        processEvents (realtimeEventListHead, numParams, static_cast<AUEventSampleTime> (timestamp->mSampleTime));
 
         if (lastTimeStamp.mSampleTime != timestamp->mSampleTime)
         {
+            processEvents (realtimeEventListHead, numParams, static_cast<AUEventSampleTime> (timestamp->mSampleTime));
+
             lastTimeStamp = *timestamp;
 
             const int numInputBuses  = inBusBuffers. size();
@@ -1540,6 +1541,12 @@ private:
             audioBuffer.pop (*outBusBuffers[(int) outputBusNumber]->get(),
                              mapper.get (false, (int) outputBusNumber));
         }
+        else {
+            // now copy the next bus data to the other output buffer
+            audioBuffer.pop (*outputData,
+                             mapper.get (false, (int) outputBusNumber));
+        }
+
 
         return noErr;
     }


### PR DESCRIPTION
This fixes an issue where AUv3 plugins with multiple output buses were not rendering their additional output buses. The host calls the callback repeatedly for each output bus during a single process cycle, but the timestamp check was only allowing the first bus output to be rendered. With the fix, the first callback will cause everything to be computed, and the following callbacks the host makes with the same timestamp will just copy the already computed bus outputs that the host requested.

Also, the events should only be processed once at the first callback for this timestamp.