### PR TITLE
BSD patches

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -31,7 +31,7 @@ function(_juce_add_pips)
         CONFIGURE_DEPENDS LIST_DIRECTORIES false
         "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
 
-    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME MATCHES ".*BSD")
         list(REMOVE_ITEM headers
             "${CMAKE_CURRENT_SOURCE_DIR}/CameraDemo.h"
             "${CMAKE_CURRENT_SOURCE_DIR}/PushNotificationsDemo.h"

--- a/examples/DemoRunner/Source/Demos/DemoPIPs1.cpp
+++ b/examples/DemoRunner/Source/Demos/DemoPIPs1.cpp
@@ -59,7 +59,7 @@
 #include "../../../DSP/WaveShaperTanhDemo.h"
 
 #include "../../../Utilities/Box2DDemo.h"
-#if JUCE_MAC || JUCE_WINDOWS || JUCE_LINUX
+#if JUCE_MAC || JUCE_WINDOWS || JUCE_LINUX || JUCE_BSD
  #include "../../../Utilities/ChildProcessDemo.h"
 #endif
 #include "../../../Utilities/CryptographyDemo.h"
@@ -104,7 +104,7 @@ void registerDemos_One() noexcept
     REGISTER_DEMO (WaveShaperTanhDemo,      DSP,       false)
 
     REGISTER_DEMO (Box2DDemo,               Utilities, false)
-   #if JUCE_MAC || JUCE_WINDOWS || JUCE_LINUX
+   #if JUCE_MAC || JUCE_WINDOWS || JUCE_LINUX || JUCE_BSD
     REGISTER_DEMO (ChildProcessDemo,        Utilities, false)
    #endif
     REGISTER_DEMO (CryptographyDemo,        Utilities, false)

--- a/examples/DemoRunner/Source/Demos/DemoPIPs2.cpp
+++ b/examples/DemoRunner/Source/Demos/DemoPIPs2.cpp
@@ -33,7 +33,7 @@
 #include "../../../GUI/AnimationAppDemo.h"
 #include "../../../GUI/AnimationDemo.h"
 #include "../../../GUI/BouncingBallWavetableDemo.h"
-#if JUCE_USE_CAMERA && ! JUCE_LINUX
+#if JUCE_USE_CAMERA && ! (JUCE_LINUX || JUCE_BSD)
  #include "../../../GUI/CameraDemo.h"
 #endif
 #if ! JUCE_ANDROID
@@ -58,7 +58,7 @@
  #include "../../../GUI/OpenGLDemo2D.h"
 #endif
 #include "../../../GUI/PropertiesDemo.h"
-#if ! JUCE_LINUX
+#if ! (JUCE_LINUX || JUCE_BSD)
  #include "../../../GUI/VideoDemo.h"
 #endif
 #include "../../../GUI/WebBrowserDemo.h"
@@ -70,7 +70,7 @@ void registerDemos_Two() noexcept
     REGISTER_DEMO (AnimationAppDemo,          GUI, false)
     REGISTER_DEMO (AnimationDemo,             GUI, false)
     REGISTER_DEMO (BouncingBallWavetableDemo, GUI, false)
-   #if JUCE_USE_CAMERA && ! JUCE_LINUX
+   #if JUCE_USE_CAMERA && ! (JUCE_LINUX || JUCE_BSD)
     REGISTER_DEMO (CameraDemo,                GUI, true)
    #endif
    #if ! JUCE_ANDROID
@@ -95,7 +95,7 @@ void registerDemos_Two() noexcept
     REGISTER_DEMO (OpenGLDemo,                GUI, true)
    #endif
     REGISTER_DEMO (PropertiesDemo,            GUI, false)
-   #if ! JUCE_LINUX
+   #if ! (JUCE_LINUX || JUCE_BSD)
     REGISTER_DEMO (VideoDemo,                 GUI, true)
    #endif
     REGISTER_DEMO (WebBrowserDemo,            GUI, true)

--- a/examples/DemoRunner/Source/Main.cpp
+++ b/examples/DemoRunner/Source/Main.cpp
@@ -29,7 +29,7 @@
 #include "UI/MainComponent.h"
 
 //==============================================================================
-#if JUCE_WINDOWS || JUCE_LINUX || JUCE_MAC
+#if JUCE_WINDOWS || JUCE_LINUX || JUCE_BSD || JUCE_MAC
  // Just add a simple icon to the Window system tray area or Mac menu bar..
  struct DemoTaskbarComponent  : public SystemTrayIconComponent,
                                 private Timer
@@ -96,7 +96,7 @@ public:
     {
         registerAllDemos();
 
-      #if JUCE_MAC || JUCE_WINDOWS || JUCE_LINUX
+      #if JUCE_MAC || JUCE_WINDOWS || JUCE_LINUX || JUCE_BSD
         // (This function call is for one of the demos, which involves launching a child process)
         if (invokeChildProcessDemo (commandLine))
             return;
@@ -144,7 +144,7 @@ private:
             setContentOwned (new MainComponent(), false);
             setVisible (true);
 
-           #if JUCE_WINDOWS || JUCE_LINUX || JUCE_MAC
+           #if JUCE_WINDOWS || JUCE_LINUX || JUCE_BSD || JUCE_MAC
             taskbarIcon.reset (new DemoTaskbarComponent());
            #endif
         }

--- a/examples/GUI/VideoDemo.h
+++ b/examples/GUI/VideoDemo.h
@@ -702,6 +702,6 @@ private:
         updatePositionSliderAndLabel();
     }
 };
-#elif JUCE_LINUX
+#elif JUCE_LINUX || JUCE_BSD
  #error "This demo is not supported on Linux!"
 #endif

--- a/extras/Build/CMake/JUCEUtils.cmake
+++ b/extras/Build/CMake/JUCEUtils.cmake
@@ -137,7 +137,7 @@ function(_juce_find_linux_target_architecture result)
     set("${result}" "${match_result}" PARENT_SCOPE)
 endfunction()
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME MATCHES ".*BSD")
     _juce_create_pkgconfig_target(JUCE_CURL_LINUX_DEPS libcurl)
     _juce_create_pkgconfig_target(JUCE_BROWSER_LINUX_DEPS webkit2gtk-4.0 gtk+-x11-3.0)
 
@@ -177,7 +177,7 @@ function(_juce_set_default_properties)
 
         set_property(GLOBAL PROPERTY JUCE_VST3_COPY_DIR "${prefix}/VST3")
         set_property(GLOBAL PROPERTY JUCE_AAX_COPY_DIR  "${prefix}/Avid/Audio/Plug-Ins")
-    elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME MATCHES ".*BSD")
         set_property(GLOBAL PROPERTY JUCE_VST_COPY_DIR  "$ENV{HOME}/.vst")
         set_property(GLOBAL PROPERTY JUCE_VST3_COPY_DIR "$ENV{HOME}/.vst3")
     endif()
@@ -575,7 +575,7 @@ function(juce_add_module module_path)
 
     target_compile_definitions(${module_name} INTERFACE JUCE_MODULE_AVAILABLE_${module_name}=1)
 
-    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME MATCHES ".*BSD")
         target_compile_definitions(${module_name} INTERFACE LINUX=1)
     endif()
 
@@ -613,7 +613,7 @@ function(juce_add_module module_path)
         endforeach()
 
         _juce_link_libs_from_metadata("${module_name}" "${metadata_dict}" iOSLibs)
-    elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME MATCHES ".*BSD")
         _juce_get_metadata("${metadata_dict}" linuxPackages module_linuxpackages)
 
         if(module_linuxpackages)
@@ -681,7 +681,7 @@ endfunction()
 # know they need it. Otherwise, we won't link anything.
 # See the NEEDS_CURL, NEEDS_WEB_BROWSER, and NEEDS_STORE_KIT options in the CMake/readme.md.
 function(_juce_link_optional_libraries target)
-    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME MATCHES ".*BSD")
         get_target_property(needs_curl ${target} JUCE_NEEDS_CURL)
 
         if(needs_curl)
@@ -1330,7 +1330,7 @@ function(_juce_set_plugin_target_properties shared_code_target kind)
 
         set(output_path "${products_folder}/${product_name}.vst3")
 
-        if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME MATCHES ".*BSD")
             set_target_properties(${target_name} PROPERTIES
                 SUFFIX .so
                 LIBRARY_OUTPUT_DIRECTORY "${output_path}/Contents/${JUCE_LINUX_TARGET_ARCHITECTURE}-linux")

--- a/extras/NetworkGraphicsDemo/Source/SlaveComponent.h
+++ b/extras/NetworkGraphicsDemo/Source/SlaveComponent.h
@@ -141,6 +141,16 @@ private:
         return "Windows";
        #elif JUCE_LINUX
         return "Linux";
+       #elif JUCE_BSD
+#if defined(__FreeBSD__)
+        return "FreeBSD";
+#elif defined(__OpenBSD__)
+        return "OpenBSD";
+#elif defined(__NetBSD__)
+        return "NetBSD";
+#else
+        #error Unknown BSD
+#endif
        #endif
     }
 

