### PR TITLE
[Projucer] Add missing plugtype category options of VST3 format.

### DIFF
--- a/extras/Projucer/Source/Project/jucer_Project.cpp
+++ b/extras/Projucer/Source/Project/jucer_Project.cpp
@@ -2286,9 +2286,9 @@ Array<var> Project::getDefaultVSTCategories() const noexcept
 
 StringArray Project::getAllVST3CategoryStrings() noexcept
 {
-    static StringArray vst3CategoryStrings { "Fx", "Instrument", "Analyzer", "Delay", "Distortion", "Drum", "Dynamics", "EQ", "External", "Filter",
-                                             "Generator", "Mastering", "Modulation", "Mono", "Network", "NoOfflineProcess", "OnlyOfflineProcess", "OnlyRT",
-                                             "Pitch Shift", "Restoration", "Reverb", "Sampler", "Spatial", "Stereo", "Surround", "Synth", "Tools", "Up-Downmix" };
+    static StringArray vst3CategoryStrings { "Fx", "Instrument", "Analyzer", "Ambisonics", "Delay", "Distortion", "Drum", "Dynamics", "EQ", "External", "Filter",
+                                             "Generator", "Mastering", "Modulation", "Mono", "Network", "NoOfflineProcess", "OnlyARA", "OnlyOfflineProcess", "OnlyRT",
+                                             "Piano", "Pitch Shift", "Restoration", "Reverb", "Sampler", "Spatial", "Stereo", "Surround", "Synth", "Tools", "Up-Downmix" };
 
     return vst3CategoryStrings;
 }


### PR DESCRIPTION
I found some missing options for plugtype category of VST3 in Projucer's editor.
The referenced PlugType definition can be found here.
https://github.com/juce-framework/JUCE/blob/e618f68d4dcaed56803e6e4120ea450f15fb5a93/modules/juce_audio_processors/format_types/VST3_SDK/pluginterfaces/vst/ivstaudioprocessor.h#L43

It would be great if Projucer could support the missing options as I use them in my projects.