### PR TITLE
fixed adsr release bug

### DIFF
--- a/modules/juce_audio_basics/utilities/juce_ADSR.h
+++ b/modules/juce_audio_basics/utilities/juce_ADSR.h
@@ -124,6 +124,7 @@ public:
         }
         else
         {
+            envelopeVal = parameters.sustain;
             state = State::sustain;
         }
     }


### PR DESCRIPTION
Fixes a bug where an attack time of 0 and sustain of 100% in conjunction with the `applyEnvelopeToBuffer` function skipped the release stage.