### PR TITLE
[Android] invoke juce::Thread runnable from within java.lang.Thread context.

### DIFF
--- a/modules/juce_core/native/juce_android_JNIHelpers.h
+++ b/modules/juce_core/native/juce_android_JNIHelpers.h
@@ -769,6 +769,14 @@ DECLARE_JNI_CLASS (AndroidBuildVersion, "android/os/Build$VERSION")
  DECLARE_JNI_CLASS (AndroidSurfaceHolder, "android/view/SurfaceHolder")
 #undef JNI_CLASS_MEMBERS
 
+#define JNI_CLASS_MEMBERS(METHOD, STATICMETHOD, FIELD, STATICFIELD, CALLBACK) \
+ METHOD (constructor1,     "<init>",     "(Ljava/lang/Runnable;)V") \
+ METHOD (constructor2,     "<init>",     "(Ljava/lang/Runnable;Ljava/lang/String;)V") \
+ METHOD (start,            "start",      "()V") \
+
+DECLARE_JNI_CLASS (JavaLangThread, "java/lang/Thread")
+#undef JNI_CLASS_MEMBERS
+
 //==============================================================================
 namespace
 {

--- a/modules/juce_core/threads/juce_Thread.h
+++ b/modules/juce_core/threads/juce_Thread.h
@@ -381,6 +381,7 @@ public:
    #endif
 
 private:
+    friend class ThreadTargetRunnable; // needs to access threadHandle
     //==============================================================================
     const String threadName;
     Atomic<void*> threadHandle { nullptr };
@@ -396,6 +397,7 @@ private:
 
    #if JUCE_ANDROID
     bool isAndroidRealtimeThread = false;
+    /*GlobalRef*/ void* javaThreadPeer { nullptr };
    #endif
 
    #ifndef DOXYGEN


### PR DESCRIPTION
(redoing #1039, sorry for the noise here too.)

This fixes the core part of the issues exposed at https://forum.juce.com/t/env-findclass-does-not-work-inside-juce-app-very-strange/46886
The full details are explained at https://atsushieno.github.io/2022/03/16/juce-android-threads.html

The existing juce::Thread invokes its runnable (`run()`) target using
`pthread_create()`. This is causing any JNI invocation that involves
non-framework classes and non-registered JUCE Java classes not loading.

This Android NDK documentation explains that it is anticipated:
https://developer.android.com/training/articles/perf-jni#threads

To fix this issue, `java.lang.Thread` context is needed.

Since there seems no way to first create `pthread_create()` and attach it to
`java.lang.Thread` without already having it running, we need to have a
`java.lang.Thread` and let it callback to native code (we can use `Runnable`
proxy based on JNIClassBase), retrieve `pthread_t` ID via `pthread_self()`
and proceeed to the actual runnable (`run()` on `juce::Thread`).

The JNI part is involved only at `start()` in this change - on Android
thread cancellation is not really supported (not in JUCE on Android either).

Thank you for submitting a pull request.

Please make sure you have read and followed our contribution guidelines (.github/contributing.md in this repository). Your pull request will not be accepted if you have not followed the instructions.

