### PR TITLE
[Android] Add missing activity lifecycle callback "onActivityConfigurationChanged"

### DIFF
--- a/modules/juce_core/native/juce_android_JNIHelpers.cpp
+++ b/modules/juce_core/native/juce_android_JNIHelpers.cpp
@@ -440,6 +440,7 @@ jobject ActivityLifecycleCallbacks::invoke (jobject proxy, jobject method, jobje
     else if (methodName == "onActivityPostSaveInstanceState")  { onActivityPostSaveInstanceState (activity, bundle); return nullptr; }
     else if (methodName == "onActivityPostStarted")            { onActivityPostStarted (activity);                   return nullptr; }
     else if (methodName == "onActivityPostStopped")            { onActivityPostStopped (activity);                   return nullptr; }
+    else if (methodName == "onActivityConfigurationChanged")   { onActivityConfigurationChanged (activity);          return nullptr; }
 
     return AndroidInterfaceImplementer::invoke (proxy, method, args);
 }

--- a/modules/juce_core/native/juce_android_JNIHelpers.h
+++ b/modules/juce_core/native/juce_android_JNIHelpers.h
@@ -916,6 +916,7 @@ public:
     virtual void onActivityPostSaveInstanceState (jobject /*activity*/, jobject /*bundle*/)  {}
     virtual void onActivityPostStarted           (jobject /*activity*/)                      {}
     virtual void onActivityPostStopped           (jobject /*activity*/)                      {}
+    virtual void onActivityConfigurationChanged  (jobject /*activity*/)                      {}
 
 private:
     jobject invoke (jobject, jobject, jobjectArray) override;


### PR DESCRIPTION
We noticed this issue when upgrading our Pixel devices to the latest (March 2022) security update. This method was apparently not being called previously, but with the latest security update, it now it does, at least when the device is rotated. This now results in such devices experiencing a crash with the error:

`Expected receiver of type android.app.Application$ActivityLifecycleCallbacks, but got java.lang.Object`

Similar to previously mergd pr: https://github.com/juce-framework/JUCE/pull/574

Disclaimer: I am not a C++ dev, feel free to correct me :)