### PR TITLE
Support for 29.97, 29.97df, 60, and 60df in VST3

### DIFF
--- a/modules/juce_audio_plugin_client/VST3/juce_VST3_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/VST3/juce_VST3_Wrapper.cpp
@@ -2573,14 +2573,38 @@ public:
                 case 30:
                 {
                     if ((processContext.frameRate.flags & Vst::FrameRate::kDropRate) != 0)
-                        info.frameRate = AudioPlayHead::fps30drop;
+                    {
+                        if ((processContext.frameRate.flags & Vst::FrameRate::kPullDownRate) != 0)
+                            info.frameRate = AudioPlayHead::fps2997drop;
+                        else
+                            info.frameRate = AudioPlayHead::fps30drop;
+                    }
                     else
-                        info.frameRate = AudioPlayHead::fps30;
+                    {
+                        if ((processContext.frameRate.flags & Vst::FrameRate::kPullDownRate) != 0)
+                            info.frameRate = AudioPlayHead::fps2997;
+                        else
+                            info.frameRate = AudioPlayHead::fps30;
+                    }
+                }
+                break;
+                    
+                case 60:
+                {
+                    if ((processContext.frameRate.flags & Vst::FrameRate::kDropRate) != 0)
+                        info.frameRate = AudioPlayHead::fps60drop;
+                    else
+                        info.frameRate = AudioPlayHead::fps60;
                 }
                 break;
 
                 default: break;
             }
+
+            double fps = static_cast<double>(processContext.frameRate.framesPerSecond);
+            if ((processContext.frameRate.flags & Vst::FrameRate::kPullDownRate) != 0)
+                fps *= 1000.0 / 1001.0;
+            info.editOriginTime = processContext.smpteOffsetSubframes / (80.0 * fps);
         }
 
         return true;


### PR DESCRIPTION
Based on some of the logic that exists in VST/juce_VST_Wrapper.cpp, this commit adds proper support for the following framerates:
- 29.97
- 29.97df
- 60
- 60df
In addition, this commit adds support for the info.editOriginTime member variable.