### PR TITLE
Add default return value for Component::exitModalState to prevent the need to pass an unused argument.

### DIFF
--- a/modules/juce_gui_basics/components/juce_Component.h
+++ b/modules/juce_gui_basics/components/juce_Component.h
@@ -2081,7 +2081,7 @@ public:
 
         @see runModalLoop, enterModalState, isCurrentlyModal
     */
-    void exitModalState (int returnValue);
+    void exitModalState (int returnValue = 0);
 
     /** Returns true if this component is the modal one.
 


### PR DESCRIPTION
When using `exitModalState()` after having called `enterModalState()` on a component, the argument passed to `exitModalState()` is unused. By providing a default return value, we're left with a neat `enter`/`exit` pair of methods.

```cpp
comp.enterModalState();
// ...
comp.exitModalState (0); // Unused magic number - bad!
```

```cpp
comp.enterModalState();
// ...
comp.exitModalState(); // No magic numbers - good!
```