### PR TITLE
Make sure BlockingMessage does not run after Lock is deleted

### DIFF
--- a/modules/juce_events/messages/juce_MessageManager.cpp
+++ b/modules/juce_events/messages/juce_MessageManager.cpp
@@ -388,6 +388,10 @@ void MessageManager::Lock::exit() const noexcept
 
         if (blockingMessage != nullptr)
         {
+            {
+              ScopedLock lock(blockingMessage->ownerCriticalSection);
+              blockingMessage->owner.set(nullptr);
+            }
             blockingMessage->releaseEvent.signal();
             blockingMessage = nullptr;
         }


### PR DESCRIPTION
See
https://forum.juce.com/t/blockingmessage-accessing-messagemanager-lock-that-went-out-of-scope/51901

Thank you for submitting a pull request.

Please make sure you have read and followed our contribution guidelines (.github/contributing.md in this repository). Your pull request will not be accepted if you have not followed the instructions.

