### PR TITLE
Fix initializing lv2BinaryLocation member of MSVCBuildConfiguration

### DIFF
--- a/extras/Projucer/Source/ProjectSaving/jucer_ProjectExport_MSVC.h
+++ b/extras/Projucer/Source/ProjectSaving/jucer_ProjectExport_MSVC.h
@@ -168,7 +168,7 @@ public:
               vstBinaryLocation              (config, Ids::vstBinaryLocation,          getUndoManager()),
               vst3BinaryLocation             (config, Ids::vst3BinaryLocation,         getUndoManager()),
               aaxBinaryLocation              (config, Ids::aaxBinaryLocation,          getUndoManager()),
-              lv2BinaryLocation              (config, Ids::aaxBinaryLocation,          getUndoManager()),
+              lv2BinaryLocation              (config, Ids::lv2BinaryLocation,          getUndoManager()),
               unityPluginBinaryLocation      (config, Ids::unityPluginBinaryLocation,  getUndoManager(), {})
         {
             setPluginBinaryCopyLocationDefaults();


### PR DESCRIPTION
This should have been done in https://github.com/juce-framework/JUCE/commit/61f3c1dd98c73373b1e57c7f2f4722af79527632.