### PR TITLE
Fix various typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ tool) or with CMake.
 The repository doesn't contain a pre-built Projucer so you will need to build it
 for your platform - Xcode, Visual Studio and Linux Makefile projects are located in
 [extras/Projucer/Builds](/extras/Projucer/Builds)
-(the minumum system requirements are listed in the __System Requirements__ section below).
+(the minimum system requirements are listed in the __System Requirements__ section below).
 The Projucer can then be used to create new JUCE projects, view tutorials and run examples.
 It is also possible to include the JUCE modules source code in an existing project directly,
 or build them into a static or dynamic library which can be linked into a project.

--- a/docs/CMake API.md
+++ b/docs/CMake API.md
@@ -539,7 +539,7 @@ attributes directly to these creation functions, rather than adding them later.
 `USE_LEGACY_COMPATIBILITY_PLUGIN_CODE`
 - May be either TRUE or FALSE (defaults to FALSE). If TRUE, will override the value of the
   preprocessor definition "JucePlugin_ManufacturerCode" with the hex equivalent of "proj". This
-  option exists to maintain compatiblity with a previous, buggy version of JUCE's CMake support
+  option exists to maintain compatibility with a previous, buggy version of JUCE's CMake support
   which mishandled the manufacturer code property. Most projects should leave this option set to
   its default value.
 

--- a/docs/JUCE Module Format.md
+++ b/docs/JUCE Module Format.md
@@ -17,7 +17,7 @@ JUCE convention for naming modules is lower-case with underscores, e.g.
     juce_events
     juce_graphics
 
-But any name that is a valid C++ identifer is OK.
+But any name that is a valid C++ identifier is OK.
 
 Inside the root of this folder, there must be a set of public header and source files which
 the user's' project will include. The module may have as many other internal source files as

--- a/docs/Linux Dependencies.md
+++ b/docs/Linux Dependencies.md
@@ -6,7 +6,7 @@ flag used to disable it is noted.
 
 This has been tested on Ubuntu 16.04 LTS (Xenial Xerus), 18.04 LTS (Bionic
 Beaver), and 20.04 LTS (Focal Fossa). Packages may differ in name or not be
-available on other distrubutions.
+available on other distributions.
 
 ## Compiler
 A C++ compiler is required. JUCE has been tested thoroughly with Clang and GCC:

--- a/extras/Build/juceaide/CMakeLists.txt
+++ b/extras/Build/juceaide/CMakeLists.txt
@@ -61,7 +61,7 @@ else()
 
     message(STATUS "Configuring juceaide")
 
-    # Looks like we're boostrapping, reinvoke CMake
+    # Looks like we're bootstrapping, reinvoke CMake
     execute_process(COMMAND "${CMAKE_COMMAND}"
             "."
             "-B${JUCE_BINARY_DIR}/tools"

--- a/extras/Projucer/Source/Project/jucer_Project.cpp
+++ b/extras/Projucer/Source/Project/jucer_Project.cpp
@@ -1314,7 +1314,7 @@ void Project::createPropertyEditors (PropertyListBuilder& props)
                "which may simplify the includes in the project.");
 
     props.add (new ChoicePropertyComponent (addUsingNamespaceToJuceHeader, "Add \"using namespace juce\" to JuceHeader.h"),
-               "If enabled, the JuceHeader.h will include a \"using namepace juce\" statement. If disabled, "
+               "If enabled, the JuceHeader.h will include a \"using namespace juce\" statement. If disabled, "
                "no such statement will be included. This setting used to be enabled by default, but it "
                "is recommended to leave it disabled for new projects.");
 

