### PR TITLE
Add atmos 7 1 4 support for AU

### DIFF
--- a/modules/juce_audio_basics/buffers/juce_AudioChannelSet.h
+++ b/modules/juce_audio_basics/buffers/juce_AudioChannelSet.h
@@ -216,7 +216,7 @@ public:
 
     /** Creates a set for Dolby Atmos 7.1.4 surround setup (left, right, centre, leftSurroundSide, rightSurroundSide, leftSurroundRear, rightSurroundRear, LFE, topFrontLeft, topFrontRight, topRearLeft, topRearRight).
 
-        Is equivalent to: k71_4 (VST), n/a (AAX), n/a (CoreAudio)
+        Is equivalent to: k71_4 (VST), n/a (AAX), kAudioChannelLayoutTag_Atmos_7_1_4 (CoreAudio)
     */
     static AudioChannelSet JUCE_CALLTYPE create7point1point4();
 

--- a/modules/juce_audio_basics/native/juce_mac_CoreAudioLayouts.h
+++ b/modules/juce_audio_basics/native/juce_mac_CoreAudioLayouts.h
@@ -202,6 +202,7 @@ private:
                 { kAudioChannelLayoutTag_AudioUnit_7_0_Front, { left, right, leftSurround, rightSurround, centre, leftCentre, rightCentre } },
                 { kAudioChannelLayoutTag_MPEG_7_1_C, { left, right, centre, LFE, leftSurroundSide, rightSurroundSide, leftSurroundRear, rightSurroundRear } },
                 { kAudioChannelLayoutTag_MPEG_7_1_A, { left, right, centre, LFE, leftSurround, rightSurround, leftCentre, rightCentre } },
+                { kAudioChannelLayoutTag_Atmos_7_1_4, { left, right, leftSurroundSide, rightSurroundSide, topFrontLeft, topFrontRight, centre, LFE, topRearLeft, topRearRight, leftSurroundRear, rightSurroundRear } },
                 { kAudioChannelLayoutTag_Ambisonic_B_Format, { ambisonicW, ambisonicX, ambisonicY, ambisonicZ } },
                 { kAudioChannelLayoutTag_Quadraphonic, { left, right, leftSurround, rightSurround } },
                 { kAudioChannelLayoutTag_Pentagonal, { left, right, leftSurroundRear, rightSurroundRear, centre } },

--- a/modules/juce_audio_formats/codecs/juce_CoreAudioFormat.cpp
+++ b/modules/juce_audio_formats/codecs/juce_CoreAudioFormat.cpp
@@ -840,6 +840,8 @@ private:
             DEFINE_CHANNEL_LAYOUT_DFL_ENTRY (kAudioChannelLayoutTag_DTS_8_1_B),
             DEFINE_CHANNEL_LAYOUT_DFL_ENTRY (kAudioChannelLayoutTag_DTS_6_1_D),
             DEFINE_CHANNEL_LAYOUT_DFL_ENTRY (kAudioChannelLayoutTag_DTS_6_1_D),
+            DEFINE_CHANNEL_LAYOUT_DFL_ENTRY (kAudioChannelLayoutTag_Atmos_7_1_4, AudioChannelSet::create7point1point4()),
+            DEFINE_CHANNEL_LAYOUT_DFL_ENTRY (kAudioChannelLayoutTag_Atmos_9_1_6),
             DEFINE_CHANNEL_LAYOUT_TAG_ENTRY (kAudioChannelLayoutTag_HOA_ACN_SN3D_0Order,  AudioChannelSet::ambisonic (0)),
             DEFINE_CHANNEL_LAYOUT_TAG_ENTRY (kAudioChannelLayoutTag_HOA_ACN_SN3D_1Order,  AudioChannelSet::ambisonic (1)),
             DEFINE_CHANNEL_LAYOUT_TAG_ENTRY (kAudioChannelLayoutTag_HOA_ACN_SN3D_2Order,  AudioChannelSet::ambisonic (2)),

--- a/modules/juce_core/native/juce_mac_CFHelpers.h
+++ b/modules/juce_core/native/juce_mac_CFHelpers.h
@@ -43,6 +43,7 @@ template <typename CFType>
 struct CFObjectHolder
 {
     CFObjectHolder() = default;
+    explicit CFObjectHolder (CFType obj)  : object (obj) {}
 
     CFObjectHolder (const CFObjectHolder&) = delete;
     CFObjectHolder (CFObjectHolder&&) = delete;


### PR DESCRIPTION
Adds support for 7.1.4 Atmos speaker layout for AU in Logic.
tested in Logic Pro v10.7.0  as an insert on masterbus post Atmos renderer and on a 7.1.4 track when not using Atmos.

https://forum.juce.com/t/extending-juce-support-for-atmos-beyond-7-1-2-channel-set-including-in-logic-pro-via-new-layout-tags/48375/7?u=skazassoglou