### PR TITLE
Fix Projucer.jucer and clean-up .jucer files

### DIFF
--- a/extras/AudioPluginHost/AudioPluginHost.jucer
+++ b/extras/AudioPluginHost/AudioPluginHost.jucer
@@ -6,7 +6,7 @@
               reportAppUsage="0" companyCopyright="Raw Material Software Limited"
               useAppConfig="0" addUsingNamespaceToJuceHeader="1" jucerFormatVersion="1">
   <EXPORTFORMATS>
-    <XCODE_MAC targetFolder="Builds/MacOSX" rtasFolder="~/SDKs/PT_80_SDK" objCExtraSuffix="M73TRi"
+    <XCODE_MAC targetFolder="Builds/MacOSX"
                smallIcon="c97aUr" bigIcon="c97aUr" microphonePermissionNeeded="1"
                sendAppleEventsPermissionNeeded="1" sendAppleEventsPermissionText="This is required for some third-party plug-ins to function correctly."
                customXcodeResourceFolders="../../examples/Assets" applicationCategory="public.app-category.developer-tools">

--- a/extras/BinaryBuilder/BinaryBuilder.jucer
+++ b/extras/BinaryBuilder/BinaryBuilder.jucer
@@ -6,8 +6,8 @@
               companyCopyright="Raw Material Software Limited" useAppConfig="0"
               addUsingNamespaceToJuceHeader="1" jucerFormatVersion="1">
   <EXPORTFORMATS>
-    <XCODE_MAC targetFolder="Builds/MacOSX" vstFolder="~/SDKs/vstsdk2.4" rtasFolder="~/SDKs/PT_80_SDK"
-               objCExtraSuffix="OeJtJb" applicationCategory="public.app-category.developer-tools">
+    <XCODE_MAC targetFolder="Builds/MacOSX"
+               applicationCategory="public.app-category.developer-tools">
       <CONFIGURATIONS>
         <CONFIGURATION name="Debug" isDebug="1" targetName="BinaryBuilder"/>
         <CONFIGURATION name="Release" isDebug="0" optimisation="2" targetName="BinaryBuilder"/>
@@ -16,7 +16,7 @@
         <MODULEPATH id="juce_core" path="../../modules"/>
       </MODULEPATHS>
     </XCODE_MAC>
-    <LINUX_MAKE targetFolder="Builds/LinuxMakefile" vstFolder="~/SDKs/vstsdk2.4">
+    <LINUX_MAKE targetFolder="Builds/LinuxMakefile">
       <CONFIGURATIONS>
         <CONFIGURATION name="Debug" isDebug="1" targetName="BinaryBuilder"/>
         <CONFIGURATION name="Release" isDebug="0" optimisation="2" targetName="BinaryBuilder"/>

--- a/extras/Projucer/Projucer.jucer
+++ b/extras/Projucer/Projucer.jucer
@@ -6,15 +6,15 @@
               companyCopyright="Raw Material Software Limited" useAppConfig="0"
               addUsingNamespaceToJuceHeader="1" jucerFormatVersion="1">
   <EXPORTFORMATS>
-    <XCODE_MAC targetFolder="Builds/MacOSX" vstFolder="~/SDKs/vstsdk2.4" rtasFolder="~/SDKs/PT_80_SDK"
-               documentExtensions=".jucer" objCExtraSuffix="zkVtji" bigIcon="Zrx1Gl"
+    <XCODE_MAC targetFolder="Builds/MacOSX"
+               documentExtensions=".jucer" bigIcon="Zrx1Gl"
                extraFrameworks="AudioUnit; Accelerate; AVFoundation; CoreAudio; CoreAudioKit; CoreMIDI; DiscRecording; QuartzCore; AudioToolbox; OpenGL; QTKit; QuickTime"
                microphonePermissionNeeded="1" cameraPermissionNeeded="1" smallIcon="Zrx1Gl"
                applicationCategory="public.app-category.developer-tools">
       <CONFIGURATIONS>
-        <CONFIGURATION name="Debug" isDebug="1" targetName="Projucer" cppLibType="libc++"
+        <CONFIGURATION name="Debug" isDebug="1" targetName="Projucer"
                        recommendedWarnings="LLVM" macOSDeploymentTarget="10.12"/>
-        <CONFIGURATION name="Release" isDebug="0" targetName="Projucer" cppLibType="libc++"
+        <CONFIGURATION name="Release" isDebug="0" targetName="Projucer"
                        linkTimeOptimisation="0" recommendedWarnings="LLVM" macOSDeploymentTarget="10.12"/>
       </CONFIGURATIONS>
       <MODULEPATHS>

--- a/extras/Projucer/Projucer.jucer
+++ b/extras/Projucer/Projucer.jucer
@@ -620,8 +620,8 @@
               file="Source/Utility/Helpers/jucer_TranslationHelpers.h"/>
         <FILE id="EuC4K4" name="jucer_ValueSourceHelpers.h" compile="0" resource="0"
               file="Source/Utility/Helpers/jucer_ValueSourceHelpers.h"/>
-        <FILE id="W5a5Fy" name="jucer_ValueWithDefaultWrapper.h" compile="0"
-              resource="0" file="Source/Utility/Helpers/jucer_ValueWithDefaultWrapper.h"/>
+        <FILE id="DIiaPk" name="jucer_ValueTreePropertyWithDefaultWrapper.h"
+              compile="0" resource="0" file="Source/Utility/Helpers/jucer_ValueTreePropertyWithDefaultWrapper.h"/>
         <FILE id="BPCoKV" name="jucer_VersionInfo.cpp" compile="1" resource="0"
               file="Source/Utility/Helpers/jucer_VersionInfo.cpp"/>
         <FILE id="TnBQtv" name="jucer_VersionInfo.h" compile="0" resource="0"


### PR DESCRIPTION
`Projucer.jucer` references a file that doesn't exist. When using `Jucer2CMake` to convert `Projucer.jucer` into a `CMakeLists.txt`, that non-existing file gets listed in the `CMakeLists.txt`, which makes cmake fail with:
```
-- Configuring done
CMake Error at D:/a/1/s/cmake/Reprojucer.cmake:2347 (add_executable):
  Cannot find source file:

    D:/a/1/s/ci/tmp/JUCE-6.1.4/extras/Projucer/Source/Utility/Helpers/jucer_ValueWithDefaultWrapper.h

  Tried extensions .c .C .c++ .cc .cpp .cxx .cu .mpp .m .M .mm .ixx .cppm .h
  .hh .h++ .hm .hpp .hxx .in .txx .f .F .for .f77 .f90 .f95 .f03 .hip .ispc
Call Stack (most recent call first):
  D:/a/1/s/generated/JUCE-6.1.4/extras/Projucer/CMakeLists.txt:667 (jucer_project_end)


CMake Error at D:/a/1/s/cmake/Reprojucer.cmake:2347 (add_executable):
  No SOURCES given to target: Projucer
Call Stack (most recent call first):
  D:/a/1/s/generated/JUCE-6.1.4/extras/Projucer/CMakeLists.txt:667 (jucer_project_end)
```

😿 