### PR TITLE
Change log file directory for linux

### DIFF
--- a/modules/juce_core/logging/juce_FileLogger.cpp
+++ b/modules/juce_core/logging/juce_FileLogger.cpp
@@ -103,6 +103,12 @@ File FileLogger::getSystemLogFileFolder()
 {
    #if JUCE_MAC
     return File ("~/Library/Logs");
+   #elif JUCE_LINUX
+    const char* state = getenv("XDG_STATE_HOME");
+    if (state != nullptr)
+        return File (state);
+    else
+        return File ("~/.local/state");
    #else
     return File::getSpecialLocation (File::userApplicationDataDirectory);
    #endif


### PR DESCRIPTION
According to the specification at https://specifications.freedesktop.org/basedir-spec/1.8/ar01s03.html
XDG_STATE_HOME should be used for "actions history", which includes logs.