### PR TITLE
juce_gui_basics: add missing header for std::exchange

### DIFF
--- a/modules/juce_gui_basics/juce_gui_basics.h
+++ b/modules/juce_gui_basics/juce_gui_basics.h
@@ -54,6 +54,8 @@
 #pragma once
 #define JUCE_GUI_BASICS_H_INCLUDED
 
+#include <utility>
+
 #include <juce_graphics/juce_graphics.h>
 #include <juce_data_structures/juce_data_structures.h>
 


### PR DESCRIPTION
This PR fixes builds on ArchLinux with GCC 12 by adding a missing include in juce_gui_basics.
Feel free to criticize or edit if you think the include should be put somewhere else.