### PR TITLE
Allow specifying a parent component for ContentShrarer

### DIFF
--- a/modules/juce_gui_basics/filebrowser/juce_ContentSharer.cpp
+++ b/modules/juce_gui_basics/filebrowser/juce_ContentSharer.cpp
@@ -151,13 +151,14 @@ ContentSharer::ContentSharer() {}
 ContentSharer::~ContentSharer() { clearSingletonInstance(); }
 
 void ContentSharer::shareFiles (const Array<URL>& files,
-                                std::function<void (bool, const String&)> callbackToUse)
+                                std::function<void (bool, const String&)> callbackToUse,
+                                Component *parentComponent)
 {
   #if JUCE_CONTENT_SHARING
-    startNewShare (callbackToUse);
+    startNewShare (callbackToUse, parentComponent);
     pimpl->shareFiles (files);
   #else
-    ignoreUnused (files);
+    ignoreUnused (files, parentComponent);
 
     // Content sharing is not available on this platform!
     jassertfalse;
@@ -168,7 +169,8 @@ void ContentSharer::shareFiles (const Array<URL>& files,
 }
 
 #if JUCE_CONTENT_SHARING
-void ContentSharer::startNewShare (std::function<void (bool, const String&)> callbackToUse)
+void ContentSharer::startNewShare (std::function<void (bool, const String&)> callbackToUse,
+                                   Component *parentComponent)
 {
     // You should not start another sharing operation before the previous one is finished.
     // Forcibly stopping a previous sharing operation is rarely a good idea!
@@ -183,19 +185,21 @@ void ContentSharer::startNewShare (std::function<void (bool, const String&)> cal
     // You need to pass a valid callback.
     jassert (callbackToUse);
     callback = std::move (callbackToUse);
+    parent = parentComponent;
 
     pimpl.reset (createPimpl());
 }
 #endif
 
 void ContentSharer::shareText (const String& text,
-                               std::function<void (bool, const String&)> callbackToUse)
+                               std::function<void (bool, const String&)> callbackToUse,
+                               Component *parentComponent)
 {
   #if JUCE_CONTENT_SHARING
-    startNewShare (callbackToUse);
+    startNewShare (callbackToUse, parentComponent);
     pimpl->shareText (text);
   #else
-    ignoreUnused (text);
+    ignoreUnused (text, parentComponent);
 
     // Content sharing is not available on this platform!
     jassertfalse;
@@ -207,13 +211,14 @@ void ContentSharer::shareText (const String& text,
 
 void ContentSharer::shareImages (const Array<Image>& images,
                                  std::function<void (bool, const String&)> callbackToUse,
-                                 ImageFileFormat* imageFileFormatToUse)
+                                 ImageFileFormat* imageFileFormatToUse,
+                                 Component *parentComponent)
 {
   #if JUCE_CONTENT_SHARING
-    startNewShare (callbackToUse);
+    startNewShare (callbackToUse, parentComponent);
     prepareImagesThread.reset (new PrepareImagesThread (*this, images, imageFileFormatToUse));
   #else
-    ignoreUnused (images, imageFileFormatToUse);
+    ignoreUnused (images, imageFileFormatToUse, parentComponent);
 
     // Content sharing is not available on this platform!
     jassertfalse;
@@ -239,13 +244,14 @@ void ContentSharer::filesToSharePrepared()
 #endif
 
 void ContentSharer::shareData (const MemoryBlock& mb,
-                               std::function<void (bool, const String&)> callbackToUse)
+                               std::function<void (bool, const String&)> callbackToUse,
+                               Component *parentComponent)
 {
   #if JUCE_CONTENT_SHARING
-    startNewShare (callbackToUse);
+    startNewShare (callbackToUse, parentComponent);
     prepareDataThread.reset (new PrepareDataThread (*this, mb));
   #else
-    ignoreUnused (mb);
+    ignoreUnused (mb, parentComponent);
 
     if (callbackToUse)
         callbackToUse (false, "Content sharing not available on this platform!");

--- a/modules/juce_gui_basics/filebrowser/juce_ContentSharer.h
+++ b/modules/juce_gui_basics/filebrowser/juce_ContentSharer.h
@@ -52,7 +52,8 @@ public:
         succeeded. Also, the optional error message is always empty on Android.
     */
     void shareFiles (const Array<URL>& files,
-                     std::function<void (bool /*success*/, const String& /*error*/)> callback);
+                     std::function<void (bool /*success*/, const String& /*error*/)> callback,
+                     Component *parentComponent = nullptr);
 
     /** Shares the given text.
 
@@ -62,7 +63,8 @@ public:
         succeeded. Also, the optional error message is always empty on Android.
     */
     void shareText (const String& text,
-                    std::function<void (bool /*success*/, const String& /*error*/)> callback);
+                    std::function<void (bool /*success*/, const String& /*error*/)> callback,
+                    Component *parentComponent = nullptr);
 
     /** A convenience function to share an image. This is useful when you have images
         loaded in memory. The images will be written to temporary files first, so if
@@ -87,7 +89,8 @@ public:
     */
     void shareImages (const Array<Image>& images,
                       std::function<void (bool /*success*/, const String& /*error*/)> callback,
-                      ImageFileFormat* imageFileFormatToUse = nullptr);
+                      ImageFileFormat* imageFileFormatToUse = nullptr,
+                      Component *parentComponent = nullptr);
 
     /** A convenience function to share arbitrary data. The data will be written
         to a temporary file and then that file will be shared. If you have
@@ -99,7 +102,8 @@ public:
         succeeded. Also, the optional error message is always empty on Android.
     */
     void shareData (const MemoryBlock& mb,
-                    std::function<void (bool /*success*/, const String& /*error*/)> callback);
+                    std::function<void (bool /*success*/, const String& /*error*/)> callback,
+                    Component *parentComponent = nullptr);
 
 private:
     ContentSharer();
