### PR TITLE
Fix invalid usage of JUCE_NODISCARD

### DIFF
--- a/modules/juce_core/maths/juce_Range.h
+++ b/modules/juce_core/maths/juce_Range.h
@@ -63,14 +63,14 @@ public:
     }
 
     /** Returns a range with a given start and length. */
-    static JUCE_NODISCARD Range withStartAndLength (const ValueType startValue, const ValueType length) noexcept
+    JUCE_NODISCARD static Range withStartAndLength (const ValueType startValue, const ValueType length) noexcept
     {
         jassert (length >= ValueType());
         return Range (startValue, startValue + length);
     }
 
     /** Returns a range with the specified start position and a length of zero. */
-    constexpr static JUCE_NODISCARD Range emptyRange (const ValueType start) noexcept
+    JUCE_NODISCARD constexpr static Range emptyRange (const ValueType start) noexcept
     {
         return Range (start, start);
     }
@@ -104,13 +104,13 @@ public:
         If the new start position is higher than the current end of the range, the end point
         will be pushed along to equal it, returning an empty range at the new position.
     */
-    constexpr JUCE_NODISCARD Range withStart (const ValueType newStart) const noexcept
+    JUCE_NODISCARD constexpr Range withStart (const ValueType newStart) const noexcept
     {
         return Range (newStart, jmax (newStart, end));
     }
 
     /** Returns a range with the same length as this one, but moved to have the given start position. */
-    constexpr JUCE_NODISCARD Range movedToStartAt (const ValueType newStart) const noexcept
+    JUCE_NODISCARD constexpr Range movedToStartAt (const ValueType newStart) const noexcept
     {
         return Range (newStart, end + (newStart - start));
     }
@@ -130,13 +130,13 @@ public:
         If the new end position is below the current start of the range, the start point
         will be pushed back to equal the new end point.
     */
-    constexpr JUCE_NODISCARD Range withEnd (const ValueType newEnd) const noexcept
+    JUCE_NODISCARD constexpr Range withEnd (const ValueType newEnd) const noexcept
     {
         return Range (jmin (start, newEnd), newEnd);
     }
 
     /** Returns a range with the same length as this one, but moved to have the given end position. */
-    constexpr JUCE_NODISCARD Range movedToEndAt (const ValueType newEnd) const noexcept
+    JUCE_NODISCARD constexpr Range movedToEndAt (const ValueType newEnd) const noexcept
     {
         return Range (start + (newEnd - end), newEnd);
     }
@@ -152,7 +152,7 @@ public:
     /** Returns a range with the same start as this one, but a different length.
         Lengths less than zero are treated as zero.
     */
-    constexpr JUCE_NODISCARD Range withLength (const ValueType newLength) const noexcept
+    JUCE_NODISCARD constexpr Range withLength (const ValueType newLength) const noexcept
     {
         return Range (start, start + newLength);
     }
@@ -161,7 +161,7 @@ public:
         given amount.
         @returns The returned range will be (start - amount, end + amount)
     */
-    constexpr JUCE_NODISCARD Range expanded (ValueType amount) const noexcept
+    JUCE_NODISCARD constexpr Range expanded (ValueType amount) const noexcept
     {
         return Range (start - amount, end + amount);
     }
@@ -231,21 +231,21 @@ public:
 
     /** Returns the range that is the intersection of the two ranges, or an empty range
         with an undefined start position if they don't overlap. */
-    constexpr JUCE_NODISCARD Range getIntersectionWith (Range other) const noexcept
+    JUCE_NODISCARD constexpr Range getIntersectionWith (Range other) const noexcept
     {
         return Range (jmax (start, other.start),
                       jmin (end, other.end));
     }
 
     /** Returns the smallest range that contains both this one and the other one. */
-    constexpr JUCE_NODISCARD Range getUnionWith (Range other) const noexcept
+    JUCE_NODISCARD constexpr Range getUnionWith (Range other) const noexcept
     {
         return Range (jmin (start, other.start),
                       jmax (end, other.end));
     }
 
     /** Returns the smallest range that contains both this one and the given value. */
-    constexpr JUCE_NODISCARD Range getUnionWith (const ValueType valueToInclude) const noexcept
+    JUCE_NODISCARD constexpr Range getUnionWith (const ValueType valueToInclude) const noexcept
     {
         return Range (jmin (valueToInclude, start),
                       jmax (valueToInclude, end));

--- a/modules/juce_graphics/colour/juce_Colour.h
+++ b/modules/juce_graphics/colour/juce_Colour.h
@@ -387,14 +387,14 @@ public:
         Looks for a colour that contrasts with both of the colours passed-in.
         Handy for things like choosing a highlight colour in text editors, etc.
     */
-    static JUCE_NODISCARD Colour contrasting (Colour colour1,
+    JUCE_NODISCARD static Colour contrasting (Colour colour1,
                                               Colour colour2) noexcept;
 
     //==============================================================================
     /** Returns an opaque shade of grey.
         @param brightness the level of grey to return - 0 is black, 1.0 is white
     */
-    static JUCE_NODISCARD Colour greyLevel (float brightness) noexcept;
+    JUCE_NODISCARD static Colour greyLevel (float brightness) noexcept;
 
     //==============================================================================
     /** Returns a stringified version of this colour.
@@ -403,7 +403,7 @@ public:
     String toString() const;
 
     /** Reads the colour from a string that was created with toString(). */
-    static JUCE_NODISCARD Colour fromString (StringRef encodedColourString);
+    JUCE_NODISCARD static Colour fromString (StringRef encodedColourString);
 
     /** Returns the colour as a hex string in the form RRGGBB or AARRGGBB. */
     String toDisplayString (bool includeAlphaValue) const;


### PR DESCRIPTION
`[[nodiscard]]` should be placed before the function declaration, not before the type in the function declaration.