### PR TITLE
Modernize Timer to allow a std::function callback instead of requiring inheritance

### DIFF
--- a/examples/DemoRunner/Source/Demos/IntroScreen.h
+++ b/examples/DemoRunner/Source/Demos/IntroScreen.h
@@ -70,13 +70,12 @@ private:
     HyperlinkButton linkButton { "www.juce.com", { "http://www.juce.com" } };
 
     //==============================================================================
-    struct LogoDrawComponent  : public Component,
-                                private Timer
+    struct LogoDrawComponent  : public Component
     {
         LogoDrawComponent()
         {
             setTitle ("JUCE Logo");
-            startTimerHz (30); // repaint at 30 fps
+            timer.startTimerHz (30); // repaint at 30 fps
         }
 
         void paint (Graphics& g) override
@@ -108,16 +107,12 @@ private:
                                                         getLocalBounds().reduced (20, getHeight() / 4).toFloat()));
         }
 
-        void timerCallback() override
-        {
-            repaint();
-            elapsed += 0.02f;
-        }
-
         std::unique_ptr<AccessibilityHandler> createAccessibilityHandler() override
         {
             return std::make_unique<AccessibilityHandler> (*this, AccessibilityRole::image);
         }
+
+        Timer timer { [this] { repaint(); elapsed += 0.02f; } };
 
         Path logoPath  { getJUCELogoPath() };
         float elapsed = 0.0f;

--- a/modules/juce_events/timers/juce_Timer.cpp
+++ b/modules/juce_events/timers/juce_Timer.cpp
@@ -112,6 +112,8 @@ public:
             JUCE_TRY
             {
                 timer->timerCallback();
+                if (timer->onTimer)
+                    timer->onTimer();
             }
             JUCE_CATCH_EXCEPTION
 
@@ -313,7 +315,8 @@ Timer::TimerThread::LockType Timer::TimerThread::lock;
 
 //==============================================================================
 Timer::Timer() noexcept {}
-Timer::Timer (const Timer&) noexcept {}
+Timer::Timer (std::function<void()> callback) noexcept { onTimer = std::move (callback); }
+Timer::Timer (const Timer& other) noexcept { onTimer = other.onTimer; }
 
 Timer::~Timer()
 {

--- a/modules/juce_events/timers/juce_Timer.h
+++ b/modules/juce_events/timers/juce_Timer.h
@@ -66,6 +66,11 @@ protected:
 
 public:
     //==============================================================================
+    /** Creates a Timer and assigns a lambda to the callback object.
+    */
+    Timer (std::function<void()>) noexcept;
+
+    //==============================================================================
     /** Destructor. */
     virtual ~Timer();
 
@@ -75,7 +80,12 @@ public:
         It's perfectly ok to call startTimer() or stopTimer() from within this
         callback to change the subsequent intervals.
     */
-    virtual void timerCallback() = 0;
+    virtual void timerCallback() {}
+
+    /** You can assign a lambda to this callback object to have it called
+        periodically.
+     */
+    std::function<void()> onTimer;
 
     //==============================================================================
     /** Starts the timer and sets the length of interval required.


### PR DESCRIPTION
Favor composition over inheritance provides higher flexibility. Allowing Timers to be named member variables provides hints to the purpose of the Timer. Supporting multiple Timers in one class becomes easier. Class hierarchies become less fragile. 

