### PR TITLE
adds Atmos 7.1.4 AudioChannelSet

### DIFF
--- a/modules/juce_audio_basics/buffers/juce_AudioChannelSet.cpp
+++ b/modules/juce_audio_basics/buffers/juce_AudioChannelSet.cpp
@@ -349,6 +349,7 @@ String AudioChannelSet::getDescription() const
     if (*this == create7point1SDDS())   return "7.1 Surround SDDS";
     if (*this == create7point0point2()) return "7.0.2 Surround";
     if (*this == create7point1point2()) return "7.1.2 Surround";
+	if (*this == create7point1point4()) return "7.1.4 Surround";
 
     if (*this == quadraphonic())       return "Quadraphonic";
     if (*this == pentagonal())         return "Pentagonal";
@@ -463,6 +464,7 @@ AudioChannelSet AudioChannelSet::hexagonal()           { return AudioChannelSet 
 AudioChannelSet AudioChannelSet::octagonal()           { return AudioChannelSet ((1u << left) | (1u << right) | (1u << centre) | (1u << leftSurround) | (1u << rightSurround) | (1u << centreSurround) | (1u << wideLeft) | (1u << wideRight)); }
 AudioChannelSet AudioChannelSet::create7point0point2() { return AudioChannelSet ((1u << left) | (1u << right) | (1u << centre) | (1u << leftSurroundSide) | (1u << rightSurroundSide) | (1u << leftSurroundRear) | (1u << rightSurroundRear) | (1u << topSideLeft) | (1u << topSideRight)); }
 AudioChannelSet AudioChannelSet::create7point1point2() { return AudioChannelSet ((1u << left) | (1u << right) | (1u << centre) | (1u << LFE) | (1u << leftSurroundSide) | (1u << rightSurroundSide) | (1u << leftSurroundRear) | (1u << rightSurroundRear) | (1u << topSideLeft) | (1u << topSideRight)); }
+AudioChannelSet AudioChannelSet::create7point1point4() { return AudioChannelSet((1u << left) | (1u << right) | (1u << centre) | (1u << LFE) | (1u << leftSurroundRear) | (1u << rightSurroundRear) | (1u << leftSurroundSide) | (1u << rightSurroundSide) | (1u << topFrontLeft) | (1u << topFrontRight) | (1u << topRearLeft) | (1u << topRearRight)); }
 
 AudioChannelSet AudioChannelSet::ambisonic (int order)
 {

--- a/modules/juce_audio_basics/buffers/juce_AudioChannelSet.h
+++ b/modules/juce_audio_basics/buffers/juce_AudioChannelSet.h
@@ -208,6 +208,12 @@ public:
     */
     static AudioChannelSet JUCE_CALLTYPE create7point1point2();
 
+	/** Creates a set for Dolby Atmos 7.1.4 surround setup (left, right, centre, LFE, leftSurroundRear, rightSurroundRear, leftSurroundSide, rightSurroundSide, topFrontLeft, topFrontRight, topRearLeft, topRearRight).
+
+		Is equivalent to: k71_4 (VST),  n/a (AAX), n/a (CoreAudio)
+	*/
+	static AudioChannelSet JUCE_CALLTYPE create7point1point4();
+
 
     //==============================================================================
     /** Creates a set for quadraphonic surround setup (left, right, leftSurround, rightSurround)

--- a/modules/juce_audio_processors/format_types/juce_VST3Common.h
+++ b/modules/juce_audio_processors/format_types/juce_VST3Common.h
@@ -286,6 +286,7 @@ static Steinberg::Vst::SpeakerArrangement getVst3SpeakerArrangement (const Audio
     else if (channels == AudioChannelSet::quadraphonic())        return k40Music;
     else if (channels == AudioChannelSet::create7point0point2()) return k71_2 & ~(Steinberg::Vst::kSpeakerLfe);
     else if (channels == AudioChannelSet::create7point1point2()) return k71_2;
+	else if (channels == AudioChannelSet::create7point1point4()) return k71_4;
     else if (channels == AudioChannelSet::ambisonic (0))         return (1ull << 20);
     else if (channels == AudioChannelSet::ambisonic (1))         return (1ull << 20) | (1ull << 21) | (1ull << 22) | (1ull << 23);
    #if VST_VERSION >= 0x030608
@@ -326,6 +327,7 @@ static AudioChannelSet getChannelSetForSpeakerArrangement (Steinberg::Vst::Speak
     else if (arr == kAmbi1stOrderACN)                                return AudioChannelSet::ambisonic();
     else if (arr == k40Music)                                        return AudioChannelSet::quadraphonic();
     else if (arr == k71_2)                                           return AudioChannelSet::create7point1point2();
+	else if (arr == k71_4)                                           return AudioChannelSet::create7point1point4();
     else if (arr == (k71_2 & ~(Steinberg::Vst::kSpeakerLfe)))        return AudioChannelSet::create7point0point2();
     else if (arr == (1 << 20))                                       return AudioChannelSet::ambisonic (0);
     else if (arr == ((1 << 20) | (1 << 21) | (1 << 22) | (1 << 23))) return AudioChannelSet::ambisonic (1);


### PR DESCRIPTION
AudioChannelSet::create7point1point4()) // tested and working in Nuendo11
see:
https://forum.juce.com/t/does-juce-support-dolby-atmos/35833/16?u=skazassoglou