### PR TITLE
Remove some unnecessary std::initializer_list temporaries.

### DIFF
--- a/modules/juce_core/containers/juce_ArrayBase.h
+++ b/modules/juce_core/containers/juce_ArrayBase.h
@@ -557,7 +557,7 @@ private:
     template <typename... Elements>
     void addImpl (Elements&&... toAdd)
     {
-        ignoreUnused (std::initializer_list<int> { (((void) checkSourceIsNotAMember (toAdd)), 0)... });
+        ((checkSourceIsNotAMember (toAdd)), ...);
         ensureAllocatedSize (numUsed + (int) sizeof... (toAdd));
         addAssumingCapacityIsReady (std::forward<Elements> (toAdd)...);
     }
@@ -565,7 +565,7 @@ private:
     template <typename... Elements>
     void addAssumingCapacityIsReady (Elements&&... toAdd)
     {
-        ignoreUnused (std::initializer_list<int> { ((void) (new (elements + numUsed++) ElementType (std::forward<Elements> (toAdd))), 0)... });
+        ignoreUnused ((new (elements + numUsed++) ElementType (std::forward<Elements> (toAdd)), ...));
     }
 
     //==============================================================================


### PR DESCRIPTION
We don't need them, since `ignoreUnused` will happily take as many
parameters as we give it. We don't need the `ignoreUnused` at all for
functions returning void - there is nothing to ignore, after all.

Thank you for submitting a pull request.

Please make sure you have read and followed our contribution guidelines (.github/contributing.md in this repository). Your pull request will not be accepted if you have not followed the instructions.

