### PR TITLE
Add missing VST3 poly aftertouch support

### DIFF
--- a/modules/juce_audio_processors/format_types/juce_VST3Common.h
+++ b/modules/juce_audio_processors/format_types/juce_VST3Common.h
@@ -957,6 +957,12 @@ private:
             return true;
         }
 
+        if (msg.isAftertouch())
+        {
+            result = { Steinberg::Vst::kCtrlPolyPressure, msg.getAfterTouchValue() / 127.0};
+            return true;
+        }
+
         result.controllerNumber = -1;
         return false;
     }


### PR DESCRIPTION
Initially reported at https://github.com/falkTX/Carla/issues/1386
Issue (missing aftertouch) confirmed fixed after this change.
