### PR TITLE
Add support for OSC Types T,F and I

### DIFF
--- a/modules/juce_osc/osc/juce_OSCArgument.cpp
+++ b/modules/juce_osc/osc/juce_OSCArgument.cpp
@@ -26,13 +26,24 @@
 namespace juce
 {
 
-OSCArgument::OSCArgument (int32 v)              : type (OSCTypes::int32),   intValue (v) {}
-OSCArgument::OSCArgument (float v)              : type (OSCTypes::float32), floatValue (v) {}
-OSCArgument::OSCArgument (const String& s)      : type (OSCTypes::string),  stringValue (s) {}
-OSCArgument::OSCArgument (MemoryBlock b)        : type (OSCTypes::blob),    blob (std::move (b)) {}
-OSCArgument::OSCArgument (OSCColour c)          : type (OSCTypes::colour),  intValue ((int32) c.toInt32()) {}
+OSCArgument::OSCArgument()                      : type(OSCTypes::I) {}
+OSCArgument::OSCArgument(bool v)                : type (v?OSCTypes::T:OSCTypes::F)               {}
+OSCArgument::OSCArgument (int32 v)              : type (OSCTypes::int32),           intValue (v) {}
+OSCArgument::OSCArgument (float v)              : type (OSCTypes::float32),         floatValue (v) {}
+OSCArgument::OSCArgument (const String& s)      : type (OSCTypes::string),          stringValue (s) {}
+OSCArgument::OSCArgument (MemoryBlock b)        : type (OSCTypes::blob),            blob (std::move (b)) {}
+OSCArgument::OSCArgument (OSCColour c)          : type (OSCTypes::colour),          intValue ((int32) c.toInt32()) {}
 
 //==============================================================================
+bool OSCArgument::getBool() const noexcept
+{
+    if (isTorF())
+        return type == OSCTypes::T;
+
+    jassertfalse; // you must check the type of an argument before attempting to get its value!
+    return {};
+}
+
 String OSCArgument::getString() const noexcept
 {
     if (isString())

--- a/modules/juce_osc/osc/juce_OSCArgument.h
+++ b/modules/juce_osc/osc/juce_OSCArgument.h
@@ -40,6 +40,12 @@ namespace juce
 class JUCE_API  OSCArgument
 {
 public:
+    /** Constructs an OSCArgument with type I (for Impulse). */
+    OSCArgument();
+    
+    /** Constructs an OSCArgument with type boolean T or F depending on the value. */
+    OSCArgument(bool trueOrFalse);
+
     /** Constructs an OSCArgument with type int32 and a given value. */
     OSCArgument (int32 value);
 
@@ -65,6 +71,12 @@ public:
     */
     OSCType getType() const noexcept        { return type; }
 
+    /** Returns whether the type of the OSCArgument is T or F. */
+    bool isImpulse() const noexcept { return type == OSCTypes::I; }
+   
+    /** Returns whether the type of the OSCArgument is T or F. */
+    bool isTorF() const noexcept { return type == OSCTypes::T || type == OSCTypes::F; }
+    
     /** Returns whether the type of the OSCArgument is int32. */
     bool isInt32() const noexcept           { return type == OSCTypes::int32; }
 
@@ -79,6 +91,11 @@ public:
 
     /** Returns whether the type of the OSCArgument is colour. */
     bool isColour() const noexcept          { return type == OSCTypes::colour; }
+
+    /** Returns the value of the OSCArgument as an int32.
+        If the type of the OSCArgument is not int32, the behaviour is undefined.
+    */
+    bool getBool() const noexcept;
 
     /** Returns the value of the OSCArgument as an int32.
         If the type of the OSCArgument is not int32, the behaviour is undefined.

--- a/modules/juce_osc/osc/juce_OSCMessage.cpp
+++ b/modules/juce_osc/osc/juce_OSCMessage.cpp
@@ -88,6 +88,7 @@ void OSCMessage::clear()
 }
 
 //==============================================================================
+void OSCMessage::addBool(bool value)                { arguments.add(OSCArgument(value)); }
 void OSCMessage::addInt32 (int32 value)             { arguments.add (OSCArgument (value)); }
 void OSCMessage::addFloat32 (float value)           { arguments.add (OSCArgument (value)); }
 void OSCMessage::addString (const String& value)    { arguments.add (OSCArgument (value)); }

--- a/modules/juce_osc/osc/juce_OSCMessage.h
+++ b/modules/juce_osc/osc/juce_OSCMessage.h
@@ -119,6 +119,11 @@ public:
     void clear();
 
     //==============================================================================
+    /** Creates a new OSCArgument of type T or F depending on the given value,
+        and adds it to the OSCMessage object.
+    */
+    void addBool(bool value);
+    
     /** Creates a new OSCArgument of type int32 with the given value,
         and adds it to the OSCMessage object.
     */

--- a/modules/juce_osc/osc/juce_OSCReceiver.cpp
+++ b/modules/juce_osc/osc/juce_OSCReceiver.cpp
@@ -174,17 +174,19 @@ namespace
             return typeList;
         }
 
-        //==============================================================================
-        OSCArgument readArgument (OSCType type)
-        {
-            switch (type)
+			//==============================================================================
+		OSCArgument readArgument(OSCType type)
+		{
+			switch (type)
             {
-                case OSCTypes::int32:       return OSCArgument (readInt32());
-                case OSCTypes::float32:     return OSCArgument (readFloat32());
-                case OSCTypes::string:      return OSCArgument (readString());
-                case OSCTypes::blob:        return OSCArgument (readBlob());
-                case OSCTypes::colour:      return OSCArgument (readColour());
-
+				case OSCTypes::I:			return OSCArgument();
+				case OSCTypes::T:			return OSCArgument(true);
+				case OSCTypes::F:			return OSCArgument(false);
+				case OSCTypes::int32:       return OSCArgument(readInt32());
+				case OSCTypes::float32:     return OSCArgument(readFloat32());
+				case OSCTypes::string:      return OSCArgument(readString());
+				case OSCTypes::blob:        return OSCArgument(readBlob());
+				case OSCTypes::colour:      return OSCArgument(readColour());
                 default:
                     // You supplied an invalid OSCType when calling readArgument! This should never happen.
                     jassertfalse;

--- a/modules/juce_osc/osc/juce_OSCSender.cpp
+++ b/modules/juce_osc/osc/juce_OSCSender.cpp
@@ -123,6 +123,9 @@ namespace
         {
             switch (arg.getType())
             {
+                case OSCTypes::T:           return true;
+                case OSCTypes::F:           return true;
+                case OSCTypes::I:           return true;
                 case OSCTypes::int32:       return writeInt32 (arg.getInt32());
                 case OSCTypes::float32:     return writeFloat32 (arg.getFloat32());
                 case OSCTypes::string:      return writeString (arg.getString());

--- a/modules/juce_osc/osc/juce_OSCTypes.cpp
+++ b/modules/juce_osc/osc/juce_OSCTypes.cpp
@@ -26,6 +26,9 @@
 namespace juce
 {
 
+const OSCType OSCTypes::T = 'T';
+const OSCType OSCTypes::F = 'F';
+const OSCType OSCTypes::I = 'I';
 const OSCType OSCTypes::int32   = 'i';
 const OSCType OSCTypes::float32 = 'f';
 const OSCType OSCTypes::string  = 's';

--- a/modules/juce_osc/osc/juce_OSCTypes.h
+++ b/modules/juce_osc/osc/juce_OSCTypes.h
@@ -46,6 +46,9 @@ using OSCTypeList = Array<OSCType>;
 class JUCE_API  OSCTypes
 {
 public:
+    static const OSCType T;
+    static const OSCType F;
+    static const OSCType I;
     static const OSCType int32;
     static const OSCType float32;
     static const OSCType string;
@@ -54,7 +57,10 @@ public:
 
     static bool isSupportedType (OSCType type) noexcept
     {
-        return type == OSCTypes::int32
+        return type == OSCTypes::T
+            || type == OSCTypes::F
+            || type == OSCTypes::I
+            || type == OSCTypes::int32
             || type == OSCTypes::float32
             || type == OSCTypes::string
             || type == OSCTypes::blob


### PR DESCRIPTION
This adds support for the types T, F and I in OSC Messages.
Thoses types are part of the required list in the OSC 1.1 specification (Page 3, Paragraph 3.5) : https://opensoundcontrol.stanford.edu/files/2009-NIME-OSC-1.1.pdf 