### PR TITLE
Adapt the audio-channel capacity of AudioFormatWriter::writeFromFloatArrays

### DIFF
--- a/modules/juce_audio_formats/format/juce_AudioFormatWriter.cpp
+++ b/modules/juce_audio_formats/format/juce_AudioFormatWriter.cpp
@@ -157,7 +157,7 @@ bool AudioFormatWriter::writeFromFloatArrays (const float* const* channels, int 
     if (isFloatingPoint())
         return write ((const int**) channels, numSamples);
 
-    std::vector<int*> chans (256);
+    std::vector<int*> chans (numSourceChannels + 1);
     std::vector<int> scratch (4096);
 
     jassert (numSourceChannels < (int) chans.size());


### PR DESCRIPTION
Saving an audio file with many audio channels hits a limit (ans asserts) at  255.

https://github.com/juce-framework/JUCE/blob/9055820a30770479e30994c9a91029474cf60f7d/modules/juce_audio_formats/format/juce_AudioFormatWriter.cpp#L160

After a quick glance at the git history: it seems like `chans` was formerly a
C-array (hence the static limit), and then was converted to a `vector` of the
same (fixed) size in 31a7c62bafe87626578e0cda7db138c78d10d9db.

I don't think there's anything on the way of making its size adapted to the
incoming audio buffer (`numSourceChannels + 1`). 
This will also spare the creation of unused channels with buffers of less 
than 255 channels.