### PR TITLE
Demangle stack traces in macOS/Linux

### DIFF
--- a/modules/juce_core/system/juce_SystemStats.cpp
+++ b/modules/juce_core/system/juce_SystemStats.cpp
@@ -20,6 +20,10 @@
   ==============================================================================
 */
 
+#if ! JUCE_ANDROID && ! JUCE_MINGW && ! JUCE_WASM && ! JUCE_WINDOWS
+ #include <cxxabi.h>
+#endif
+
 namespace juce
 {
 
@@ -178,7 +182,25 @@ String SystemStats::getStackBacktrace()
     char** frameStrings = backtrace_symbols (stack, frames);
 
     for (int i = 0; i < frames; ++i)
+    {
+        Dl_info info;
+        if (dladdr (stack[i], &info))
+        {
+            int status;
+            std::unique_ptr<char, decltype (::free)*> demangled (abi::__cxa_demangle (info.dli_sname, nullptr, 0, &status), ::free);
+            if (status == 0)
+            {
+                result
+                    << juce::String (i).paddedRight (' ', 3)
+                    << " " << juce::File (juce::String (info.dli_fname)).getFileName().paddedRight (' ', 35)
+                    << " 0x" << juce::String::toHexString ((size_t) stack[i]).paddedLeft ('0', sizeof (void*) * 2)
+                    << " " << demangled.get()
+                    << " + " << ((char*) stack[i] - (char*) info.dli_saddr) << newLine;
+                continue;
+            }
+        }
         result << frameStrings[i] << newLine;
+    }
 
     ::free (frameStrings);
    #endif


### PR DESCRIPTION
When using `JUCE_HEAVYWEIGHT_LEAK_DETECTOR` the stack traces are currently only demangled on Windows. This change demangles them on macOS and Linux (not tested) as well.

To test, add a JUCE_HEAVYWEIGHT_LEAK_DETECTOR and an accompanying memory leak to any JUCE app.

Before the change stack traces used to look like this:

```
Backtrace 1
-----------------------------------------------------------------
0   DemoRunner                          0x0000000104c681d0 _ZN4juce11SystemStats17getStackBacktraceEv + 88
1   DemoRunner                          0x000000010461d78c _ZN4juce31HeavyweightLeakedObjectDetectorI11IntroScreenEC2Ev + 36
2   DemoRunner                          0x0000000104619da4 _ZN4juce31HeavyweightLeakedObjectDetectorI11IntroScreenEC1Ev + 28
3   DemoRunner                          0x00000001046199f4 _ZN11IntroScreenC2Ev + 252
4   DemoRunner                          0x00000001046193a8 _ZN11IntroScreenC1Ev + 28
5   DemoRunner                          0x000000010461935c _Z15createIntroDemov + 28
6   DemoRunner                          0x00000001048ec328 _ZN11DemoContent14showHomeScreenEv + 28
7   DemoRunner                          0x00000001048ec294 _ZN20DemoContentComponent14showHomeScreenEv + 36
8   DemoRunner                          0x00000001048f51f8 _ZN13MainComponentC2Ev + 716
9   DemoRunner                          0x00000001048f5750 _ZN13MainComponentC1Ev + 28
10  DemoRunner                          0x0000000104908760 _ZN21DemoRunnerApplication13MainAppWindowC2ERKN4juce6StringE + 432
11  DemoRunner                          0x00000001049085a0 _ZN21DemoRunnerApplication13MainAppWindowC1ERKN4juce6StringE + 36
12  DemoRunner                          0x0000000104907fe4 _ZN21DemoRunnerApplication10initialiseERKN4juce6StringE + 120
13  DemoRunner                          0x0000000104ec7654 _ZN4juce19JUCEApplicationBase13initialiseAppEv + 168
14  DemoRunner                          0x00000001050a7620 _ZN4juce15JUCEApplication13initialiseAppEv + 24
15  DemoRunner                          0x0000000104ec7430 _ZN4juce19JUCEApplicationBase4mainEv + 212
16  DemoRunner                          0x0000000104ec7300 _ZN4juce19JUCEApplicationBase4mainEiPPKc + 68
17  DemoRunner                          0x0000000104907d88 main + 56
18  dyld                                0x000000010891d0f4 start + 520
```

After the change they are properly demangled:

```
Backtrace 1
-----------------------------------------------------------------
0   DemoRunner                          0x0000000100afba40 juce::SystemStats::getStackBacktrace() + 100
1   DemoRunner                          0x00000001004b0ff0 juce::HeavyweightLeakedObjectDetector<IntroScreen>::HeavyweightLeakedObjectDetector() + 36
2   DemoRunner                          0x00000001004ad608 juce::HeavyweightLeakedObjectDetector<IntroScreen>::HeavyweightLeakedObjectDetector() + 28
3   DemoRunner                          0x00000001004ad258 IntroScreen::IntroScreen() + 252
4   DemoRunner                          0x00000001004acc0c IntroScreen::IntroScreen() + 28
5   DemoRunner                          0x00000001004acbc0 createIntroDemo() + 28
6   DemoRunner                          0x000000010077fb8c DemoContent::showHomeScreen() + 28
7   DemoRunner                          0x000000010077faf8 DemoContentComponent::showHomeScreen() + 36
8   DemoRunner                          0x0000000100788a5c MainComponent::MainComponent() + 716
9   DemoRunner                          0x0000000100788fb4 MainComponent::MainComponent() + 28
10  DemoRunner                          0x000000010079bfc4 DemoRunnerApplication::MainAppWindow::MainAppWindow(juce::String const&) + 432
11  DemoRunner                          0x000000010079be04 DemoRunnerApplication::MainAppWindow::MainAppWindow(juce::String const&) + 36
12  DemoRunner                          0x000000010079b848 DemoRunnerApplication::initialise(juce::String const&) + 120
13  DemoRunner                          0x0000000100d5b5a0 juce::JUCEApplicationBase::initialiseApp() + 168
14  DemoRunner                          0x0000000100f3b56c juce::JUCEApplication::initialiseApp() + 24
15  DemoRunner                          0x0000000100d5b37c juce::JUCEApplicationBase::main() + 212
16  DemoRunner                          0x0000000100d5b24c juce::JUCEApplicationBase::main(int, char const**) + 68
17  DemoRunner                          0x000000010079b5ec main + 56
18  dyld                                0x00000001048250f4 start + 520
```