### PR TITLE
VST3 in Ardour on Linux - resizing fix

### DIFF
--- a/modules/juce_audio_plugin_client/VST3/juce_VST3_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/VST3/juce_VST3_Wrapper.cpp
@@ -1303,6 +1303,8 @@ private:
                         cubase10Workaround->triggerAsyncUpdate();
                     }
                     else
+                   #elif JUCE_LINUX
+                    if (!getHostType().isArdour())
                    #endif
                     {
                         if (auto* peer = component->getPeer())


### PR DESCRIPTION
Hi JUCE team, I believe this PR fixes resize loop issues I have been experiencing trying to build VST3 plugins on Linux to run in Ardour. 

Initially I took a look at the Ardour VST3 host code to see if there was an issue there. That lead to [this PR](https://github.com/Ardour/ardour/pull/599), but upon further digging I found that JUCE's call to `updateBounds` on the ComponentPeer seems to be interfering with Ardour's own window resizing. It seems like JUCE is trying to modify the plugin window size directly during the `onSize` callback, while the VST3 spec indicates that the host should handle window resizing.

Prior to this change, any _resizable_ JUCE plugin causes huge performance issues in Ardour (Linux) when the GUI is opened and immediately enters a resize loop. It's not usable at all. After the change is applied, the plugin UI behaves fine and everything seems stable.