### PR TITLE
Check if controller is valid before destroying `boundsUpdater`

### DIFF
--- a/modules/juce_gui_basics/native/juce_ios_UIViewComponentPeer.mm
+++ b/modules/juce_gui_basics/native/juce_ios_UIViewComponentPeer.mm
@@ -580,7 +580,8 @@ UIViewComponentPeer::~UIViewComponentPeer()
     currentTouches.deleteAllTouchesForPeer (this);
     Desktop::getInstance().removeFocusChangeListener (this);
 
-    ((JuceUIViewController*) controller)->boundsUpdater = nullptr;
+    if (auto* juceUiViewController = (JuceUIViewController*) controller)
+        juceUiViewController->boundsUpdater = nullptr;
 
     view->owner = nullptr;
     [view removeFromSuperview];


### PR DESCRIPTION
In our iOS app, we are managing the `UIViewController` that holds a `JuceUIView`. Since updating to JUCE 6, we experienced crashes when calling `removeFromDesktop` on our JUCE components show in `UIView`s managed by our app. 

Checking that the `controller` is in fact a `JuceUIViewController` fixed the crash. 

