### PR TITLE
Improve popup box keyboard control

### DIFF
--- a/modules/juce_gui_basics/menus/juce_PopupMenu.cpp
+++ b/modules/juce_gui_basics/menus/juce_PopupMenu.cpp
@@ -257,7 +257,12 @@ struct MenuWindow  : public Component
             auto& item = menu.items.getReference (i);
 
             if (i + 1 < menu.items.size() || ! item.isSeparator)
-                items.add (new ItemComponent (item, options, *this));
+            {
+                auto* child = items.add (new ItemComponent (item, options, *this));
+
+                if (item.itemID == options.getHighlightedItem())
+                    setCurrentlyHighlightedChild (child);
+            }
         }
 
         auto targetArea = options.getTargetScreenArea() / scaleFactor;
@@ -1243,7 +1248,7 @@ private:
     {
         if (globalMousePos != lastMousePos || timeNow > lastMouseMoveTime + 350)
         {
-            const bool isMouseOver = window.reallyContains (localMousePos, true);
+            const auto isMouseOver = window.reallyContains (localMousePos, true);
 
             if (isMouseOver)
                 window.hasBeenOver = true;
@@ -1283,7 +1288,12 @@ private:
                         window.activeSubMenu->hide (nullptr, true);
 
                     if (! isMouseOver)
+                    {
+                        if (! window.hasBeenOver)
+                            return;
+
                         itemUnderMouse = nullptr;
+                    }
 
                     window.setCurrentlyHighlightedChild (itemUnderMouse);
                 }
@@ -1818,6 +1828,13 @@ PopupMenu::Options PopupMenu::Options::withItemThatMustBeVisible (int idOfItemTo
 {
     Options o (*this);
     o.visibleItemID = idOfItemToBeVisible;
+    return o;
+}
+
+PopupMenu::Options PopupMenu::Options::withItemToHighlight (int idOfItemToHighlight) const
+{
+    Options o (*this);
+    o.highlightedItemID = idOfItemToHighlight;
     return o;
 }
 

--- a/modules/juce_gui_basics/menus/juce_PopupMenu.h
+++ b/modules/juce_gui_basics/menus/juce_PopupMenu.h
@@ -468,6 +468,7 @@ public:
         Options withMaximumNumColumns (int maxNumColumns) const;
         Options withStandardItemHeight (int standardHeight) const;
         Options withItemThatMustBeVisible (int idOfItemToBeVisible) const;
+        Options withItemToHighlight (int idOfItemToHighlight) const;
         Options withParentComponent (Component* parentComponent) const;
         Options withPreferredPopupDirection (PopupDirection direction) const;
 
@@ -481,6 +482,7 @@ public:
         int getMinimumNumColumns() const noexcept                    { return minColumns; }
         int getStandardItemHeight() const noexcept                   { return standardHeight; }
         int getItemThatMustBeVisible() const noexcept                { return visibleItemID; }
+        int getHighlightedItem() const noexcept                      { return highlightedItemID; }
         PopupDirection getPreferredPopupDirection() const noexcept   { return preferredPopupDirection; }
 
     private:
@@ -489,7 +491,8 @@ public:
         Component* targetComponent = nullptr;
         Component* parentComponent = nullptr;
         WeakReference<Component> componentToWatchForDeletion;
-        int visibleItemID = 0, minWidth = 0, minColumns = 1, maxColumns = 0, standardHeight = 0;
+        int visibleItemID = 0, highlightedItemID = 0, minWidth = 0,
+            minColumns = 1, maxColumns = 0, standardHeight = 0;
         bool isWatchingForDeletion = false;
         PopupDirection preferredPopupDirection = PopupDirection::downwards;
     };


### PR DESCRIPTION
Set ticked/selected item as highlighted on menu construction and
prevent fake mouse events from resetting this.

Previously when a menu was opened with the enter key a user would have to press escape key to close the menu. This was inconsistent if the selected/ticked item was highlighted using the arrow keys and then enter pressed.

Also previosuly keyboard navigation would start at the top/bottom of the list depending on whether up/down was pressed but this change uses the ticked/selected item as the start point.