### PR TITLE
Prevent unused variable warning using jassert in release

### DIFF
--- a/modules/juce_core/system/juce_PlatformDefs.h
+++ b/modules/juce_core/system/juce_PlatformDefs.h
@@ -171,7 +171,7 @@ namespace juce
   #if JUCE_LOG_ASSERTIONS
    #define jassert(expression)      JUCE_BLOCK_WITH_FORCED_SEMICOLON (if (! (expression)) jassertfalse;)
   #else
-   #define jassert(expression)      JUCE_BLOCK_WITH_FORCED_SEMICOLON ( ; )
+   #define jassert(expression)      JUCE_BLOCK_WITH_FORCED_SEMICOLON ( [[maybe_unused]] constexpr bool jassert_unused = false && (expression); )
   #endif
 
 #endif


### PR DESCRIPTION
When a variable is declared and then only used inside a `jassert`
statement, the compiler rightfully complains about the variable being
unused when building in release mode - since in that case `jassert`
doesn't do anything.

This change will "use" the variable even in that case, but careful use
of constexpr and short-circuiting ensures the expression is never
actually executed, which is important to avoid both performance issues
when the thing being asserted is a heavy expression (which you only do
in debug) or when the expression itself has side-effects.

See https://forum.juce.com/t/make-jassert-use-ignoreunused-internally/36728 for discussion