### PR TITLE
Always set sample rate of hosted AU plugins, fixes a bug with plugins…

### DIFF
--- a/modules/juce_audio_processors/format_types/juce_AudioUnitPluginFormat.mm
+++ b/modules/juce_audio_processors/format_types/juce_AudioUnitPluginFormat.mm
@@ -1057,24 +1057,21 @@ public:
 
                     AudioUnitGetProperty (audioUnit, kAudioUnitProperty_SampleRate, scope, static_cast<UInt32> (i), &sampleRate, &sampleRateSize);
 
-                    if (sampleRate != sr)
+                    if (isAUv3) // setting kAudioUnitProperty_SampleRate fails on AUv3s
                     {
-                        if (isAUv3) // setting kAudioUnitProperty_SampleRate fails on AUv3s
-                        {
-                            AudioStreamBasicDescription stream;
-                            UInt32 dataSize = sizeof (stream);
-                            auto err = AudioUnitGetProperty (audioUnit, kAudioUnitProperty_StreamFormat, scope, static_cast<UInt32> (i), &stream, &dataSize);
+                        AudioStreamBasicDescription stream;
+                        UInt32 dataSize = sizeof (stream);
+                        auto err = AudioUnitGetProperty (audioUnit, kAudioUnitProperty_StreamFormat, scope, static_cast<UInt32> (i), &stream, &dataSize);
 
-                            if (err == noErr && dataSize == sizeof (stream))
-                            {
-                                stream.mSampleRate = sr;
-                                AudioUnitSetProperty (audioUnit, kAudioUnitProperty_StreamFormat, scope, static_cast<UInt32> (i), &stream, sizeof (stream));
-                            }
-                        }
-                        else
+                        if (err == noErr && dataSize == sizeof (stream))
                         {
-                            AudioUnitSetProperty (audioUnit, kAudioUnitProperty_SampleRate, scope, static_cast<UInt32> (i), &sr, sizeof (sr));
+                            stream.mSampleRate = sr;
+                            AudioUnitSetProperty (audioUnit, kAudioUnitProperty_StreamFormat, scope, static_cast<UInt32> (i), &stream, sizeof (stream));
                         }
+                    }
+                    else
+                    {
+                        AudioUnitSetProperty (audioUnit, kAudioUnitProperty_SampleRate, scope, static_cast<UInt32> (i), &sr, sizeof (sr));
                     }
 
                     if (isInput)


### PR DESCRIPTION
The **AU** plugins from the **Roland Cloud** collection (e.g. [JX3P](https://www.roland.com/us/products/rc_jx-3p/)) report that they are already set to a sample rate of 44.1 kHz when they are first instantiated. This is incorrect and internally they are set to another default sample rate.

On the JUCE side, the AU hosting code compares the sample rate set in the hosted plugin with the new sample rate to be set. When both are the same, the sample rate is not set again and has the effect that Roland Cloud AU plugins play back at incorrect pitch when being instantiated in a JUCE host with 44.1 kHz sample rate.

While this clearly is a bug in the Roalnd plugins I think JUCE could handle that case more gracefully by simply always setting the sample rate during `prepareToPlay()` as shown in this pull request.

