### PR TITLE
Allow custom compiler for juceaide bootstrapping

### DIFF
--- a/extras/Build/juceaide/CMakeLists.txt
+++ b/extras/Build/juceaide/CMakeLists.txt
@@ -67,6 +67,8 @@ else()
             "-DCMAKE_BUILD_TYPE=Debug"
             "-DJUCE_BUILD_HELPER_TOOLS=ON"
             "-DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}"
+            "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}"
+            "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
         WORKING_DIRECTORY "${JUCE_SOURCE_DIR}"
         OUTPUT_VARIABLE command_output
         ERROR_VARIABLE command_output


### PR DESCRIPTION
Use custom defined compilers that have been defined by

`CMAKE_C_COMPILER` and
`CMAKE_CXX_COMPILER`

when trying to bootstrap `juceaide`.

A few lines above actually the environment variables `CC` and `CXX` get undefined and the following statement is found:

https://github.com/juce-framework/JUCE/blob/4f01392000965f6c5e957329220d5ad06ca174c4/extras/Build/juceaide/CMakeLists.txt#L52-L55

However the variables are not transferred to the `CMake` call when `juceaide` is being bootstrapped.

Note that `CMAKE_C_COMPILER` and `CMAKE_CXX_COMPILER` work fine for the overall project when defined - they just won't get used in this step.

I stumbled across this one when I was using a very compiler specific feature deep down in the JUCE graphics context code. Due to the project's architecture it seems that these parts are also getting compiled when `juceaide` is getting compiled which results in a failure because it was using the default compiler which did not understand the features used.

I'm not sure if that will break cross compilation though as the compilers may be cross compilers and there is no distinguishing between cross and native targets.
