### PR TITLE
Mac modifier key handling bug fix improvement.

### DIFF
--- a/modules/juce_gui_basics/native/juce_mac_NSViewComponentPeer.mm
+++ b/modules/juce_gui_basics/native/juce_mac_NSViewComponentPeer.mm
@@ -834,8 +834,15 @@ public:
         // (need to retain this in case a modal loop runs and our event object gets lost)
         const std::unique_ptr<NSEvent, NSObjectDeleter> r ([ev retain]);
 
-        keysCurrentlyDown.clear();
-        handleKeyUpOrDown (true);
+        // Previous behavior clears all the currently held keys before applying the modifier.
+        // But there is only a problem with sticking keys when command modifier key is pressed.
+        // more in-depth explanation: https://forum.juce.com/t/mac-modifier-key-bug-fix-improvement/44476
+        // Proposed: only clear the keysCurrentlyDown when the Command key is pressed
+        if (([ev modifierFlags] & NSEventModifierFlagCommand) != 0)
+        {
+            keysCurrentlyDown.clear();
+            handleKeyUpOrDown (true);
+        }
 
         updateModifiers (ev);
         handleModifierKeysChange();


### PR DESCRIPTION
NSViewComponentPeer::redirectModKeyChange clears all of the currently held keys before applying the modifier changes on Mac. According to this old thread: https://forum.juce.com/t/hanging-keys-when-pressing-modifier-key-bugfix/4824, the currently down keys were cleared to prevent a bug where the key up for those keys was never registered if the command key were pressed while holding a key.

I can confirm that is the case and that the change added in that thread fixed that case. But the sticking keys aren't an issue with any other modifier. What I’m using now and what I propose as an improvement would be to conditionally clear the keysCurrentlyDown ONLY when the command modifier is pressed.