### PR TITLE
JSON: Add toString() method for StringPairArray

### DIFF
--- a/modules/juce_core/javascript/juce_JSON.cpp
+++ b/modules/juce_core/javascript/juce_JSON.cpp
@@ -507,6 +507,50 @@ String JSON::toString (const var& data, const bool allOnOneLine, int maximumDeci
     return mo.toUTF8();
 }
 
+String JSON::toString (const StringPairArray& data, bool allOnOneLine)
+{
+    if (data.size() == 0)
+        return "{}";
+
+    MemoryOutputStream mo (1024);
+
+    mo << '{';
+
+    if (! allOnOneLine)
+        mo << newLine;
+
+    auto itemsLeft = data.size();
+
+    for (const auto& key : data.getAllKeys())
+    {
+        if (! allOnOneLine)
+            JSONFormatter::writeSpaces (mo, JSONFormatter::indentSize);
+
+        mo << '"';
+        JSONFormatter::writeString (mo, JSON::escapeString (key).getCharPointer());
+        mo << "\": \"";
+        JSONFormatter::writeString (mo, JSON::escapeString (data[key]).getCharPointer());
+        mo << '"';
+        
+        if (--itemsLeft)
+        {
+            mo << ',';
+
+            if (allOnOneLine)
+                mo << ' ';
+            else
+                mo << newLine;
+        }
+    }
+
+    if (! allOnOneLine)
+        mo << newLine;
+
+    mo << '}';
+
+    return mo.toUTF8();
+}
+
 void JSON::writeToStream (OutputStream& output, const var& data, const bool allOnOneLine, int maximumDecimalPlaces)
 {
     JSONFormatter::write (output, data, 0, allOnOneLine, maximumDecimalPlaces);

--- a/modules/juce_core/javascript/juce_JSON.h
+++ b/modules/juce_core/javascript/juce_JSON.h
@@ -100,6 +100,15 @@ public:
                             bool allOnOneLine = false,
                             int maximumDecimalPlaces = 15);
 
+    /** Returns a string which contains a JSON-formatted representation of the StringPairArray object.
+        Keys are treated as JSON attributes, values as JSON values. If strings contain
+        any non-ASCII characters, you need to take care of them first.
+        If allOnOneLine is true, the result will be compacted into a single line of text
+        with no carriage-returns. If false, it will be laid-out in a more human-readable format.
+    */
+    static String toString (const StringPairArray& dataToFormat,
+                            bool allOnOneLine = false);
+
     /** Parses a string that was created with the toString() method.
         This is slightly different to the parse() methods because they will reject primitive
         values and only accept array or object definitions, whereas this method will handle


### PR DESCRIPTION
Had a few ```StringPairArray```'s I had to convert to JSON, was surprised JUCE can't do that yet. I used ```JSONFormatter``` stuff as much as possible, so it should behave nicely. Example:

```c++
    juce::StringPairArray data;

    DBG("*** Empty array ***");
    DBG("Single line" << juce::newLine << juce::JSON::toString(data, true));
    DBG("Multiple lines" << juce::newLine << juce::JSON::toString(data, false));

    DBG(juce::newLine << "*** One item ***");
    data.set("Key1", "Value1");
    DBG("Single line" << juce::newLine << juce::JSON::toString(data, true));
    DBG("Multiple lines" << juce::newLine << juce::JSON::toString(data, false));

    DBG(juce::newLine << "*** A bunch of items ***");
    data.set("Key2", "Value2");
    data.set("Key3", "Value\that\needs\escaping");
    DBG("Single line" << juce::newLine << juce::JSON::toString(data, true));
    DBG("Multiple lines" << juce::newLine << juce::JSON::toString(data, false));
```

Output:
```
*** Empty array ***
Single line
{}
Multiple lines
{}

*** One item ***
Single line
{"Key1": "Value1"}
Multiple lines
{
  "Key1": "Value1"
}

*** A bunch of items ***
Single line
{"Key1": "Value1", "Key2": "Value2", "Key3": "Value\\that\\needsescaping"}
Multiple lines
{
  "Key1": "Value1",
  "Key2": "Value2",
  "Key3": "Value\\that\\needsescaping"
}
```

It can also live as  ```StringPairArray``` method, but I think you prefer to keep all JSON stuff in one class. Also, noticed weird string escaping behaviour (see how one backslash has disappeared in last item?), but that's another matter.