### PR TITLE
Take TextEditor top border, indent and line spacing into account when placing caret

### DIFF
--- a/modules/juce_gui_basics/widgets/juce_TextEditor.cpp
+++ b/modules/juce_gui_basics/widgets/juce_TextEditor.cpp
@@ -1630,7 +1630,7 @@ int TextEditor::getTextIndexAt (const int x, const int y) const
     const auto offset = getTextOffset();
 
     return indexAtPosition ((float) (x - offset.x),
-                            (float) (y - offset.y));
+                            (float) (y));
 }
 
 void TextEditor::insertTextAtCaret (const String& t)

--- a/modules/juce_gui_basics/widgets/juce_TextEditor.cpp
+++ b/modules/juce_gui_basics/widgets/juce_TextEditor.cpp
@@ -2577,7 +2577,7 @@ int TextEditor::indexAtPosition (const float x, const float y) const
     {
         for (Iterator i (*this); i.next();)
         {
-            if (y < i.lineY + i.lineHeight)
+            if (y < i.lineY + (i.lineHeight * lineSpacing))
             {
                 if (y < i.lineY)
                     return jmax (0, i.indexInText - 1);


### PR DESCRIPTION
[See the forum post for details](https://forum.juce.com/t/2-small-texteditor-bugs/51239)