### PR TITLE
juce_events/WinRTWrapper: Fix crash on WinRTWrapper re-initialization

### DIFF
--- a/modules/juce_events/native/juce_win32_WinRTWrapper.h
+++ b/modules/juce_events/native/juce_win32_WinRTWrapper.h
@@ -30,7 +30,7 @@ public:
     ~WinRTWrapper();
     bool isInitialised() const noexcept  { return initialised; }
 
-    JUCE_DECLARE_SINGLETON (WinRTWrapper, true)
+    JUCE_DECLARE_SINGLETON (WinRTWrapper, false)
 
     //==============================================================================
     template <class ComClass>


### PR DESCRIPTION
Fix crash when host closes and re-opens plugins (e.g. VST2: Reaper, AAX: ProTools).
@tpoole : Most changes in this area point towards your name. Do you recall why re-initialization was not allowed in the first place?