### PR TITLE
Small changes to handle large, multi-message sysEx data transfers

### DIFF
--- a/modules/juce_audio_basics/midi/juce_MidiMessage.cpp
+++ b/modules/juce_audio_basics/midi/juce_MidiMessage.cpp
@@ -134,7 +134,8 @@ MidiMessage::MidiMessage (const void* const d, const int dataSize, const double 
 {
     jassert (dataSize > 0);
     // this checks that the length matches the data..
-    jassert (dataSize > 3 || *(uint8*)d >= 0xf0 || getMessageLengthFromFirstByte (*(uint8*)d) == size);
+    auto lastByte = static_cast<const char*>(d)[dataSize-1];
+    jassert (dataSize > 3 || *(uint8*)d >= 0xf0 || (uint8)lastByte == 0xf7 || getMessageLengthFromFirstByte (*(uint8*)d) == size);
 
     memcpy (allocateSpace (dataSize), d, (size_t) dataSize);
 }

--- a/modules/juce_audio_devices/native/juce_mac_CoreMidi.mm
+++ b/modules/juce_audio_devices/native/juce_mac_CoreMidi.mm
@@ -52,7 +52,11 @@ namespace CoreMidiHelpers
         onlyOld
     };
 
-    #if (defined (MAC_OS_VERSION_11_0) || defined (__IPHONE_14_0))
+     #if defined (JUCE_FORCE_OLD_COREMIDI_API) && JUCE_FORCE_OLD_COREMIDI_API
+       #define JUCE_HAS_NEW_COREMIDI_API 0
+       #define JUCE_HAS_OLD_COREMIDI_API 1
+       constexpr auto implementationStrategy = ImplementationStrategy::onlyOld;
+     #elif (!defined (JUCE_FORCE_OLD_COREMIDI_API)) && (defined (MAC_OS_VERSION_11_0) || defined (__IPHONE_14_0))
      #if (MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_VERSION_11_0 || __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_14_0)
       #define JUCE_HAS_NEW_COREMIDI_API 1
       #define JUCE_HAS_OLD_COREMIDI_API 0


### PR DESCRIPTION
Hi. We are currently working on a project to use JUCE to handle firmware updates which require us to send large sysEx payloads that span multiple messages. In the process, we found that we needed to make a couple small changes to the JUCE library.

One change to the MidiMessage validation: We needed to allow small messages that could be the trailing end of a sysEx payload to pass the `jassert`

And secondly, we needed a way to force CoreMidi to use the old implementation because the new implementation does not currently handle large, multi-message sysEx payloads.

Thanks!
(resubmitting because the CLA verification failed on the first try)