### PR TITLE
case of the flag JUCE_USE_XRENDER set  received  a compilation error

### DIFF
--- a/modules/juce_gui_basics/native/x11/juce_linux_XWindowSystem.cpp
+++ b/modules/juce_gui_basics/native/x11/juce_linux_XWindowSystem.cpp
@@ -628,13 +628,13 @@ namespace Visuals
                         {
                             for (int i = 0; i < numVisuals; ++i)
                             {
-                                auto pictVisualFormat = X11Symbols::getInstance()->xRenderFindVisualFormat (display, xvinfos[i].visual);
+                                auto pictVisualFormat = X11Symbols::getInstance()->xRenderFindVisualFormat (display, xvinfos.get()[i].visual);
 
                                 if (pictVisualFormat != nullptr
                                      && pictVisualFormat->type == PictTypeDirect
                                      && pictVisualFormat->direct.alphaMask)
                                 {
-                                    visual = xvinfos[i].visual;
+                                    visual = xvinfos.get()[i].visual;
                                     matchedDepth = 32;
                                     break;
                                 }


### PR DESCRIPTION
JUCE/modules/juce_gui_basics/native/x11/juce_linux_XWindowSystem.cpp:631:125: error: no match for ‘operator[]’ (operand types are ‘std::unique_ptr<XVisualInfo, juce::{anonymous}::XFreeDeleter>’ and ‘int’)
  631 |                          auto pictVisualFormat = X11Symbols::getInstance()->xRenderFindVisualFormat (display, xvinfos[i]->visual);