--- a/extras/Projucer/Source/Application/jucer_Application.cpp
+++ b/extras/Projucer/Source/Application/jucer_Application.cpp
@@ -111,7 +111,7 @@ bool ProjucerApplication::initialiseLogger (const char* filePrefix)
 {
     if (logger == nullptr)
     {
-       #if JUCE_LINUX
+       #if JUCE_LINUX || JUCE_BSD
         String folder = "~/.config/Projucer/Logs";
        #else
         String folder = "com.juce.projucer";
@@ -717,7 +717,7 @@ static String getPlatformSpecificFileExtension()
     return ".app";
    #elif JUCE_WINDOWS
     return ".exe";
-   #elif JUCE_LINUX
+   #elif JUCE_LINUX || JUCE_BSD
     return {};
    #else
     jassertfalse;
@@ -738,7 +738,7 @@ static File getPlatformSpecificProjectFolder()
     return buildsFolder.getChildFile ("MacOSX");
    #elif JUCE_WINDOWS
     return buildsFolder.getChildFile ("VisualStudio2017");
-   #elif JUCE_LINUX
+   #elif JUCE_LINUX || JUCE_BSD
     return buildsFolder.getChildFile ("LinuxMakefile");
    #else
     jassertfalse;
@@ -775,7 +775,7 @@ static File tryToFindDemoRunnerExecutableInBuilds()
 
     if (demoRunnerExecutable.existsAsFile())
         return demoRunnerExecutable;
-   #elif JUCE_LINUX
+   #elif JUCE_LINUX || JUCE_BSD
     projectFolder = projectFolder.getChildFile ("LinuxMakefile").getChildFile ("build");
     auto demoRunnerExecutable = projectFolder.getChildFile ("DemoRunner");
 
@@ -854,7 +854,7 @@ File ProjucerApplication::tryToFindDemoRunnerProject()
     auto demoRunnerProjectFile = projectFolder.getChildFile ("DemoRunner.xcodeproj");
    #elif JUCE_WINDOWS
     auto demoRunnerProjectFile = projectFolder.getChildFile ("DemoRunner.sln");
-   #elif JUCE_LINUX
+   #elif JUCE_LINUX || JUCE_BSD
     auto demoRunnerProjectFile = projectFolder.getChildFile ("Makefile");
    #endif
 
@@ -885,7 +885,7 @@ void ProjucerApplication::launchDemoRunner()
 
         demoRunnerAlert.reset (lf.createAlertWindow ("Open Project",
                                                      "Couldn't find a compiled version of the Demo Runner."
-                                                    #if JUCE_LINUX
+                                                    #if JUCE_LINUX || JUCE_BSD
                                                      " Do you want to build it now?", "Build project", "Cancel",
                                                     #else
                                                      " Do you want to open the project?", "Open project", "Cancel",
@@ -900,7 +900,7 @@ void ProjucerApplication::launchDemoRunner()
 
                                                     if (retVal == 1)
                                                     {
-                                                       #if JUCE_LINUX
+                                                       #if JUCE_LINUX || JUCE_BSD
                                                         String command ("make -C " + demoRunnerFile.getParentDirectory().getFullPathName() + " CONFIG=Release -j3");
 
                                                         if (! makeProcess.start (command))
@@ -998,7 +998,7 @@ void ProjucerApplication::getCommandInfo (CommandID commandID, ApplicationComman
         break;
 
     case CommandIDs::launchDemoRunner:
-       #if JUCE_LINUX
+       #if JUCE_LINUX || JUCE_BSD
         if (makeProcess.isRunning())
         {
             result.setInfo ("Building Demo Runner...", "The Demo Runner project is currently building", CommandCategories::general, 0);
@@ -1426,7 +1426,7 @@ PropertiesFile::Options ProjucerApplication::getPropertyFileOptionsFor (const St
     options.applicationName     = filename;
     options.filenameSuffix      = "settings";
     options.osxLibrarySubFolder = "Application Support";
-   #if JUCE_LINUX
+   #if JUCE_LINUX || JUCE_BSD
     options.folderName          = "~/.config/Projucer";
    #else
     options.folderName          = "Projucer";

--- a/extras/Projucer/Source/Application/jucer_Application.h
+++ b/extras/Projucer/Source/Application/jucer_Application.h
@@ -220,7 +220,7 @@ private:
     std::unique_ptr<AlertWindow> demoRunnerAlert;
     bool hasScannedForDemoRunnerExecutable = false, hasScannedForDemoRunnerProject = false;
     File lastJUCEPath, lastDemoRunnerExectuableFile, lastDemoRunnerProjectFile;
-   #if JUCE_LINUX
+   #if JUCE_LINUX || JUCE_BSD
     ChildProcess makeProcess;
    #endif
 

--- a/extras/Projucer/Source/Application/jucer_AutoUpdater.cpp
+++ b/extras/Projucer/Source/Application/jucer_AutoUpdater.cpp
@@ -82,6 +82,8 @@ void LatestVersionCheckerAndUpdater::run()
         return "windows";
        #elif JUCE_LINUX
         return "linux";
+       #elif JUCE_BSD
+        return "bsd";
        #else
         jassertfalse;
         return "Unknown";
@@ -444,7 +446,7 @@ private:
         if (threadShouldExit())
             return Result::fail ("Cancelled");
 
-       #if JUCE_LINUX || JUCE_MAC
+       #if JUCE_LINUX || JUCE_BSD || JUCE_MAC
         r = setFilePermissions (unzipTarget.folder, zip);
 
         if (r.failed())
@@ -502,10 +504,10 @@ private:
 
 static void restartProcess (const File& targetFolder)
 {
-   #if JUCE_MAC || JUCE_LINUX
+   #if JUCE_MAC || JUCE_LINUX || JUCE_BSD
     #if JUCE_MAC
      auto newProcess = targetFolder.getChildFile ("Projucer.app").getChildFile ("Contents").getChildFile ("MacOS").getChildFile ("Projucer");
-    #elif JUCE_LINUX
+    #elif JUCE_LINUX || JUCE_BSD
      auto newProcess = targetFolder.getChildFile ("Projucer");
     #endif
 

--- a/extras/Projucer/Source/Application/jucer_CommandLine.cpp
+++ b/extras/Projucer/Source/Application/jucer_CommandLine.cpp
@@ -701,16 +701,17 @@ namespace
         if      (os == "osx")        targetOS = TargetOS::osx;
         else if (os == "windows")    targetOS = TargetOS::windows;
         else if (os == "linux")      targetOS = TargetOS::linux;
+        else if (os == "bsd")        targetOS = TargetOS::bsd;
 
         if (targetOS == TargetOS::unknown)
-            ConsoleApplication::fail ("You need to specify a valid OS! Use osx, windows or linux");
+            ConsoleApplication::fail ("You need to specify a valid OS! Use osx, windows, linux or bsd");
 
         return targetOS == TargetOS::getThisOS();
     }
 
     static bool isValidPathIdentifier (const String& id, const String& os)
     {
-        return id == "vstLegacyPath" || (id == "aaxPath" && os != "linux") || (id == "rtasPath" && os != "linux")
+        return id == "vstLegacyPath" || (id == "aaxPath" && os != "linux" && os != "bsd") || (id == "rtasPath" && os != "linux" && os != "bsd")
             || id == "androidSDKPath" || id == "defaultJuceModulePath" || id == "defaultUserModulePath";
     }
 

--- a/extras/Projucer/Source/Application/jucer_CommonHeaders.h
+++ b/extras/Projucer/Source/Application/jucer_CommonHeaders.h
@@ -39,6 +39,7 @@ struct TargetOS
         windows = 0,
         osx,
         linux,
+        bsd,
         unknown
     };
 
@@ -50,6 +51,8 @@ struct TargetOS
         return osx;
        #elif JUCE_LINUX
         return linux;
+       #elif JUCE_BSD
+        return bsd;
        #else
         return unknown;
        #endif

--- a/extras/Projucer/Source/Licenses/jucer_LicenseController.cpp
+++ b/extras/Projucer/Source/Licenses/jucer_LicenseController.cpp
@@ -143,7 +143,7 @@ void LicenseController::logout()
     thread.reset();
     updateState ({});
 
-   #if ! JUCE_LINUX
+   #if ! (JUCE_LINUX || JUCE_BSD)
     WebBrowserComponent::clearCookies();
    #endif
 
@@ -187,7 +187,7 @@ void LicenseController::ensureLicenseWebviewIsOpenWithPage (const String& param)
     }
     else
     {
-       #if ! JUCE_LINUX
+       #if ! (JUCE_LINUX || JUCE_BSD)
         WebBrowserComponent::clearCookies();
        #endif
 

--- a/extras/Projucer/Source/LiveBuildEngine/jucer_CompileEngineDLL.h
+++ b/extras/Projucer/Source/LiveBuildEngine/jucer_CompileEngineDLL.h
@@ -96,7 +96,7 @@ struct CompileEngineDLL  : private DeletedAtShutdown
     {
        #if JUCE_MAC
         return "JUCECompileEngine.dylib";
-       #elif JUCE_LINUX
+       #elif JUCE_LINUX || JUCE_BSD
         return "JUCECompileEngine.so";
        #elif JUCE_WINDOWS
         return "JUCECompileEngine.dll";

--- a/extras/Projucer/Source/LiveBuildEngine/jucer_CompileEngineServer.cpp
+++ b/extras/Projucer/Source/LiveBuildEngine/jucer_CompileEngineServer.cpp
@@ -35,7 +35,7 @@
 #include "jucer_ProjectBuildInfo.h"
 #include "jucer_ClientServerMessages.h"
 
-#if JUCE_LINUX
+#if JUCE_LINUX || JUCE_BSD
  #include <sys/types.h>
  #include <unistd.h>
 #endif

--- a/extras/Projucer/Source/LiveBuildEngine/jucer_CompileEngineSettings.h
+++ b/extras/Projucer/Source/LiveBuildEngine/jucer_CompileEngineSettings.h
@@ -97,6 +97,8 @@ private:
         return "WINDOWS";
        #elif JUCE_LINUX
         return "LINUX";
+       #elif JUCE_BSD
+        return "BSD";
        #else
         // unknown platform?!
         jassertfalse;

--- a/extras/Projucer/Source/Project/UI/jucer_ProjectContentComponent.cpp
+++ b/extras/Projucer/Source/Project/UI/jucer_ProjectContentComponent.cpp
@@ -1369,7 +1369,7 @@ void ProjectContentComponent::handleMissingSystemHeaders()
    #elif JUCE_WINDOWS
     String tabMessage ("Compiler not available due to missing system headers\nPlease install a recent version of Visual Studio and the Windows Desktop SDK");
     String alertWindowMessage ("Missing system headers\nPlease install a recent version of Visual Studio and the Windows Desktop SDK");
-   #elif JUCE_LINUX
+   #elif JUCE_LINUX || JUCE_BSD
     String tabMessage ("Compiler not available due to missing system headers\nPlease do a sudo apt-get install ...");
     String alertWindowMessage ("Missing system headers\nPlease do sudo apt-get install ...");
    #endif

--- a/extras/Projucer/Source/ProjectSaving/jucer_ProjectExport_CLion.h
+++ b/extras/Projucer/Source/ProjectSaving/jucer_ProjectExport_CLion.h
@@ -110,7 +110,7 @@ public:
         static Identifier exporterName (XcodeProjectExporter::getValueTreeTypeNameMac());
        #elif JUCE_WINDOWS
         static Identifier exporterName (CodeBlocksProjectExporter::getValueTreeTypeNameWindows());
-       #elif JUCE_LINUX
+       #elif JUCE_LINUX || JUCE_BSD
         static Identifier exporterName (MakefileProjectExporter::getValueTreeTypeName());
        #else
         static Identifier exporterName;

--- a/extras/Projucer/Source/ProjectSaving/jucer_ProjectExporter.cpp
+++ b/extras/Projucer/Source/ProjectSaving/jucer_ProjectExporter.cpp
@@ -130,7 +130,7 @@ ProjectExporter::ExporterTypeInfo ProjectExporter::getCurrentPlatformExporterTyp
      return ProjectExporter::getTypeInfoForExporter (XcodeProjectExporter::getValueTreeTypeNameMac());
     #elif JUCE_WINDOWS
      return ProjectExporter::getTypeInfoForExporter (MSVCProjectExporterVC2019::getValueTreeTypeName());
-    #elif JUCE_LINUX
+    #elif JUCE_LINUX || JUCE_BSD
      return ProjectExporter::getTypeInfoForExporter (MakefileProjectExporter::getValueTreeTypeName());
     #else
      #error "unknown platform!"

--- a/extras/Projucer/Source/ProjectSaving/jucer_ProjectExporter.h
+++ b/extras/Projucer/Source/ProjectSaving/jucer_ProjectExporter.h
@@ -115,7 +115,7 @@ public:
         return isOSX() || isAndroid() || isiOS();
        #elif JUCE_WINDOWS
         return isWindows() || isAndroid();
-       #elif JUCE_LINUX
+       #elif JUCE_LINUX || JUCE_BSD
         return isLinux() || isAndroid();
        #else
         #error

--- a/modules/juce_audio_devices/audio_io/juce_AudioIODeviceType.cpp
+++ b/modules/juce_audio_devices/audio_io/juce_AudioIODeviceType.cpp
@@ -88,19 +88,19 @@ void AudioIODeviceType::callDeviceChangeListeners()
  AudioIODeviceType* AudioIODeviceType::createAudioIODeviceType_ASIO()         { return nullptr; }
 #endif
 
-#if JUCE_LINUX && JUCE_ALSA
+#if (JUCE_LINUX || JUCE_BSD) && JUCE_ALSA
  AudioIODeviceType* AudioIODeviceType::createAudioIODeviceType_ALSA()         { return createAudioIODeviceType_ALSA_PCMDevices(); }
 #else
  AudioIODeviceType* AudioIODeviceType::createAudioIODeviceType_ALSA()         { return nullptr; }
 #endif
 
-#if JUCE_LINUX && JUCE_JACK
+#if (JUCE_LINUX || JUCE_BSD) && JUCE_JACK
  AudioIODeviceType* AudioIODeviceType::createAudioIODeviceType_JACK()         { return new JackAudioIODeviceType(); }
 #else
  AudioIODeviceType* AudioIODeviceType::createAudioIODeviceType_JACK()         { return nullptr; }
 #endif
 
-#if JUCE_LINUX && JUCE_BELA
+#if (JUCE_LINUX || JUCE_BSD) && JUCE_BELA
  AudioIODeviceType* AudioIODeviceType::createAudioIODeviceType_Bela()         { return new BelaAudioIODeviceType(); }
 #else
  AudioIODeviceType* AudioIODeviceType::createAudioIODeviceType_Bela()         { return nullptr; }

--- a/modules/juce_audio_devices/juce_audio_devices.cpp
+++ b/modules/juce_audio_devices/juce_audio_devices.cpp
@@ -162,7 +162,7 @@ namespace ump = universal_midi_packets;
  #endif
 
 //==============================================================================
-#elif JUCE_LINUX
+#elif JUCE_LINUX || JUCE_BSD
  #if JUCE_ALSA
   /* Got an include error here? If so, you've either not got ALSA installed, or you've
      not got your paths set up correctly to find its header files.

--- a/modules/juce_audio_devices/midi_io/juce_MidiDevices.h
+++ b/modules/juce_audio_devices/midi_io/juce_MidiDevices.h
@@ -108,7 +108,7 @@ public:
     */
     static std::unique_ptr<MidiInput> openDevice (const String& deviceIdentifier, MidiInputCallback* callback);
 
-   #if JUCE_LINUX || JUCE_MAC || JUCE_IOS || DOXYGEN
+   #if JUCE_LINUX || JUCE_BSD || JUCE_MAC || JUCE_IOS || DOXYGEN
     /** This will try to create a new midi input device (only available on Linux, macOS and iOS).
 
         This will attempt to create a new midi input device with the specified name for other
@@ -268,7 +268,7 @@ public:
     */
     static std::unique_ptr<MidiOutput> openDevice (const String& deviceIdentifier);
 
-   #if JUCE_LINUX || JUCE_MAC || JUCE_IOS || DOXYGEN
+   #if JUCE_LINUX || JUCE_BSD || JUCE_MAC || JUCE_IOS || DOXYGEN
     /** This will try to create a new midi output device (only available on Linux, macOS and iOS).
 
         This will attempt to create a new midi output device with the specified name that other

--- a/modules/juce_audio_plugin_client/Standalone/juce_StandaloneFilterApp.cpp
+++ b/modules/juce_audio_plugin_client/Standalone/juce_StandaloneFilterApp.cpp
@@ -58,7 +58,7 @@ public:
         options.applicationName     = getApplicationName();
         options.filenameSuffix      = ".settings";
         options.osxLibrarySubFolder = "Application Support";
-       #if JUCE_LINUX
+       #if JUCE_LINUX || JUCE_BSD
         options.folderName          = "~/.config";
        #else
         options.folderName          = "";

--- a/modules/juce_audio_plugin_client/VST/juce_VST_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/VST/juce_VST_Wrapper.cpp
@@ -188,7 +188,7 @@ namespace
 }
 
 //==============================================================================
-#elif JUCE_LINUX
+#elif JUCE_LINUX || JUCE_BSD
 
 struct SharedMessageThread  : public Thread
 {
@@ -364,7 +364,7 @@ public:
         JUCE_AUTORELEASEPOOL
         {
             {
-               #if JUCE_LINUX
+               #if JUCE_LINUX || JUCE_BSD
                 MessageManagerLock mmLock;
                #endif
                 stopTimer();
@@ -385,7 +385,7 @@ public:
 
             if (activePlugins.size() == 0)
             {
-               #if JUCE_LINUX
+               #if JUCE_LINUX || JUCE_BSD
                 SharedMessageThread::deleteInstance();
                #endif
                 shutdownJuce_GUI();
@@ -1066,11 +1066,11 @@ public:
         {
             setVisible (false);
 
-           #if JUCE_WINDOWS || JUCE_LINUX
+           #if JUCE_WINDOWS || JUCE_LINUX || JUCE_BSD
             addToDesktop (0, args.ptr);
             hostWindow = (HostWindowType) args.ptr;
 
-            #if JUCE_LINUX
+            #if JUCE_LINUX || JUCE_BSD
              X11Symbols::getInstance()->xReparentWindow (display,
                                                          (Window) getWindowHandle(),
                                                          (HostWindowType) hostWindow,
@@ -1174,7 +1174,7 @@ public:
                 {
                     const ScopedValueSetter<bool> resizingParentSetter (resizingParent, true);
 
-                   #if JUCE_LINUX // setSize() on linux causes renoise and energyxt to fail.
+                   #if JUCE_LINUX || JUCE_BSD // setSize() on linux causes renoise and energyxt to fail.
                     auto rect = convertToHostBounds ({ 0, 0, (int16) editorBounds.getHeight(), (int16) editorBounds.getWidth() });
 
                     X11Symbols::getInstance()->xResizeWindow (display, (Window) getWindowHandle(),
@@ -1219,7 +1219,7 @@ public:
 
                #if JUCE_MAC
                 setNativeHostWindowSizeVST (hostWindow, this, newWidth, newHeight, wrapper.useNSView);
-               #elif JUCE_LINUX
+               #elif JUCE_LINUX || JUCE_BSD
                 // (Currently, all linux hosts support sizeWindow, so this should never need to happen)
                 setSize (newWidth, newHeight);
                #else
@@ -1355,7 +1355,7 @@ public:
         float editorScaleFactor = 1.0f;
         juce::Rectangle<int> lastBounds;
 
-       #if JUCE_LINUX
+       #if JUCE_LINUX || JUCE_BSD
         using HostWindowType = ::Window;
         ::Display* display = XWindowSystem::getInstance()->getDisplay();
        #elif JUCE_WINDOWS
@@ -2142,7 +2142,7 @@ namespace
             {
                 if (audioMaster (nullptr, Vst2::audioMasterVersion, 0, 0, nullptr, 0) != 0)
                 {
-                   #if JUCE_LINUX
+                   #if JUCE_LINUX || JUCE_BSD
                     MessageManagerLock mmLock;
                    #endif
 
@@ -2197,7 +2197,7 @@ namespace
 
 //==============================================================================
 // Linux startup code..
-#elif JUCE_LINUX
+#elif JUCE_LINUX || JUCE_BSD
 
     JUCE_EXPORTED_FUNCTION Vst2::AEffect* VSTPluginMain (Vst2::audioMasterCallback audioMaster);
     JUCE_EXPORTED_FUNCTION Vst2::AEffect* VSTPluginMain (Vst2::audioMasterCallback audioMaster)

--- a/modules/juce_audio_plugin_client/VST3/juce_VST3_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/VST3/juce_VST3_Wrapper.cpp
@@ -27,7 +27,7 @@
 #include <juce_core/system/juce_TargetPlatform.h>
 
 //==============================================================================
-#if JucePlugin_Build_VST3 && (JUCE_MAC || JUCE_WINDOWS || JUCE_LINUX)
+#if JucePlugin_Build_VST3 && (JUCE_MAC || JUCE_WINDOWS || JUCE_LINUX || JUCE_BSD)
 
 #if JUCE_PLUGINHOST_VST3
  #if JUCE_MAC
@@ -74,7 +74,7 @@
  #endif
 #endif
 
-#if JUCE_LINUX
+#if JUCE_LINUX || JUCE_BSD
  #include <unordered_map>
 
  std::vector<std::pair<int, std::function<void (int)>>> getFdReadCallbacks();
@@ -1163,7 +1163,7 @@ private:
     //==============================================================================
     class JuceVST3Editor  : public Vst::EditorView,
                             public Steinberg::IPlugViewContentScaleSupport,
-                           #if JUCE_LINUX
+                           #if JUCE_LINUX || JUCE_BSD
                             public Steinberg::Linux::IEventHandler,
                            #endif
                             private Timer
@@ -1193,7 +1193,7 @@ private:
         REFCOUNT_METHODS (Vst::EditorView)
 
         //==============================================================================
-       #if JUCE_LINUX
+       #if JUCE_LINUX || JUCE_BSD
         void PLUGIN_API onFDIsSet (Steinberg::Linux::FileDescriptor fd) override
         {
             if (plugFrame != nullptr)
@@ -1215,7 +1215,7 @@ private:
                 if (strcmp (type, kPlatformTypeHWND) == 0)
                #elif JUCE_MAC
                 if (strcmp (type, kPlatformTypeNSView) == 0 || strcmp (type, kPlatformTypeHIView) == 0)
-               #elif JUCE_LINUX
+               #elif JUCE_LINUX || JUCE_BSD
                 if (strcmp (type, kPlatformTypeX11EmbedWindowID) == 0)
                #endif
                     return kResultTrue;
@@ -1233,7 +1233,7 @@ private:
 
             createContentWrapperComponentIfNeeded();
 
-           #if JUCE_WINDOWS || JUCE_LINUX
+           #if JUCE_WINDOWS || JUCE_LINUX || JUCE_BSD
             component->setOpaque (true);
             component->addToDesktop (0, (void*) systemWindow);
             component->setVisible (true);
@@ -1243,7 +1243,7 @@ private:
              component->startTimer (500);
             #endif
 
-            #if JUCE_LINUX
+            #if JUCE_LINUX || JUCE_BSD
              if (auto* runLoop = getHostRunLoop())
              {
                  for (auto& cb : getFdReadCallbacks())
@@ -1275,7 +1275,7 @@ private:
             {
                #if JUCE_WINDOWS
                 component->removeFromDesktop();
-               #elif JUCE_LINUX
+               #elif JUCE_LINUX || JUCE_BSD
                 fdCallbackMap.clear();
 
                 if (auto* runLoop = getHostRunLoop())
@@ -1569,7 +1569,7 @@ private:
                 {
                     resizeHostWindow();
 
-                   #if JUCE_LINUX
+                   #if JUCE_LINUX || JUCE_BSD
                     if (getHostType().isBitwigStudio())
                         repaint();
                    #endif
@@ -1721,7 +1721,7 @@ private:
 
         #if JUCE_WINDOWS
          WindowsHooks hooks;
-        #elif JUCE_LINUX
+        #elif JUCE_LINUX || JUCE_BSD
          std::unordered_map<int, std::function<void (int)>> fdCallbackMap;
 
          ::Display* display = XWindowSystem::getInstance()->getDisplay();
@@ -3080,7 +3080,7 @@ bool shutdownModule()
 #if JUCE_WINDOWS
  extern "C" __declspec (dllexport) bool InitDll()   { return initModule(); }
  extern "C" __declspec (dllexport) bool ExitDll()   { return shutdownModule(); }
-#elif JUCE_LINUX
+#elif JUCE_LINUX || JUCE_BSD
  void* moduleHandle = nullptr;
  int moduleEntryCounter = 0;
 

--- a/modules/juce_audio_plugin_client/utility/juce_IncludeSystemHeaders.h
+++ b/modules/juce_audio_plugin_client/utility/juce_IncludeSystemHeaders.h
@@ -36,7 +36,7 @@
  #ifdef __INTEL_COMPILER
   #pragma warning (disable : 1899)
  #endif
-#elif JUCE_LINUX
+#elif JUCE_LINUX || JUCE_BSD
  #include <float.h>
  #include <sys/time.h>
  #include <arpa/inet.h>

--- a/modules/juce_audio_plugin_client/utility/juce_PluginUtilities.cpp
+++ b/modules/juce_audio_plugin_client/utility/juce_PluginUtilities.cpp
@@ -42,7 +42,7 @@ namespace juce
  #define JUCE_VST3_CAN_REPLACE_VST2 1
 #endif
 
-#if JucePlugin_Build_VST3 && JUCE_VST3_CAN_REPLACE_VST2 && (JUCE_MAC || JUCE_WINDOWS || JUCE_LINUX)
+#if JucePlugin_Build_VST3 && JUCE_VST3_CAN_REPLACE_VST2 && (JUCE_MAC || JUCE_WINDOWS || JUCE_LINUX || JUCE_BSD)
  #define VST3_REPLACEMENT_AVAILABLE 1
 
  // NB: Nasty old-fashioned code in here because it's copied from the Steinberg example code.

--- a/modules/juce_audio_processors/format/juce_AudioPluginFormatManager.cpp
+++ b/modules/juce_audio_processors/format/juce_AudioPluginFormatManager.cpp
@@ -38,11 +38,11 @@ void AudioPluginFormatManager::addDefaultFormats()
     {
         ignoreUnused (format);
 
-       #if JUCE_PLUGINHOST_VST && (JUCE_MAC || JUCE_WINDOWS || JUCE_LINUX || JUCE_IOS)
+       #if JUCE_PLUGINHOST_VST && (JUCE_MAC || JUCE_WINDOWS || JUCE_LINUX || JUCE_BSD || JUCE_IOS)
         jassert (dynamic_cast<VSTPluginFormat*> (format) == nullptr);
        #endif
 
-       #if JUCE_PLUGINHOST_VST3 && (JUCE_MAC || JUCE_WINDOWS || JUCE_LINUX)
+       #if JUCE_PLUGINHOST_VST3 && (JUCE_MAC || JUCE_WINDOWS || JUCE_LINUX || JUCE_BSD)
         jassert (dynamic_cast<VST3PluginFormat*> (format) == nullptr);
        #endif
 
@@ -50,7 +50,7 @@ void AudioPluginFormatManager::addDefaultFormats()
         jassert (dynamic_cast<AudioUnitPluginFormat*> (format) == nullptr);
        #endif
 
-       #if JUCE_PLUGINHOST_LADSPA && JUCE_LINUX
+       #if JUCE_PLUGINHOST_LADSPA && JUCE_LINUX || JUCE_BSD
         jassert (dynamic_cast<LADSPAPluginFormat*> (format) == nullptr);
        #endif
     }
@@ -60,15 +60,15 @@ void AudioPluginFormatManager::addDefaultFormats()
     formats.add (new AudioUnitPluginFormat());
    #endif
 
-   #if JUCE_PLUGINHOST_VST && (JUCE_MAC || JUCE_WINDOWS || JUCE_LINUX || JUCE_IOS)
+   #if JUCE_PLUGINHOST_VST && (JUCE_MAC || JUCE_WINDOWS || JUCE_LINUX || JUCE_BSD || JUCE_IOS)
     formats.add (new VSTPluginFormat());
    #endif
 
-   #if JUCE_PLUGINHOST_VST3 && (JUCE_MAC || JUCE_WINDOWS || JUCE_LINUX)
+   #if JUCE_PLUGINHOST_VST3 && (JUCE_MAC || JUCE_WINDOWS || JUCE_LINUX || JUCE_BSD)
     formats.add (new VST3PluginFormat());
    #endif
 
-   #if JUCE_PLUGINHOST_LADSPA && JUCE_LINUX
+   #if JUCE_PLUGINHOST_LADSPA && JUCE_LINUX || JUCE_BSD
     formats.add (new LADSPAPluginFormat());
    #endif
 }

--- a/modules/juce_audio_processors/format_types/VST3_SDK/pluginterfaces/base/fplatform.h
+++ b/modules/juce_audio_processors/format_types/VST3_SDK/pluginterfaces/base/fplatform.h
@@ -119,6 +119,41 @@
 		#define SMTG_HAS_NOEXCEPT 1
 	#endif
 //-----------------------------------------------------------------------------
+// BSD
+//-----------------------------------------------------------------------------
+#elif __FreeBSD__
+	#define SMTG_OS_LINUX	1 // atomic operations need to be implemented
+	#define SMTG_OS_MACOS	0
+	#define SMTG_OS_WINDOWS	0
+	#define SMTG_OS_IOS		0
+	#define SMTG_OS_OSX		0
+
+	#include <sys/endian.h>
+	#if __BYTE_ORDER == __LITTLE_ENDIAN
+		#define BYTEORDER kLittleEndian
+	#else
+		#define BYTEORDER kBigEndian
+	#endif
+
+	#define COM_COMPATIBLE	0
+	#define PLUGIN_API
+	#define SMTG_PTHREADS	1
+
+	#if __LP64__
+		#define SMTG_PLATFORM_64 1
+	#else
+		#define SMTG_PLATFORM_64 0
+	#endif
+	#ifdef __cplusplus
+		#include <cstddef>
+		#define SMTG_CPP11 (__cplusplus >= 201103L)
+		#ifndef SMTG_CPP11
+			#error unsupported compiler
+		#endif
+		#define SMTG_CPP11_STDLIBSUPPORT 1
+		#define SMTG_HAS_NOEXCEPT 1
+	#endif
+//-----------------------------------------------------------------------------
 // Mac and iOS
 //-----------------------------------------------------------------------------
 #elif __APPLE__

--- a/modules/juce_audio_processors/format_types/VST3_SDK/pluginterfaces/base/funknown.cpp
+++ b/modules/juce_audio_processors/format_types/VST3_SDK/pluginterfaces/base/funknown.cpp
@@ -35,7 +35,7 @@
 
 #endif
 
-#if SMTG_OS_LINUX
+#if SMTG_OS_LINUX && !JUCE_BSD
 #include <ext/atomicity.h>
 #endif
 
@@ -71,7 +71,7 @@ int32 PLUGIN_API atomicAdd (int32& var, int32 d)
 	return InterlockedExchangeAdd (&var, d) + d;
 #elif SMTG_OS_MACOS
 	return OSAtomicAdd32Barrier (d, (int32_t*)&var);
-#elif SMTG_OS_LINUX
+#elif SMTG_OS_LINUX && !JUCE_BSD
 	__gnu_cxx::__atomic_add (&var, d);
 	return var;
 #else

--- a/modules/juce_audio_processors/format_types/juce_LADSPAPluginFormat.cpp
+++ b/modules/juce_audio_processors/format_types/juce_LADSPAPluginFormat.cpp
@@ -23,7 +23,7 @@
   ==============================================================================
 */
 
-#if JUCE_PLUGINHOST_LADSPA && JUCE_LINUX
+#if JUCE_PLUGINHOST_LADSPA && (JUCE_LINUX || JUCE_BSD)
 
 #include <ladspa.h>
 

--- a/modules/juce_audio_processors/format_types/juce_LADSPAPluginFormat.h
+++ b/modules/juce_audio_processors/format_types/juce_LADSPAPluginFormat.h
@@ -26,7 +26,7 @@
 namespace juce
 {
 
-#if (JUCE_PLUGINHOST_LADSPA && JUCE_LINUX) || DOXYGEN
+#if (JUCE_PLUGINHOST_LADSPA && JUCE_LINUX || JUCE_BSD) || DOXYGEN
 
 //==============================================================================
 /**

--- a/modules/juce_audio_processors/format_types/juce_VST3Common.h
+++ b/modules/juce_audio_processors/format_types/juce_VST3Common.h
@@ -91,7 +91,7 @@ inline void toString128 (Steinberg::Vst::String128 result, const juce::String& s
  static const Steinberg::FIDString defaultVST3WindowType = Steinberg::kPlatformTypeHWND;
 #elif JUCE_MAC
  static const Steinberg::FIDString defaultVST3WindowType = Steinberg::kPlatformTypeNSView;
-#elif JUCE_LINUX
+#elif JUCE_LINUX || JUCE_BSD
  static const Steinberg::FIDString defaultVST3WindowType = Steinberg::kPlatformTypeX11EmbedWindowID;
 #endif
 

--- a/modules/juce_audio_processors/format_types/juce_VST3Headers.h
+++ b/modules/juce_audio_processors/format_types/juce_VST3Headers.h
@@ -156,7 +156,7 @@ namespace Steinberg
     DEF_CLASS_IID (IPlugFrame)
     DEF_CLASS_IID (IPlugViewContentScaleSupport)
 
-   #if JUCE_LINUX
+   #if JUCE_LINUX || JUCE_BSD
     DEF_CLASS_IID (Linux::IRunLoop)
    #endif
 }

--- a/modules/juce_audio_processors/format_types/juce_VST3PluginFormat.h
+++ b/modules/juce_audio_processors/format_types/juce_VST3PluginFormat.h
@@ -26,7 +26,7 @@
 namespace juce
 {
 
-#if (JUCE_PLUGINHOST_VST3 && (JUCE_MAC || JUCE_WINDOWS || JUCE_LINUX)) || DOXYGEN
+#if (JUCE_PLUGINHOST_VST3 && (JUCE_MAC || JUCE_WINDOWS || JUCE_LINUX || JUCE_BSD)) || DOXYGEN
 
 /**
     Implements a plugin format for VST3s.

--- a/modules/juce_audio_processors/format_types/juce_VSTPluginFormat.cpp
+++ b/modules/juce_audio_processors/format_types/juce_VSTPluginFormat.cpp
@@ -173,7 +173,7 @@ namespace
     {
        #if JUCE_WINDOWS
         return timeGetTime() * 1000000.0;
-       #elif JUCE_LINUX || JUCE_IOS || JUCE_ANDROID
+       #elif JUCE_LINUX || JUCE_BSD || JUCE_IOS || JUCE_ANDROID
         timeval micro;
         gettimeofday (&micro, nullptr);
         return (double) micro.tv_usec * 1000.0;
@@ -230,7 +230,7 @@ static pointer_sized_int VSTCALLBACK audioMaster (Vst2::AEffect*, int32, int32, 
 #endif
 
 //==============================================================================
-#if JUCE_LINUX
+#if JUCE_LINUX || JUCE_BSD
 
 namespace
 {
@@ -624,7 +624,7 @@ struct ModuleHandle    : public ReferenceCountedObject
     {
         getActiveModules().add (this);
 
-       #if JUCE_WINDOWS || JUCE_LINUX || JUCE_IOS || JUCE_ANDROID
+       #if JUCE_WINDOWS || JUCE_LINUX || JUCE_BSD || JUCE_IOS || JUCE_ANDROID
         fullParentDirectoryPathName = f.getParentDirectory().getFullPathName();
        #elif JUCE_MAC
         FSRef ref;
@@ -644,7 +644,7 @@ struct ModuleHandle    : public ReferenceCountedObject
     String fullParentDirectoryPathName;
    #endif
 
-  #if JUCE_WINDOWS || JUCE_LINUX || JUCE_ANDROID
+  #if JUCE_WINDOWS || JUCE_LINUX || JUCE_BSD || JUCE_ANDROID
     DynamicLibrary module;
 
     bool open()
@@ -2110,7 +2110,7 @@ private:
     {
         if (auto* ed = getActiveEditor())
         {
-           #if JUCE_LINUX
+           #if JUCE_LINUX || JUCE_BSD
             const MessageManagerLock mmLock;
            #endif
 
@@ -2744,7 +2744,7 @@ public:
          #endif
           plugin (plug)
     {
-       #if JUCE_LINUX
+       #if JUCE_LINUX || JUCE_BSD
         pluginWindow = None;
         ignoreUnused (pluginRefusesToResize, alreadyInside);
        #elif JUCE_MAC
@@ -2829,7 +2829,7 @@ public:
     {
         if (isOpen)
         {
-           #if JUCE_LINUX
+           #if JUCE_LINUX || JUCE_BSD
             if (pluginWindow != 0)
             {
                 auto clip = g.getClipBounds();
@@ -2863,7 +2863,7 @@ public:
                 ScopedThreadDPIAwarenessSetter threadDpiAwarenessSetter { pluginHWND };
                 MoveWindow (pluginHWND, pos.getX(), pos.getY(), pos.getWidth(), pos.getHeight(), TRUE);
             }
-           #elif JUCE_LINUX
+           #elif JUCE_LINUX || JUCE_BSD
             if (pluginWindow != 0)
             {
                 X11Symbols::getInstance()->xMoveResizeWindow (display, pluginWindow,
@@ -2890,7 +2890,7 @@ public:
         if (auto* peer = getTopLevelComponent()->getPeer())
             setScaleFactorAndDispatchMessage (peer->getPlatformScaleFactor());
 
-       #if JUCE_LINUX
+       #if JUCE_LINUX || JUCE_BSD
         SafePointer<VSTPluginWindow> safeThis (this);
 
         MessageManager::callAsync ([this, safeThis]
@@ -2965,7 +2965,7 @@ public:
                 reentrantGuard = false;
             }
 
-           #if JUCE_LINUX
+           #if JUCE_LINUX || JUCE_BSD
             if (pluginWindow == 0)
             {
                 updatePluginWindowHandle();
@@ -2982,7 +2982,7 @@ public:
     {
         ignoreUnused (e);
 
-       #if JUCE_WINDOWS || JUCE_LINUX
+       #if JUCE_WINDOWS || JUCE_LINUX || JUCE_BSD
         toFront (true);
        #endif
     }
@@ -3140,7 +3140,7 @@ private:
                 }
             }
         }
-       #elif JUCE_LINUX
+       #elif JUCE_LINUX || JUCE_BSD
         updatePluginWindowHandle();
 
         int w = 250, h = 150;
@@ -3208,7 +3208,7 @@ private:
 
             originalWndProc = 0;
             pluginHWND = 0;
-           #elif JUCE_LINUX
+           #elif JUCE_LINUX || JUCE_BSD
             pluginWindow = 0;
            #endif
         }
@@ -3289,7 +3289,7 @@ private:
     }
    #endif
 
-   #if JUCE_LINUX
+   #if JUCE_LINUX || JUCE_BSD
     void updatePluginWindowHandle()
     {
         pluginWindow = getChildWindow ((Window) getWindowHandle());
@@ -3404,7 +3404,7 @@ private:
      HWND pluginHWND = {};
      void* originalWndProc = {};
      int sizeCheckCount = 0;
-    #elif JUCE_LINUX
+    #elif JUCE_LINUX || JUCE_BSD
      ::Display* display = XWindowSystem::getInstance()->getDisplay();
      Window pluginWindow = 0;
     #endif
@@ -3564,7 +3564,7 @@ bool VSTPluginFormat::fileMightContainThisPluginType (const String& fileOrIdenti
     return f.isDirectory() && f.hasFileExtension (".vst");
   #elif JUCE_WINDOWS
     return f.existsAsFile() && f.hasFileExtension (".dll");
-  #elif JUCE_LINUX || JUCE_ANDROID
+  #elif JUCE_LINUX || JUCE_BSD || JUCE_ANDROID
     return f.existsAsFile() && f.hasFileExtension (".so");
   #endif
 }
@@ -3618,7 +3618,7 @@ FileSearchPath VSTPluginFormat::getDefaultLocationsToSearch()
 {
    #if JUCE_MAC
     return FileSearchPath ("~/Library/Audio/Plug-Ins/VST;/Library/Audio/Plug-Ins/VST");
-   #elif JUCE_LINUX || JUCE_ANDROID
+   #elif JUCE_LINUX || JUCE_BSD || JUCE_ANDROID
     return FileSearchPath (SystemStats::getEnvironmentVariable ("VST_PATH",
                                                                 "/usr/lib/vst;/usr/local/lib/vst;~/.vst")
                              .replace (":", ";"));

--- a/modules/juce_audio_processors/juce_audio_processors.cpp
+++ b/modules/juce_audio_processors/juce_audio_processors.cpp
@@ -48,14 +48,14 @@
  #endif
 #endif
 
-#if (JUCE_PLUGINHOST_VST || JUCE_PLUGINHOST_VST3) && JUCE_LINUX
+#if (JUCE_PLUGINHOST_VST || JUCE_PLUGINHOST_VST3) && (JUCE_LINUX || JUCE_BSD)
  #include <X11/Xlib.h>
  #include <X11/Xutil.h>
  #include <sys/utsname.h>
  #undef KeyPress
 #endif
 
-#if ! JUCE_WINDOWS && ! JUCE_MAC && ! JUCE_LINUX
+#if ! JUCE_WINDOWS && ! JUCE_MAC && ! JUCE_LINUX && ! JUCE_BSD
  #undef JUCE_PLUGINHOST_VST3
  #define JUCE_PLUGINHOST_VST3 0
 #endif
@@ -68,7 +68,7 @@
 namespace juce
 {
 
-#if JUCE_PLUGINHOST_VST || (JUCE_PLUGINHOST_LADSPA && JUCE_LINUX)
+#if JUCE_PLUGINHOST_VST || (JUCE_PLUGINHOST_LADSPA && (JUCE_LINUX || JUCE_BSD))
 
 static bool arrayContainsPlugin (const OwnedArray<PluginDescription>& list,
                                  const PluginDescription& desc)

--- a/modules/juce_audio_processors/utilities/juce_PluginHostType.cpp
+++ b/modules/juce_audio_processors/utilities/juce_PluginHostType.cpp
@@ -290,7 +290,7 @@ PluginHostType::HostType PluginHostType::getHostType()
     if (hostFilename.containsIgnoreCase   ("AudioPluginHost"))       return JUCEPluginHost;
     if (hostFilename.containsIgnoreCase   ("Vienna Ensemble Pro"))   return ViennaEnsemblePro;
 
-   #elif JUCE_LINUX
+   #elif JUCE_LINUX || JUCE_BSD
     if (hostFilename.containsIgnoreCase   ("Ardour"))            return Ardour;
     if (hostFilename.startsWithIgnoreCase ("Waveform"))          return TracktionWaveform;
     if (hostFilename.containsIgnoreCase   ("Tracktion"))         return TracktionGeneric;

--- a/modules/juce_audio_utils/audio_cd/juce_AudioCDReader.h
+++ b/modules/juce_audio_utils/audio_cd/juce_AudioCDReader.h
@@ -166,7 +166,7 @@ private:
     AudioCDReader (void* handle);
     int getIndexAt (int samplePos);
 
-   #elif JUCE_LINUX
+   #elif JUCE_LINUX || JUCE_BSD
     AudioCDReader();
    #endif
 

--- a/modules/juce_audio_utils/juce_audio_utils.cpp
+++ b/modules/juce_audio_utils/juce_audio_utils.cpp
@@ -81,7 +81,7 @@
 #elif JUCE_ANDROID
  #include "native/juce_android_BluetoothMidiDevicePairingDialogue.cpp"
 
-#elif JUCE_LINUX
+#elif JUCE_LINUX || JUCE_BSD
  #if JUCE_USE_CDREADER
   #include "native/juce_linux_AudioCDReader.cpp"
  #endif

--- a/modules/juce_core/files/juce_File.cpp
+++ b/modules/juce_core/files/juce_File.cpp
@@ -231,7 +231,7 @@ String File::addTrailingSeparator (const String& path)
 }
 
 //==============================================================================
-#if JUCE_LINUX
+#if JUCE_LINUX || JUCE_BSD
  #define NAMES_ARE_CASE_SENSITIVE 1
 #endif
 
@@ -972,7 +972,7 @@ bool File::createSymbolicLink (const File& linkFileToCreate,
             linkFileToCreate.deleteFile();
     }
 
-   #if JUCE_MAC || JUCE_LINUX
+   #if JUCE_MAC || JUCE_LINUX || JUCE_BSD
     // one common reason for getting an error here is that the file already exists
     if (symlink (nativePathOfTarget.toRawUTF8(), linkFileToCreate.getFullPathName().toRawUTF8()) == -1)
     {

--- a/modules/juce_core/juce_core.cpp
+++ b/modules/juce_core/juce_core.cpp
@@ -64,7 +64,7 @@
  #endif
 
 #else
- #if JUCE_LINUX || JUCE_ANDROID
+ #if JUCE_LINUX || JUCE_BSD || JUCE_ANDROID
   #include <sys/types.h>
   #include <sys/socket.h>
   #include <sys/errno.h>
@@ -82,7 +82,7 @@
   #include <sys/stat.h>
  #endif
 
- #if JUCE_LINUX
+ #if JUCE_LINUX || JUCE_BSD
   #include <stdio.h>
   #include <langinfo.h>
   #include <ifaddrs.h>
@@ -218,7 +218,7 @@
  #include "native/juce_win32_Threads.cpp"
 
 //==============================================================================
-#elif JUCE_LINUX
+#elif JUCE_LINUX || JUCE_BSD
  #include "native/juce_linux_CommonFile.cpp"
  #include "native/juce_linux_Files.cpp"
  #include "native/juce_linux_Network.cpp"

--- a/modules/juce_core/native/juce_linux_Files.cpp
+++ b/modules/juce_core/native/juce_linux_Files.cpp
@@ -20,6 +20,10 @@
   ==============================================================================
 */
 
+#if defined(__FreeBSD__)
+extern char **environ;
+#endif
+
 namespace juce
 {
 

--- a/modules/juce_core/native/juce_linux_Network.cpp
+++ b/modules/juce_core/native/juce_linux_Network.cpp
@@ -25,6 +25,7 @@ namespace juce
 
 void MACAddress::findAllAddresses (Array<MACAddress>& result)
 {
+#if !defined(__FreeBSD__) // TODO implement
     auto s = socket (AF_INET, SOCK_DGRAM, 0);
 
     if (s != -1)
@@ -53,6 +54,7 @@ void MACAddress::findAllAddresses (Array<MACAddress>& result)
 
         ::close (s);
     }
+#endif
 }
 
 

--- a/modules/juce_core/native/juce_linux_SystemStats.cpp
+++ b/modules/juce_core/native/juce_linux_SystemStats.cpp
@@ -20,6 +20,10 @@
   ==============================================================================
 */
 
+#if defined(__FreeBSD__)
+#include <sys/sysinfo.h>
+#endif
+
 #if JUCE_BELA
 extern "C" int cobalt_thread_mode();
 #endif
@@ -139,8 +143,13 @@ static String getLocaleValue (nl_item key)
     return result;
 }
 
+#if JUCE_BSD
+String SystemStats::getUserLanguage()     { return String(); }
+String SystemStats::getUserRegion()       { return String(); }
+#else
 String SystemStats::getUserLanguage()     { return getLocaleValue (_NL_IDENTIFICATION_LANGUAGE); }
 String SystemStats::getUserRegion()       { return getLocaleValue (_NL_IDENTIFICATION_TERRITORY); }
+#endif
 String SystemStats::getDisplayLanguage()  { return getUserLanguage() + "-" + getUserRegion(); }
 
 //==============================================================================

--- a/modules/juce_core/native/juce_posix_SharedCode.h
+++ b/modules/juce_core/native/juce_posix_SharedCode.h
@@ -59,7 +59,7 @@ void JUCE_CALLTYPE Process::terminate()
 }
 
 
-#if JUCE_MAC || JUCE_LINUX
+#if JUCE_MAC || JUCE_LINUX || JUCE_BSD
 bool Process::setMaxNumberOfFileHandles (int newMaxNumber) noexcept
 {
     rlimit lim;
@@ -162,6 +162,9 @@ namespace
    #if JUCE_LINUX || (JUCE_IOS && ! __DARWIN_ONLY_64_BIT_INO_T) // (this iOS stuff is to avoid a simulator bug)
     using juce_statStruct = struct stat64;
     #define JUCE_STAT  stat64
+   #elif JUCE_BSD
+    using juce_statStruct = struct stat;
+    #define JUCE_STAT  stat
    #else
     using juce_statStruct = struct stat;
     #define JUCE_STAT  stat
@@ -260,7 +263,7 @@ uint64 File::getFileIdentifier() const
 
 static bool hasEffectiveRootFilePermissions()
 {
-   #if JUCE_LINUX
+   #if JUCE_LINUX || JUCE_BSD
     return geteuid() == 0;
    #else
     return false;
@@ -940,9 +943,9 @@ void JUCE_CALLTYPE Thread::setCurrentThreadName (const String& name)
     {
         [[NSThread currentThread] setName: juceStringToNS (name)];
     }
-   #elif JUCE_LINUX || JUCE_ANDROID
+   #elif JUCE_LINUX || JUCE_BSD || JUCE_ANDROID
     #if ((JUCE_LINUX && (__GLIBC__ * 1000 + __GLIBC_MINOR__) >= 2012) \
-          || JUCE_ANDROID && __ANDROID_API__ >= 9)
+          || JUCE_ANDROID && __ANDROID_API__ >= 9) || JUCE_BSD
      pthread_setname_np (pthread_self(), name.toRawUTF8());
     #else
      prctl (PR_SET_NAME, name.toRawUTF8(), 0, 0, 0);
@@ -1000,7 +1003,7 @@ void JUCE_CALLTYPE Thread::setCurrentThreadAffinityMask (uint32 affinityMask)
         if ((affinityMask & (uint32) (1 << i)) != 0)
             CPU_SET ((size_t) i, &affinity);
 
-   #if (! JUCE_ANDROID) && ((! JUCE_LINUX) || ((__GLIBC__ * 1000 + __GLIBC_MINOR__) >= 2004))
+   #if (! JUCE_ANDROID) && ((! (JUCE_LINUX || JUCE_BSD)) || ((__GLIBC__ * 1000 + __GLIBC_MINOR__) >= 2004))
     pthread_setaffinity_np (pthread_self(), sizeof (cpu_set_t), &affinity);
    #elif JUCE_ANDROID
     sched_setaffinity (gettid(), sizeof (cpu_set_t), &affinity);
@@ -1045,7 +1048,7 @@ void* DynamicLibrary::getFunction (const String& functionName) noexcept
 }
 
 //==============================================================================
-#if JUCE_LINUX || JUCE_ANDROID
+#if JUCE_LINUX || JUCE_BSD || JUCE_ANDROID
 static String readPosixConfigFileValue (const char* file, const char* key)
 {
     StringArray lines;

--- a/modules/juce_core/network/juce_Socket.cpp
+++ b/modules/juce_core/network/juce_Socket.cpp
@@ -132,7 +132,7 @@ namespace SocketHelpers
                 // a chance to process before close is called. On Mac OS X shutdown
                 // does not unblock a select call, so using a lock here will dead-lock
                 // both threads.
-               #if JUCE_LINUX || JUCE_ANDROID
+               #if JUCE_LINUX || JUCE_BSD || JUCE_ANDROID
                 CriticalSection::ScopedLockType lock (readLock);
                 ::close (h);
                #else
@@ -780,7 +780,7 @@ bool DatagramSocket::setEnablePortReuse (bool enabled)
    #else
     if (handle >= 0)
         return SocketHelpers::setOption ((SocketHandle) handle.load(),
-                                        #if JUCE_WINDOWS || JUCE_LINUX
+                                        #if JUCE_WINDOWS || JUCE_LINUX || JUCE_BSD
                                          SO_REUSEADDR,  // port re-use is implied by addr re-use on these platforms
                                         #else
                                          SO_REUSEPORT,

--- a/modules/juce_core/system/juce_PlatformDefs.h
+++ b/modules/juce_core/system/juce_PlatformDefs.h
@@ -59,7 +59,7 @@ namespace juce
 #endif
 
 //==============================================================================
-#if JUCE_IOS || (JUCE_MAC && JUCE_ARM) || JUCE_LINUX
+#if JUCE_IOS || (JUCE_MAC && JUCE_ARM) || (JUCE_LINUX || JUCE_BSD)
   /** This will try to break into the debugger if the app is currently being debugged.
       If called by an app that's not being debugged, the behaviour isn't defined - it may
       crash or not, depending on the platform.

--- a/modules/juce_core/system/juce_StandardHeader.h
+++ b/modules/juce_core/system/juce_StandardHeader.h
@@ -83,7 +83,7 @@ JUCE_BEGIN_IGNORE_WARNINGS_MSVC (4514 4245 4100)
  #include <signal.h>
 #endif
 
-#if JUCE_LINUX
+#if JUCE_LINUX || JUCE_BSD
  #include <cstring>
  #include <signal.h>
 

--- a/modules/juce_core/system/juce_TargetPlatform.h
+++ b/modules/juce_core/system/juce_TargetPlatform.h
@@ -154,7 +154,7 @@
 #endif
 
 //==============================================================================
-#if JUCE_LINUX || JUCE_ANDROID
+#if JUCE_LINUX || JUCE_BSD || JUCE_ANDROID
 
   #ifdef _DEBUG
     #define JUCE_DEBUG 1

--- a/modules/juce_core/text/juce_CharPointer_ASCII.h
+++ b/modules/juce_core/text/juce_CharPointer_ASCII.h
@@ -335,7 +335,7 @@ public:
     /** Parses this string as a 64-bit integer. */
     int64 getIntValue64() const noexcept
     {
-       #if JUCE_LINUX || JUCE_ANDROID || JUCE_MINGW
+       #if JUCE_LINUX || JUCE_BSD || JUCE_ANDROID || JUCE_MINGW
         return atoll (data);
        #elif JUCE_WINDOWS
         return _atoi64 (data);

--- a/modules/juce_core/threads/juce_ChildProcess.cpp
+++ b/modules/juce_core/threads/juce_ChildProcess.cpp
@@ -96,7 +96,7 @@ public:
     {
         beginTest ("Child Processes");
 
-      #if JUCE_WINDOWS || JUCE_MAC || JUCE_LINUX
+      #if JUCE_WINDOWS || JUCE_MAC || JUCE_LINUX || JUCE_BSD
         ChildProcess p;
 
        #if JUCE_WINDOWS

--- a/modules/juce_core/threads/juce_Process.h
+++ b/modules/juce_core/threads/juce_Process.h
@@ -139,7 +139,7 @@ public:
     static void setDockIconVisible (bool isVisible);
    #endif
 
-   #if JUCE_MAC || JUCE_LINUX || DOXYGEN
+   #if JUCE_MAC || JUCE_LINUX || JUCE_BSD || DOXYGEN
     //==============================================================================
     /** UNIX ONLY - Attempts to use setrlimit to change the maximum number of file
         handles that the app can open. Pass 0 or less as the parameter to mean

--- a/modules/juce_data_structures/app_properties/juce_PropertiesFile.cpp
+++ b/modules/juce_data_structures/app_properties/juce_PropertiesFile.cpp
@@ -89,7 +89,7 @@ File PropertiesFile::Options::getDefaultFile() const
     if (folderName.isNotEmpty())
         dir = dir.getChildFile (folderName);
 
-   #elif JUCE_LINUX || JUCE_ANDROID
+   #elif JUCE_LINUX || JUCE_BSD || JUCE_ANDROID
     auto dir = File (commonToAllUsers ? "/var" : "~")
                       .getChildFile (folderName.isNotEmpty() ? folderName
                                                              : ("." + applicationName));

--- a/modules/juce_events/juce_events.cpp
+++ b/modules/juce_events/juce_events.cpp
@@ -49,7 +49,7 @@
  #import <IOKit/hid/IOHIDKeys.h>
  #import <IOKit/pwr_mgt/IOPMLib.h>
 
-#elif JUCE_LINUX
+#elif JUCE_LINUX || JUCE_BSD
  #include <unistd.h>
 #endif
 
@@ -85,7 +85,7 @@
   #include "native/juce_win32_WinRTWrapper.cpp"
  #endif
 
-#elif JUCE_LINUX
+#elif JUCE_LINUX || JUCE_BSD
  #include "native/juce_linux_Messaging.cpp"
 
 #elif JUCE_ANDROID

--- a/modules/juce_events/juce_events.h
+++ b/modules/juce_events/juce_events.h
@@ -90,7 +90,7 @@
 #include "interprocess/juce_ConnectedChildProcess.h"
 #include "interprocess/juce_NetworkServiceDiscovery.h"
 
-#if JUCE_LINUX
+#if JUCE_LINUX || JUCE_BSD
  #include "native/juce_linux_EventLoop.h"
 #endif
 

--- a/modules/juce_events/messages/juce_ApplicationBase.cpp
+++ b/modules/juce_events/messages/juce_ApplicationBase.cpp
@@ -183,7 +183,7 @@ StringArray JUCE_CALLTYPE JUCEApplicationBase::getCommandLineParameterArray()
  extern void initialiseNSApplication();
 #endif
 
-#if JUCE_LINUX && JUCE_MODULE_AVAILABLE_juce_gui_extra && (! defined(JUCE_WEB_BROWSER) || JUCE_WEB_BROWSER)
+#if (JUCE_LINUX || JUCE_BSD) && JUCE_MODULE_AVAILABLE_juce_gui_extra && (! defined(JUCE_WEB_BROWSER) || JUCE_WEB_BROWSER)
  extern int juce_gtkWebkitMain (int argc, const char* argv[]);
 #endif
 
@@ -228,7 +228,7 @@ int JUCEApplicationBase::main (int argc, const char* argv[])
         initialiseNSApplication();
        #endif
 
-       #if JUCE_LINUX && JUCE_MODULE_AVAILABLE_juce_gui_extra && (! defined(JUCE_WEB_BROWSER) || JUCE_WEB_BROWSER)
+       #if (JUCE_LINUX || JUCE_BSD) && JUCE_MODULE_AVAILABLE_juce_gui_extra && (! defined(JUCE_WEB_BROWSER) || JUCE_WEB_BROWSER)
         if (argc >= 2 && String (argv[1]) == "--juce-gtkwebkitfork-child")
             return juce_gtkWebkitMain (argc, argv);
        #endif

--- a/modules/juce_graphics/images/juce_Image.cpp
+++ b/modules/juce_graphics/images/juce_Image.cpp
@@ -144,7 +144,7 @@ int NativeImageType::getTypeID() const
     return 1;
 }
 
-#if JUCE_WINDOWS || JUCE_LINUX
+#if JUCE_WINDOWS || JUCE_LINUX || JUCE_BSD
 ImagePixelData::Ptr NativeImageType::create (Image::PixelFormat format, int width, int height, bool clearImage) const
 {
     return new SoftwarePixelData (format, width, height, clearImage);

--- a/modules/juce_graphics/juce_graphics.cpp
+++ b/modules/juce_graphics/juce_graphics.cpp
@@ -75,7 +75,7 @@
  #import <QuartzCore/QuartzCore.h>
  #import <CoreText/CoreText.h>
 
-#elif JUCE_LINUX
+#elif JUCE_LINUX || JUCE_BSD
  #ifndef JUCE_USE_FREETYPE
   #define JUCE_USE_FREETYPE 1
  #endif
@@ -147,7 +147,7 @@
   #include "native/juce_win32_Direct2DGraphicsContext.cpp"
  #endif
 
-#elif JUCE_LINUX
+#elif JUCE_LINUX || JUCE_BSD
  #include "native/juce_linux_Fonts.cpp"
  #include "native/juce_linux_IconHelpers.cpp"
 

--- a/modules/juce_gui_basics/components/juce_Component.cpp
+++ b/modules/juce_gui_basics/components/juce_Component.cpp
@@ -626,7 +626,7 @@ void Component::addToDesktop (int styleWanted, void* nativeWindowToAttachTo)
     {
         const WeakReference<Component> safePointer (this);
 
-       #if JUCE_LINUX
+       #if JUCE_LINUX || JUCE_BSD
         // it's wise to give the component a non-zero size before
         // putting it on the desktop, as X windows get confused by this, and
         // a (1, 1) minimum size is enforced here.

--- a/modules/juce_gui_basics/filebrowser/juce_FileBrowserComponent.cpp
+++ b/modules/juce_gui_basics/filebrowser/juce_FileBrowserComponent.cpp
@@ -441,7 +441,7 @@ void FileBrowserComponent::browserRootChanged (const File&) {}
 
 bool FileBrowserComponent::keyPressed (const KeyPress& key)
 {
-   #if JUCE_LINUX || JUCE_WINDOWS
+   #if JUCE_LINUX || JUCE_BSD || JUCE_WINDOWS
     if (key.getModifiers().isCommandDown()
          && (key.getKeyCode() == 'H' || key.getKeyCode() == 'h'))
     {

--- a/modules/juce_gui_basics/juce_gui_basics.cpp
+++ b/modules/juce_gui_basics/juce_gui_basics.cpp
@@ -253,7 +253,7 @@ namespace juce
  #include "native/juce_win32_DragAndDrop.cpp"
  #include "native/juce_win32_FileChooser.cpp"
 
-#elif JUCE_LINUX
+#elif JUCE_LINUX || JUCE_BSD
  #include "native/x11/juce_linux_X11_Symbols.cpp"
  #include "native/x11/juce_linux_X11_DragAndDrop.cpp"
 

--- a/modules/juce_gui_basics/juce_gui_basics.h
+++ b/modules/juce_gui_basics/juce_gui_basics.h
@@ -294,7 +294,7 @@ namespace juce
 #include "lookandfeel/juce_LookAndFeel_V4.h"
 #include "mouse/juce_LassoComponent.h"
 
-#if JUCE_LINUX
+#if JUCE_LINUX || JUCE_BSD
  #if JUCE_GUI_BASICS_INCLUDE_XHEADERS
   // If you're missing these headers, you need to install the libx11-dev package
   #include <X11/Xlib.h>

--- a/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel.cpp
+++ b/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel.cpp
@@ -182,7 +182,7 @@ void LookAndFeel::setUsingNativeAlertWindows (bool shouldUseNativeAlerts)
 
 bool LookAndFeel::isUsingNativeAlertWindows()
 {
-   #if JUCE_LINUX
+   #if JUCE_LINUX || JUCE_BSD
     return false; // not available currently..
    #else
     return useNativeAlertWindows;

--- a/modules/juce_gui_basics/windows/juce_AlertWindow.cpp
+++ b/modules/juce_gui_basics/windows/juce_AlertWindow.cpp
@@ -28,7 +28,7 @@ namespace juce
 
 static juce_wchar getDefaultPasswordChar() noexcept
 {
-   #if JUCE_LINUX
+   #if JUCE_LINUX || JUCE_BSD
     return 0x2022;
    #else
     return 0x25cf;

--- a/modules/juce_gui_extra/embedding/juce_XEmbedComponent.h
+++ b/modules/juce_gui_extra/embedding/juce_XEmbedComponent.h
@@ -31,7 +31,7 @@ bool juce_handleXEmbedEvent (ComponentPeer*, void*);
 /** @internal */
 unsigned long juce_getCurrentFocusWindow (ComponentPeer*);
 
-#if JUCE_LINUX || DOXYGEN
+#if JUCE_LINUX || JUCE_BSD || DOXYGEN
 
 //==============================================================================
 /**

--- a/modules/juce_gui_extra/juce_gui_extra.cpp
+++ b/modules/juce_gui_extra/juce_gui_extra.cpp
@@ -109,7 +109,7 @@
  #endif
 
 //==============================================================================
-#elif JUCE_LINUX && JUCE_WEB_BROWSER
+#elif (JUCE_LINUX || JUCE_BSD) && JUCE_WEB_BROWSER
  JUCE_BEGIN_IGNORE_WARNINGS_GCC_LIKE ("-Wzero-as-null-pointer-constant", "-Wparentheses")
 
  // If you're missing this header, you need to install the webkit2gtk-4.0 package
@@ -168,7 +168,7 @@
  #include "native/juce_win32_SystemTrayIcon.cpp"
 
 //==============================================================================
-#elif JUCE_LINUX
+#elif JUCE_LINUX || JUCE_BSD
  JUCE_BEGIN_IGNORE_WARNINGS_GCC_LIKE ("-Wzero-as-null-pointer-constant")
 
  #include "native/juce_linux_XEmbedComponent.cpp"

--- a/modules/juce_gui_extra/misc/juce_SystemTrayIconComponent.cpp
+++ b/modules/juce_gui_extra/misc/juce_SystemTrayIconComponent.cpp
@@ -26,7 +26,7 @@
 namespace juce
 {
 
-#if JUCE_WINDOWS || JUCE_LINUX || JUCE_MAC
+#if JUCE_WINDOWS || JUCE_LINUX || JUCE_BSD || JUCE_MAC
 
 SystemTrayIconComponent::SystemTrayIconComponent()
 {

--- a/modules/juce_gui_extra/misc/juce_SystemTrayIconComponent.h
+++ b/modules/juce_gui_extra/misc/juce_SystemTrayIconComponent.h
@@ -26,7 +26,7 @@
 namespace juce
 {
 
-#if JUCE_WINDOWS || JUCE_LINUX || JUCE_MAC || DOXYGEN
+#if JUCE_WINDOWS || JUCE_LINUX || JUCE_BSD || JUCE_MAC || DOXYGEN
 
 
 //==============================================================================
@@ -91,7 +91,7 @@ public:
     */
     void* getNativeHandle() const;
 
-   #if JUCE_LINUX
+   #if JUCE_LINUX || JUCE_BSD
     /** @internal */
     void paint (Graphics&) override;
    #endif

--- a/modules/juce_opengl/juce_opengl.cpp
+++ b/modules/juce_opengl/juce_opengl.cpp
@@ -54,7 +54,7 @@
  #endif
 
 //==============================================================================
-#elif JUCE_LINUX
+#elif JUCE_LINUX || JUCE_BSD
  /* Got an include error here?
 
     If you want to install OpenGL support, the packages to get are "mesa-common-dev"
@@ -91,7 +91,7 @@ namespace juce
 
 void OpenGLExtensionFunctions::initialise()
 {
-   #if JUCE_WINDOWS || JUCE_LINUX
+   #if JUCE_WINDOWS || JUCE_LINUX || JUCE_BSD
     #define JUCE_INIT_GL_FUNCTION(name, returnType, params, callparams) \
         name = (type_ ## name) OpenGLHelpers::getExtensionFunction (#name);
 
@@ -273,7 +273,7 @@ private:
 #elif JUCE_WINDOWS
  #include "native/juce_OpenGL_win32.h"
 
-#elif JUCE_LINUX
+#elif JUCE_LINUX || JUCE_BSD
  #include "native/juce_OpenGL_linux_X11.h"
 
 #elif JUCE_ANDROID

--- a/modules/juce_opengl/juce_opengl.h
+++ b/modules/juce_opengl/juce_opengl.h
@@ -88,7 +88,7 @@
   #undef APIENTRY
   #undef CLEAR_TEMP_APIENTRY
  #endif
-#elif JUCE_LINUX
+#elif JUCE_LINUX || JUCE_BSD
  #include <GL/gl.h>
  #undef KeyPress
 #elif JUCE_IOS

--- a/modules/juce_opengl/native/juce_OpenGLExtensions.h
+++ b/modules/juce_opengl/native/juce_OpenGLExtensions.h
@@ -119,7 +119,7 @@ struct OpenGLExtensionFunctions
     #endif
 
     //==============================================================================
-   #elif JUCE_LINUX
+   #elif JUCE_LINUX || JUCE_BSD
     #define JUCE_DECLARE_GL_FUNCTION(name, returnType, params, callparams)      typedef returnType (*type_ ## name) params; type_ ## name name;
     JUCE_GL_BASE_FUNCTIONS (JUCE_DECLARE_GL_FUNCTION)
     JUCE_GL_EXTENSION_FUNCTIONS (JUCE_DECLARE_GL_FUNCTION)

--- a/modules/juce_opengl/opengl/juce_OpenGLFrameBuffer.cpp
+++ b/modules/juce_opengl/opengl/juce_OpenGLFrameBuffer.cpp
@@ -39,7 +39,7 @@ public:
         // context. You'll need to create this object in one of the OpenGLContext's callbacks.
         jassert (OpenGLHelpers::isContextActive());
 
-       #if JUCE_WINDOWS || JUCE_LINUX
+       #if JUCE_WINDOWS || JUCE_LINUX || JUCE_BSD
         if (context.extensions.glGenFramebuffers == nullptr)
             return;
        #endif

--- a/modules/juce_opengl/opengl/juce_OpenGLHelpers.cpp
+++ b/modules/juce_opengl/opengl/juce_OpenGLHelpers.cpp
@@ -35,7 +35,7 @@ void* OpenGLHelpers::getExtensionFunction (const char* functionName)
 {
    #if JUCE_WINDOWS
     return (void*) wglGetProcAddress (functionName);
-   #elif JUCE_LINUX
+   #elif JUCE_LINUX || JUCE_BSD
     return (void*) glXGetProcAddress ((const GLubyte*) functionName);
    #else
     static void* handle = dlopen (nullptr, RTLD_LAZY);

--- a/modules/juce_product_unlocking/marketplace/juce_OnlineUnlockForm.cpp
+++ b/modules/juce_product_unlocking/marketplace/juce_OnlineUnlockForm.cpp
@@ -151,7 +151,7 @@ struct OnlineUnlockForm::OverlayComp  : public Component,
 
 static juce_wchar getDefaultPasswordChar() noexcept
 {
-   #if JUCE_LINUX
+   #if JUCE_LINUX || JUCE_BSD
     return 0x2022;
    #else
     return 0x25cf;

--- a/modules/juce_product_unlocking/marketplace/juce_OnlineUnlockStatus.cpp
+++ b/modules/juce_product_unlocking/marketplace/juce_OnlineUnlockStatus.cpp
@@ -280,6 +280,8 @@ char OnlineUnlockStatus::MachineIDUtilities::getPlatformPrefix()
     return 'W';
    #elif JUCE_LINUX
     return 'L';
+   #elif JUCE_BSD
+    return 'B';
    #elif JUCE_IOS
     return 'I';
    #elif JUCE_ANDROID

--- a/modules/juce_video/playback/juce_VideoComponent.cpp
+++ b/modules/juce_video/playback/juce_VideoComponent.cpp
@@ -26,7 +26,7 @@
 namespace juce
 {
 
-#if ! (JUCE_LINUX || JUCE_PROJUCER_LIVE_BUILD)
+#if ! (JUCE_LINUX || JUCE_BSD || JUCE_PROJUCER_LIVE_BUILD)
 
 #if JUCE_MAC || JUCE_IOS
  #include "../native/juce_mac_Video.h"


### PR DESCRIPTION
This is a set of patches that make JUCE build on FreeBSD. Other BSDs should be similar.

On FreeBSD JUCE builds and seems to run fine with these patches.

The purpose of this PR is not to ask for BSD platforms to be officially supported, but to make building JUCE easier on BSD systems.
