### PR TITLE
Adding 0 elements to an empty array resulted in undefined behaviour

### DIFF
--- a/modules/juce_core/containers/juce_ArrayBase.h
+++ b/modules/juce_core/containers/juce_ArrayBase.h
@@ -402,7 +402,8 @@ private:
     template <typename T = ElementType>
     TriviallyCopyableVoid<T> addArrayInternal (const ElementType* otherElements, int numElements)
     {
-        memcpy (elements + numUsed, otherElements, (size_t) numElements * sizeof (ElementType));
+        if (numElements > 0)
+            memcpy (elements + numUsed, otherElements, (size_t) numElements * sizeof (ElementType));
     }
 
     template <typename Type, typename T = ElementType>


### PR DESCRIPTION
If the array is empty and you're pushing zero elements, no pointer is
allocated (because it's not needed), but then a nullptr is given to
memcpy, which is explicitly defined as UB in the standard.