### PR TITLE
Paste from the correct X11 selection

### DIFF
--- a/modules/juce_gui_basics/native/x11/juce_linux_XWindowSystem.cpp
+++ b/modules/juce_gui_basics/native/x11/juce_linux_XWindowSystem.cpp
@@ -2605,12 +2605,12 @@ String XWindowSystem::getTextFromClipboard() const
        2) and then try to read from "PRIMARY" selection (the "legacy" selection
        filled by good old x11 apps such as xterm)
     */
-    auto selection = XA_PRIMARY;
+    auto selection = atoms.clipboard;
     Window selectionOwner = None;
 
     if ((selectionOwner = X11Symbols::getInstance()->xGetSelectionOwner (display, selection)) == None)
     {
-        selection = atoms.clipboard;
+        selection = XA_PRIMARY;
         selectionOwner = X11Symbols::getInstance()->xGetSelectionOwner (display, selection);
     }
 


### PR DESCRIPTION
Pasting text on Linux in JUCE plugins and applications has never worked correctly. Pasting would always be done from the `PRIMARY` selection instead of the `CLIPBOARD` selection, even if the comment right this did say that pasting should always be done from the `CLIPBOARD` selection like one would expect. This would cause issues when trying to paste passwords from a password manager, or when trying to paste serial numbers from websites copied using a copy button (i.e. without selecting the entire serial number first).

https://forum.juce.com/t/juce-uses-the-wrong-x11-selection-for-pasting/45330