### PR TITLE
CMake:  Allow generated files to be included in juce_add_binary_data 

### DIFF
--- a/extras/Build/CMake/JUCEUtils.cmake
+++ b/extras/Build/CMake/JUCEUtils.cmake
@@ -391,7 +391,7 @@ function(juce_add_binary_data target)
     set(newline_delimited_input)
 
     foreach(name IN LISTS JUCE_ARG_SOURCES)
-        _juce_make_absolute_and_check(name)
+        _juce_make_absolute(name)
         set(newline_delimited_input "${newline_delimited_input}${name}\n")
     endforeach()
 


### PR DESCRIPTION
This trivial patch allows one to include generated files in the list of SOURCES of `juce_add_binary_data`.

Example:

```
# create a zip of dir foo/
add_custom_command(COMMAND
    ${CMAKE_COMMAND} -E tar "cfv" "foo.zip" --format=zip
    "${CMAKE_CURRENT_DIRECTORY}/foo/"
)
# create a custom target for it
add_custom_target (FooZip DEPENDS "foo.zip")
# create juce binary data
juce_add_binary_data(FooData
    NAMESPACE FooData
    HEADER_NAME FooData.h
    SOURCES "${CMAKE_CURRENT_BINARY_DIR}/foo.zip"
)
# let it depend on FooZip target
add_dependencies (FooData FooZip)
```

Another way to do it would be to add a DEPENDS argument to keep the `_and_check` on SOURCES, but it doesn't seem required since `juceaide` will error on missing files anyhow.

cheers, piem