@@ -108,6 +112,7 @@ private:
     Array<File> temporaryFiles;
 
     std::function<void (bool, String)> callback;
+    Component *parent = nullptr;
 
   #if JUCE_CONTENT_SHARING
     struct Pimpl
@@ -120,7 +125,7 @@ private:
     std::unique_ptr<Pimpl> pimpl;
     Pimpl* createPimpl();
 
-    void startNewShare (std::function<void (bool, const String&)>);
+    void startNewShare (std::function<void (bool, const String&)>, Component *);
 
     class ContentSharerNativeImpl;
     friend class ContentSharerNativeImpl;

--- a/modules/juce_gui_basics/native/juce_ios_ContentSharer.cpp
+++ b/modules/juce_gui_basics/native/juce_ios_ContentSharer.cpp
@@ -124,12 +124,21 @@ private:
 
         controller.get().modalTransitionStyle = UIModalTransitionStyleCoverVertical;
 
-        auto bounds = Desktop::getInstance().getDisplays().getPrimaryDisplay()->userArea;
-        setBounds (bounds);
-
         setAlwaysOnTop (true);
-        setVisible (true);
-        addToDesktop (0);
+
+        if (owner.parent)
+        {
+                setBounds (owner.parent->getLocalBounds());
+                owner.parent->addAndMakeVisible (this);
+        }
+        else
+        {
+                auto bounds = Desktop::getInstance().getDisplays().getPrimaryDisplay()->userArea;
+                setBounds (bounds);
+
+                setVisible (true);
+                addToDesktop (0);
+        }
 
         enterModalState (true,
                          ModalCallbackFunction::create ([this] (int)
@@ -157,11 +166,19 @@ private:
             {
                 controller.get().preferredContentSize = peer->view.frame.size;
 
-                auto screenBounds = [UIScreen mainScreen].bounds;
-
                 auto* popoverController = controller.get().popoverPresentationController;
                 popoverController.sourceView = peer->view;
-                popoverController.sourceRect = CGRectMake (0.f, screenBounds.size.height - 10.f, screenBounds.size.width, 10.f);
+
+                if (owner.parent)
+                {
+                    popoverController.sourceRect = CGRectMake (0.f, getHeight() - 10.f, getWidth(), 10.f);
+                }
+                else
+                {
+                    auto screenBounds = [UIScreen mainScreen].bounds;
+                    popoverController.sourceRect = CGRectMake (0.f, screenBounds.size.height - 10.f, screenBounds.size.width, 10.f);
+                }
+
                 popoverController.canOverlapSourceViewRect = YES;
                 popoverController.delegate = popoverDelegate.get();
             }


### PR DESCRIPTION
AudioUnits on iOS don't support components added to desktop. This patch will
add the popover to the specified parent component's peer instead.