### PR TITLE
Fix: Should not update the lastNonFullscreenBounds variable when ComponentPeer is in minimised.

### DIFF
--- a/modules/juce_gui_basics/windows/juce_ComponentPeer.cpp
+++ b/modules/juce_gui_basics/windows/juce_ComponentPeer.cpp
@@ -322,7 +322,7 @@ void ComponentPeer::handleMovedOrResized()
         component.sendVisibilityChangeMessage();
     }
 
-    if (! isFullScreen())
+    if (!(isFullScreen() || isMinimised() || isKioskMode()))
         lastNonFullscreenBounds = component.getBounds();
 }
 


### PR DESCRIPTION
Hello JUCE team,

I found a strange behaviour when `juce::DocumentWindow` is using native title bar.
This PR fixes the strange behavior of maximizing and minimizing window operations.

How to reproduce.
+ Operating System: Windows 10
+ Use native title bar on document window by `juce::DocumentWindow::setUsingNativeTitleBar (true)`
+ Make window maximised by clicking maximise button. Window will be fullscreen.
+ Make window minimised by clicking Windows taskbar app icon. Window will be minimised.
+ Show window by clicking Windows taskbar app icon. Window will be fullscreen.
+ If you click the maximize button of the window, it will stay at the maximized size instead of returning to its original size.

I found a code below that can solve a similar problem.
https://github.com/juce-framework/JUCE/blob/master/modules/juce_gui_basics/windows/juce_ResizableWindow.cpp#L509

However, that code will not pass when using the native title bar, so I adopt a similar implementation in this PR.

Before applying this PR, the window will not return to the size it was before going fullscreen.
After applying this PR, the window will return to the size it was before going fullscreen.

Please check it.