--- a/modules/juce_audio_basics/midi/ump/juce_UMPSysEx7.h
+++ b/modules/juce_audio_basics/midi/ump/juce_UMPSysEx7.h
@@ -28,7 +28,7 @@ namespace universal_midi_packets
 {
 
 /**
-    This struct acts as a single-file namespace for Univeral MIDI Packet
+    This struct acts as a single-file namespace for Universal MIDI Packet
     functionality related to 7-bit SysEx.
 
     @tags{Audio}

--- a/modules/juce_audio_devices/native/oboe/include/oboe/Definitions.h
+++ b/modules/juce_audio_devices/native/oboe/include/oboe/Definitions.h
@@ -309,7 +309,7 @@ namespace oboe {
 
         /**
          * Use this for notifying the user when a message has arrived or some
-         * other background event has occured.
+         * other background event has occurred.
          */
         Notification = 5, // AAUDIO_USAGE_NOTIFICATION
 

--- a/modules/juce_audio_formats/codecs/flac/libFLAC/stream_encoder.c
+++ b/modules/juce_audio_formats/codecs/flac/libFLAC/stream_encoder.c
@@ -650,7 +650,7 @@ static FLAC__StreamEncoderInitStatus init_stream_internal_(
 		encoder->protected_->loose_mid_side_stereo = false;
 
 	if(encoder->protected_->bits_per_sample >= 32)
-		encoder->protected_->do_mid_side_stereo = false; /* since we currenty do 32-bit math, the side channel would have 33 bps and overflow */
+		encoder->protected_->do_mid_side_stereo = false; /* since we currently do 32-bit math, the side channel would have 33 bps and overflow */
 
 	if(encoder->protected_->bits_per_sample < FLAC__MIN_BITS_PER_SAMPLE || encoder->protected_->bits_per_sample > FLAC__REFERENCE_CODEC_MAX_BITS_PER_SAMPLE)
 		return FLAC__STREAM_ENCODER_INIT_STATUS_INVALID_BITS_PER_SAMPLE;

--- a/modules/juce_audio_formats/codecs/oggvorbis/libvorbis-1.3.7/lib/vorbisfile.c
+++ b/modules/juce_audio_formats/codecs/oggvorbis/libvorbis-1.3.7/lib/vorbisfile.c
@@ -1920,7 +1920,7 @@ vorbis_info *ov_info(OggVorbis_File *vf,int link){
   }
 }
 
-/* grr, strong typing, grr, no templates/inheritence, grr */
+/* grr, strong typing, grr, no templates/inheritance, grr */
 vorbis_comment *ov_comment(OggVorbis_File *vf,int link){
   if(vf->seekable){
     if(link<0)

--- a/modules/juce_audio_plugin_client/AU/CoreAudioUtilityClasses/AUBase.cpp
+++ b/modules/juce_audio_plugin_client/AU/CoreAudioUtilityClasses/AUBase.cpp
@@ -783,7 +783,7 @@ OSStatus			AUBase::DispatchGetProperty(	AudioUnitPropertyID 			inID,
 			{
 				result = CopyClumpName(inScope, ioClumpInfo->inID, ioClumpInfo->inDesiredLength, &ioClumpInfo->outName);
 
-					// this is provided for compatbility with existing implementations that don't know
+					// this is provided for compatibility with existing implementations that don't know
 					// about this new mechanism
 				if (result == kAudioUnitErr_InvalidProperty)
 					result = GetProperty (inID, inScope, inElement, outData);
@@ -863,7 +863,7 @@ OSStatus			AUBase::DispatchSetProperty(	AudioUnitPropertyID 			inID,
 
 			CAStreamBasicDescription newDesc;
 				// now we're going to be ultra conservative! because of discrepancies between
-				// sizes of this struct based on aligment padding inconsistencies
+				// sizes of this struct based on alignment padding inconsistencies
 			memset (&newDesc, 0, sizeof(newDesc));
 			memcpy (&newDesc, inData, 36);
 

--- a/modules/juce_audio_plugin_client/AU/CoreAudioUtilityClasses/AUBase.h
+++ b/modules/juce_audio_plugin_client/AU/CoreAudioUtilityClasses/AUBase.h
@@ -706,7 +706,7 @@ public:
 #pragma mark AU Music Base Dispatch
 
 #if !TARGET_OS_IPHONE
-// these methods are deprecated, so we don't include them except for compatability
+// these methods are deprecated, so we don't include them except for compatibility
 	/*! @method PrepareInstrument */
 	virtual OSStatus			PrepareInstrument(MusicDeviceInstrumentID inInstrument) { return kAudio_UnimplementedError; }
 

--- a/modules/juce_audio_plugin_client/AU/CoreAudioUtilityClasses/AUCarbonViewControl.cpp
+++ b/modules/juce_audio_plugin_client/AU/CoreAudioUtilityClasses/AUCarbonViewControl.cpp
@@ -120,7 +120,7 @@ void	AUCarbonViewControl::ParameterToControl(Float32 paramValue)
 			// special case [1] -- menu parameters
 			if (mParam.HasNamedParams()) {
 				// if we're dealing with menus they behave differently!
-				// becaue setting min and max doesn't work correctly for the control value
+				// because setting min and max doesn't work correctly for the control value
 				// first menu item always reports a control value of 1
 				ControlKind ctrlKind;
 				if (GetControlKind(mControl, &ctrlKind) == noErr) {
@@ -188,7 +188,7 @@ void	AUCarbonViewControl::ControlToParameter()
 			// special case [1] -- Menus
 			if (mParam.HasNamedParams()) {
 				// if we're dealing with menus they behave differently!
-				// becaue setting min and max doesn't work correctly for the control value
+				// because setting min and max doesn't work correctly for the control value
 				// first menu item always reports a control value of 1
 				ControlKind ctrlKind;
 				if (GetControlKind(mControl, &ctrlKind) == noErr) {

--- a/modules/juce_audio_plugin_client/AU/CoreAudioUtilityClasses/AUPlugInDispatch.cpp
+++ b/modules/juce_audio_plugin_client/AU/CoreAudioUtilityClasses/AUPlugInDispatch.cpp
@@ -437,7 +437,7 @@ static OSStatus AUMethodStop(void *self)
 // ------------------------------------------------------------------------------------------------
 
 #if !CA_BASIC_AU_FEATURES
-// I don't know what I'm doing here; conflicts with the multiple inheritence in MusicDeviceBase.
+// I don't know what I'm doing here; conflicts with the multiple inheritance in MusicDeviceBase.
 static OSStatus AUMethodMIDIEvent(void *self, UInt32 inStatus, UInt32 inData1, UInt32 inData2, UInt32 inOffsetSampleFrame)
 {
 	OSStatus result = noErr;

--- a/modules/juce_audio_plugin_client/AU/CoreAudioUtilityClasses/AUScopeElement.cpp
+++ b/modules/juce_audio_plugin_client/AU/CoreAudioUtilityClasses/AUScopeElement.cpp
@@ -404,7 +404,7 @@ UInt32		AUIOElement::GetAudioChannelLayout (AudioChannelLayout		*outMapPtr,
 
 // the incoming channel map will be at least as big as a basic AudioChannelLayout
 // but its contents will determine its actual size
-// Subclass should overide if channel map is writable
+// Subclass should override if channel map is writable
 OSStatus	AUIOElement::SetAudioChannelLayout (const AudioChannelLayout &inData)
 {
 	return kAudioUnitErr_InvalidProperty;

--- a/modules/juce_audio_plugin_client/AU/CoreAudioUtilityClasses/CAAtomic.h
+++ b/modules/juce_audio_plugin_client/AU/CoreAudioUtilityClasses/CAAtomic.h
@@ -80,7 +80,7 @@ inline SInt32 CAAtomicAdd32Barrier(SInt32 theAmt, volatile SInt32* theValue)
 #if TARGET_OS_WIN32
 	long lRetVal = InterlockedExchangeAdd((volatile long*)theValue, theAmt);
 	// InterlockedExchangeAdd returns the original value which differs from OSX version.
-	// At this point the addition would have occured and hence returning the new value
+	// At this point the addition would have occurred and hence returning the new value
 	// to keep it sync with OSX.
 	return lRetVal + theAmt;
 #else

--- a/modules/juce_audio_plugin_client/AU/CoreAudioUtilityClasses/CAMutex.cpp
+++ b/modules/juce_audio_plugin_client/AU/CoreAudioUtilityClasses/CAMutex.cpp
@@ -249,7 +249,7 @@ bool	CAMutex::Try(bool& outWasLocked)
 		}
 		else
 		{
-			//	any other return value means something really bad happenned
+			//	any other return value means something really bad happened
 			ThrowIfError(theError, CAException(theError), "CAMutex::Try: call to pthread_mutex_trylock failed");
 		}
 	}
@@ -292,7 +292,7 @@ bool	CAMutex::Try(bool& outWasLocked)
 		}
 		else
 		{
-			//	any other return value means something really bad happenned
+			//	any other return value means something really bad happened
 			ThrowIfError(theError, CAException(GetLastError()), "CAMutex::Try: call to lock the mutex failed");
 		}
 	}

--- a/modules/juce_audio_processors/format_types/VST3_SDK/base/source/fobject.h
+++ b/modules/juce_audio_processors/format_types/VST3_SDK/base/source/fobject.h
@@ -108,7 +108,7 @@ public:
 	virtual void addDependent (IDependent* dep);							///< adds dependency to the object
 	virtual void removeDependent (IDependent* dep);							///< removes dependency from the object
 	virtual void changed (int32 msg = kChanged);							///< Inform all dependents, that the object has changed.
-	virtual void deferUpdate (int32 msg = kChanged);						///< Similar to triggerUpdates, except only delivered in idle (usefull in collecting updates).
+	virtual void deferUpdate (int32 msg = kChanged);						///< Similar to triggerUpdates, except only delivered in idle (useful in collecting updates).
 	virtual void updateDone (int32 /* msg */) {}							///< empty virtual method that should be overridden by derived classes
 	virtual bool isEqualInstance (FUnknown* d) {return this == d;}
 	

--- a/modules/juce_audio_processors/format_types/VST3_SDK/pluginterfaces/base/iupdatehandler.h
+++ b/modules/juce_audio_processors/format_types/VST3_SDK/pluginterfaces/base/iupdatehandler.h
@@ -57,7 +57,7 @@ public:
 	                 a private message as well (only known to sender and dependent)*/
 	virtual	tresult PLUGIN_API triggerUpdates (FUnknown* object, int32 message) = 0;
 
-	/** Same as triggerUpdates, but delivered in idle (usefull to collect updates).*/
+	/** Same as triggerUpdates, but delivered in idle (useful to collect updates).*/
 	virtual	tresult PLUGIN_API deferUpdates (FUnknown* object, int32 message) = 0;
 	static const FUID iid;
 };

--- a/modules/juce_audio_processors/processors/juce_AudioProcessorEditor.h
+++ b/modules/juce_audio_processors/processors/juce_AudioProcessorEditor.h
@@ -174,7 +174,7 @@ public:
         A pointer to the object you pass in will be kept, but it won't be deleted
         by this object, so it's the caller's responsibility to manage it.
 
-        If you pass a nullptr, then no contraints will be placed on the positioning of the window.
+        If you pass a nullptr, then no constraints will be placed on the positioning of the window.
     */
     void setConstrainer (ComponentBoundsConstrainer* newConstrainer);
 

--- a/modules/juce_audio_processors/utilities/juce_AudioProcessorValueTreeState.h
+++ b/modules/juce_audio_processors/utilities/juce_AudioProcessorValueTreeState.h
@@ -175,7 +175,7 @@ public:
                        std::make_unique<AudioParameterInt> ("b", "Parameter B", 0, 5, 2) })
         @endcode
 
-        To add parameters programatically you can call `add` repeatedly on a
+        To add parameters programmatically you can call `add` repeatedly on a
         ParameterLayout instance:
 
         @code

--- a/modules/juce_audio_utils/gui/juce_AudioThumbnailCache.h
+++ b/modules/juce_audio_utils/gui/juce_AudioThumbnailCache.h
@@ -64,7 +64,7 @@ public:
     */
     bool loadThumb (AudioThumbnailBase& thumb, int64 hashCode);
 
-    /** Stores the cachable data from the specified thumb in this cache.
+    /** Stores the cacheable data from the specified thumb in this cache.
 
         This is called automatically by the AudioThumbnail class, so you shouldn't
         normally need to call it directly.

--- a/modules/juce_audio_utils/gui/juce_BluetoothMidiDevicePairingDialogue.h
+++ b/modules/juce_audio_utils/gui/juce_BluetoothMidiDevicePairingDialogue.h
@@ -36,7 +36,7 @@ namespace juce
     Only after a Bluetooth MIDI device has been paired will its MIDI ports
     be available through JUCE's MidiInput and MidiOutput classes.
 
-    This dialogue is currently only available on macOS targetting versions 10.11+,
+    This dialogue is currently only available on macOS targeting versions 10.11+,
     iOS and Android. When targeting older versions of macOS you should instead
     pair Bluetooth MIDI devices using the "Audio MIDI Setup" app (located in
     /Applications/Utilities). On Windows, you should use the system settings. On

--- a/modules/juce_audio_utils/native/juce_mac_BluetoothMidiDevicePairingDialogue.mm
+++ b/modules/juce_audio_utils/native/juce_mac_BluetoothMidiDevicePairingDialogue.mm
@@ -164,7 +164,7 @@ bool BluetoothMidiDevicePairingDialogue::open (ModalComponentManager::Callback* 
     }
 
     std::unique_ptr<ModalComponentManager::Callback> cb (exitCallback);
-    // This functionality is unavailable when targetting OSX < 10.11. Instead,
+    // This functionality is unavailable when targeting OSX < 10.11. Instead,
     // you should pair Bluetooth MIDI devices using the "Audio MIDI Setup" app
     // (located in /Applications/Utilities).
     jassertfalse;

--- a/modules/juce_core/containers/juce_Array.h
+++ b/modules/juce_core/containers/juce_Array.h
@@ -76,7 +76,7 @@ public:
     {
     }
 
-    /** Initalises from a null-terminated raw array of values.
+    /** Initialises from a null-terminated raw array of values.
         @param data   the data to copy from
     */
     template <typename TypeToCreateFrom>
@@ -86,7 +86,7 @@ public:
             add (*data++);
     }
 
-    /** Initalises from a raw array of values.
+    /** Initialises from a raw array of values.
         @param data         the data to copy from
         @param numValues    the number of values in the array
     */
@@ -96,26 +96,26 @@ public:
         values.addArray (data, numValues);
     }
 
-    /** Initalises an Array of size 1 containing a single element. */
+    /** Initialises an Array of size 1 containing a single element. */
     Array (const ElementType& singleElementToAdd)
     {
         add (singleElementToAdd);
     }
 
-    /** Initalises an Array of size 1 containing a single element. */
+    /** Initialises an Array of size 1 containing a single element. */
     Array (ElementType&& singleElementToAdd)
     {
         add (std::move (singleElementToAdd));
     }
 
-    /** Initalises an Array from a list of items. */
+    /** Initialises an Array from a list of items. */
     template <typename... OtherElements>
     Array (const ElementType& firstNewElement, OtherElements&&... otherElements)
     {
         values.add (firstNewElement, std::forward<OtherElements> (otherElements)...);
     }
 
-    /** Initalises an Array from a list of items. */
+    /** Initialises an Array from a list of items. */
     template <typename... OtherElements>
     Array (ElementType&& firstNewElement, OtherElements&&... otherElements)
     {

--- a/modules/juce_core/xml/juce_XmlDocument.h
+++ b/modules/juce_core/xml/juce_XmlDocument.h
@@ -125,7 +125,7 @@ public:
     /** Sets a flag to change the treatment of empty text elements.
 
         If this is true (the default state), then any text elements that contain only
-        whitespace characters will be ingored during parsing. If you need to catch
+        whitespace characters will be ignored during parsing. If you need to catch
         whitespace-only text, then you should set this to false before calling the
         getDocumentElement() method.
     */

--- a/modules/juce_dsp/widgets/juce_Chorus.h
+++ b/modules/juce_dsp/widgets/juce_Chorus.h
@@ -37,7 +37,7 @@ namespace dsp
     of the modulation.
 
     Note: To get classic chorus sounds try to use a centre delay time around 7-8 ms
-    with a low feeback volume and a low depth. This effect can also be used as a
+    with a low feedback volume and a low depth. This effect can also be used as a
     flanger with a lower centre delay time and a lot of feedback, and as a vibrato
     effect if the mix value is 1.
 

--- a/modules/juce_graphics/images/juce_ScaledImage.h
+++ b/modules/juce_graphics/images/juce_ScaledImage.h
@@ -65,7 +65,7 @@ public:
     ScaledImage (const Image& imageIn, double scaleIn)
         : image (imageIn), scaleFactor (scaleIn) {}
 
-    /** Returns the image at its original dimentions. */
+    /** Returns the image at its original dimensions. */
     Image getImage() const { return image; }
 
     /** Returns the image's scale. */

--- a/modules/juce_gui_basics/accessibility/interfaces/juce_AccessibilityValueInterface.h
+++ b/modules/juce_gui_basics/accessibility/interfaces/juce_AccessibilityValueInterface.h
@@ -113,7 +113,7 @@ public:
         /** Returns the minimum value for this range. */
         double getMinimumValue() const noexcept  { return range.min; }
 
-        /** Returns the maxiumum value for this range. */
+        /** Returns the maximum value for this range. */
         double getMaximumValue() const noexcept  { return range.max; }
 
         /** Returns the interval for this range. */

--- a/modules/juce_gui_basics/layout/juce_MultiDocumentPanel.h
+++ b/modules/juce_gui_basics/layout/juce_MultiDocumentPanel.h
@@ -328,7 +328,7 @@ public:
         operation you could give a value of false to the callback to abort the close operation.
 
         If your component is based on the FileBasedDocument class, then you'd probably want
-        to call FileBasedDocument::saveIfNeededAndUserAgreesAsync() and call the calback with
+        to call FileBasedDocument::saveIfNeededAndUserAgreesAsync() and call the callback with
         true if this returned FileBasedDocument::savedOk.
 
         @see closeDocumentAsync, FileBasedDocument::saveIfNeededAndUserAgreesAsync()

--- a/modules/juce_gui_basics/native/accessibility/juce_ios_Accessibility.mm
+++ b/modules/juce_gui_basics/native/accessibility/juce_ios_Accessibility.mm
@@ -399,7 +399,7 @@ private:
         {
             if (auto* handler = getHandler (self))
             {
-                // occasionaly VoiceOver sends accessibilityActivate to the wrong element, so we first query
+                // occasionally VoiceOver sends accessibilityActivate to the wrong element, so we first query
                 // which element it thinks has focus and forward the event on to that element if it differs
                 id focusedElement = UIAccessibilityFocusedElement (UIAccessibilityNotificationVoiceOverIdentifier);
 

--- a/modules/juce_gui_basics/native/juce_common_MimeTypes.cpp
+++ b/modules/juce_gui_basics/native/juce_common_MimeTypes.cpp
@@ -434,7 +434,7 @@ MimeTypeTableEntry MimeTypeTableEntry::table[641] =
     {"psd",      "application/octet-stream"},
     {"pvu",      "paleovu/x-pv"},
     {"pwz",      "application/vnd.ms-powerpoint"},
-    {"py",       "text/x-script.phyton"},
+    {"py",       "text/x-script.python"},
     {"pyc",      "application/x-bytecode.python"},
     {"qcp",      "audio/vnd.qcelp"},
     {"qd3",      "x-world/x-3dmf"},

--- a/modules/juce_gui_basics/widgets/juce_Slider.h
+++ b/modules/juce_gui_basics/widgets/juce_Slider.h
@@ -889,7 +889,7 @@ public:
     //==============================================================================
     /** An RAII class for sending slider listener drag messages.
 
-        This is useful if you are programatically updating the slider's value and want
+        This is useful if you are programmatically updating the slider's value and want
         to imitate a mouse event, for example in a custom AccessibilityHandler.
 
         @see Slider::Listener

--- a/modules/juce_video/native/juce_ios_CameraDevice.h
+++ b/modules/juce_video/native/juce_ios_CameraDevice.h
@@ -1305,7 +1305,7 @@ struct CameraDevice::ViewerComponent  : public UIViewComponent
     {
         static JuceCameraDeviceViewerClass cls;
 
-        // Initial size that can be overriden later.
+        // Initial size that can be overridden later.
         setSize (640, 480);
 
         auto view = [cls.createInstance() init];

--- a/modules/juce_video/native/juce_win32_CameraDevice.h
+++ b/modules/juce_video/native/juce_win32_CameraDevice.h
@@ -362,7 +362,7 @@ struct CameraDevice::Pimpl  : public ChangeBroadcaster
 
                             using Fn = HRESULT (*) (IWMProfileManager**);
 
-                            // This function is available on Windows 2000 and up, but we load it at runtime anway
+                            // This function is available on Windows 2000 and up, but we load it at runtime anyway
                             // because some versions of MinGW ship with libraries that don't include this symbol.
                             if (auto* fn = reinterpret_cast<Fn> (wmvcoreLibrary.getFunction ("WMCreateProfileManager")))
                                 hr = fn (profileManager.resetAndGetPointerAddress());


### PR DESCRIPTION
Found via `codespell -q 3 -S ./modules/juce_audio_formats/codecs/flac,./modules/juce_audio_formats/codecs/oggvorbis,./modules/juce_audio_processors/format_types/VST3_SDK,./modules/juce_graphics/image_formats/pnglib,./modules/juce_graphics/image_formats/jpglib,./modules/juce_core/zip/zlib -L acn,alse,ba,busses,currenty,fo,ifset,initialy,inout,lod,nd,numer,ontext,ons,originaly,prset,pres,ptd,ro,statics,te,toi,vew,windowz`