### PR TITLE
Use onlyOld as option for CoreMIDI if not on right version

### DIFF
--- a/modules/juce_audio_devices/native/juce_mac_CoreMidi.mm
+++ b/modules/juce_audio_devices/native/juce_mac_CoreMidi.mm
@@ -52,16 +52,10 @@ namespace CoreMidiHelpers
         onlyOld
     };
 
-    #if (defined (MAC_OS_VERSION_11_0) || defined (__IPHONE_14_0))
-     #if (MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_VERSION_11_0 || __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_14_0)
-      #define JUCE_HAS_NEW_COREMIDI_API 1
-      #define JUCE_HAS_OLD_COREMIDI_API 0
-      constexpr auto implementationStrategy = ImplementationStrategy::onlyNew;
-     #else
-      #define JUCE_HAS_NEW_COREMIDI_API 1
-      #define JUCE_HAS_OLD_COREMIDI_API 1
-      constexpr auto implementationStrategy = ImplementationStrategy::both;
-     #endif
+    #if (MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_VERSION_11_0 || __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_14_0)
+     #define JUCE_HAS_NEW_COREMIDI_API 1
+     #define JUCE_HAS_OLD_COREMIDI_API 0
+     constexpr auto implementationStrategy = ImplementationStrategy::onlyNew;
     #else
      #define JUCE_HAS_NEW_COREMIDI_API 0
      #define JUCE_HAS_OLD_COREMIDI_API 1


### PR DESCRIPTION
Finding a crash on startup on iOS13 due to what I imagine is due __IPHONE_14_0 defined at compile time, but __IPHONE_OS_VErSION_MIN_REQUIRED == __IPHONE_13_0