### PR TITLE
Add option to build modules as static/shared libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,15 @@ if(JUCE_BUILD_EXAMPLES)
     add_subdirectory(examples)
 endif()
 
+# Normally JUCE creates modules as INTERFACE targets.
+# By turning this option on modules will instead be built as libraries.
+# CMake will create static or shared libs depending on BUILD_SHARED_LIBS.
+
+option(JUCE_BUILD_LIBRARIES
+    "Enable to build libraries (static or shared) of modules instead of source interface targets"
+    OFF
+)
+
 # ==================================================================================================
 # Install configuration
 

--- a/extras/Build/CMake/JUCEUtils.cmake
+++ b/extras/Build/CMake/JUCEUtils.cmake
@@ -82,13 +82,6 @@ set_property(GLOBAL PROPERTY JUCE_COPY_PLUGIN_AFTER_BUILD FALSE)
 
 # ==================================================================================================
 
-function(_juce_add_interface_library target)
-    add_library(${target} INTERFACE)
-    target_sources(${target} INTERFACE ${ARGN})
-endfunction()
-
-# ==================================================================================================
-
 function(_juce_create_pkgconfig_target name)
     if(TARGET juce::pkgconfig_${name})
         return()
@@ -457,7 +450,9 @@ function(_juce_add_plugin_wrapper_target format path out_path)
     list(FILTER out_var EXCLUDE REGEX "/juce_audio_plugin_client_utils.cpp$")
     set(target_name juce_audio_plugin_client_${format})
 
-    _juce_add_interface_library("${target_name}" ${out_var})
+    add_library("${target_name}" INTERFACE)
+    target_sources("${target_name}" INTERFACE ${out_var})
+
     _juce_add_plugin_definitions("${target_name}" INTERFACE ${format})
     _juce_add_standard_defs("${target_name}")
 
@@ -535,7 +530,8 @@ function(juce_add_module module_path)
         list(APPEND all_module_sources ${globbed_sources})
     endif()
 
-    _juce_add_interface_library(${module_name} ${all_module_sources})
+    add_library(${module_name} INTERFACE)
+    target_sources(${module_name} INTERFACE ${all_module_sources})
 
     set_property(GLOBAL APPEND PROPERTY _juce_module_names ${module_name})
 

--- a/extras/Build/CMake/JUCEUtils.cmake
+++ b/extras/Build/CMake/JUCEUtils.cmake
@@ -657,7 +657,12 @@ function(juce_add_module module_path)
     endif()
 
     if(JUCE_ARG_INSTALL_PATH)
-        install(DIRECTORY "${module_path}" DESTINATION "${JUCE_ARG_INSTALL_PATH}")
+        if(JUCE_BUILD_LIBRARIES)
+            install(TARGETS ${module_name})
+            install(DIRECTORY "${module_path}" DESTINATION include FILES_MATCHING PATTERN "*.h*")
+        else()
+            install(DIRECTORY "${module_path}" DESTINATION "${JUCE_ARG_INSTALL_PATH}")
+        endif()
     endif()
 
     if(JUCE_ARG_ALIAS_NAMESPACE)


### PR DESCRIPTION
I'm working on a Conan package manager recipe for JUCE https://github.com/conan-io/conan-center-index/compare/master...DiracResearch:new/juce.
Still very much work in progress :)

One of the first things I ran into was that JUCE doesn't really build libraries.
I started implementing a work-around in the Conan recipe based on the same approach as:
https://forum.juce.com/t/using-cmake-flow-to-build-libraries-android-apps/40492/2.
But then I though that it would be much better if JUCE had an option to build libs,
others might benefit from this also.

This PR contains one approach to enable this. I would like to get some feedback if you think
this is a way forward or if you think this should be handled in the Conan recipe instead?

