### PR TITLE
juce::Colour HSL support: Skip unnecessary calculations, avoid division by zero

### DIFF
--- a/modules/juce_graphics/colour/juce_Colour.cpp
+++ b/modules/juce_graphics/colour/juce_Colour.cpp
@@ -86,8 +86,9 @@ namespace ColourHelpers
 
                 if (lightness > 0.0f)
                     hue = getHue (col);
-
-                saturation = ((float) (hi - lo) / 255.0f) / (1.0f - std::abs ((2.0f * lightness) - 1.0f));
+    
+                if (!approximatelyEqual(hi, lo))
+                    saturation = ((float) (hi - lo) / 255.0f) / (1.0f - std::abs ((2.0f * lightness) - 1.0f));
             }
         }
 

--- a/modules/juce_graphics/colour/juce_Colour.cpp
+++ b/modules/juce_graphics/colour/juce_Colour.cpp
@@ -42,6 +42,9 @@ namespace ColourHelpers
         auto hi = jmax (r, g, b);
         auto lo = jmin (r, g, b);
 
+        if (approximatelyEqual(hi, lo))
+            return 0;
+
         float hue = 0.0f;
 
         if (hi > 0)


### PR DESCRIPTION
Fixes the hue/saturation conversion code to skip further calculations if `min(r,g,b) == max(r,g,b)`, since hue (and saturation) is always zero in that case. This also avoids a division by zero due to `invDiff = hi - lo = 0` for e.g. plain white.