### PR TITLE
Remove unnecessary CMake version check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,9 +109,7 @@ endif()
 # ==================================================================================================
 # Install configuration
 
-if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.14")
-    set(extra_version_arg ARCH_INDEPENDENT)
-endif()
+set(extra_version_arg ARCH_INDEPENDENT)
 
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file("${JUCE_BINARY_DIR}/JUCEConfigVersion.cmake"


### PR DESCRIPTION
This check is unnecessary, since we require CMake 3.15 or higher, so
this check can _never_ return false and thus we don't need it.

Thank you for submitting a pull request.

Please make sure you have read and followed our contribution guidelines (.github/contributing.md in this repository). Your pull request will not be accepted if you have not followed the instructions.

