### PR TITLE
added missing rgb to floating points conversion

### DIFF
--- a/modules/juce_graphics/colour/juce_Colour.cpp
+++ b/modules/juce_graphics/colour/juce_Colour.cpp
@@ -84,7 +84,7 @@ namespace ColourHelpers
                 if (lightness > 0.0f)
                     hue = getHue (col);
 
-                saturation = (float) (hi - lo) / (1.0f - std::abs ((2.0f * lightness) - 1.0f));
+                saturation = ((float) (hi - lo) / 255.0f) / (1.0f - std::abs ((2.0f * lightness) - 1.0f));
             }
         }
 


### PR DESCRIPTION
Fixes #858

added missing floating point conversion of 'chroma' variable while calculating HSL saturation 