### PR TITLE
Allow dynamic updates of VST3 parameter step count

### DIFF
--- a/modules/juce_audio_plugin_client/VST3/juce_VST3_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/VST3/juce_VST3_Wrapper.cpp
@@ -736,16 +736,6 @@ public:
 
             updateParameterInfo();
 
-            info.stepCount = (Steinberg::int32) 0;
-
-           #if ! JUCE_FORCE_LEGACY_PARAMETER_AUTOMATION_TYPE
-            if (param.isDiscrete())
-           #endif
-            {
-                const int numSteps = param.getNumSteps();
-                info.stepCount = (Steinberg::int32) (numSteps > 0 && numSteps < 0x7fffffff ? numSteps - 1 : 0);
-            }
-
             info.defaultNormalizedValue = param.getDefaultValue();
             jassert (info.defaultNormalizedValue >= 0 && info.defaultNormalizedValue <= 1.0f);
 
@@ -775,6 +765,19 @@ public:
             auto anyUpdated = updateParamIfChanged (info.title,      param.getName (128));
             anyUpdated     |= updateParamIfChanged (info.shortTitle, param.getName (8));
             anyUpdated     |= updateParamIfChanged (info.units,      param.getLabel());
+
+            auto prevStepCount = info.stepCount;
+            info.stepCount = (Steinberg::int32) 0;
+
+           #if ! JUCE_FORCE_LEGACY_PARAMETER_AUTOMATION_TYPE
+            if (param.isDiscrete())
+           #endif
+            {
+                const int numSteps = param.getNumSteps();
+                info.stepCount = (Steinberg::int32) (numSteps > 0 && numSteps < 0x7fffffff ? numSteps - 1 : 0);
+            }
+
+            anyUpdated |= (prevStepCount != info.stepCount);
 
             return anyUpdated;
         }


### PR DESCRIPTION
Sometimes it may be necessary to not only change the name or unit of a parameter at runtime but also to change the number of steps and notify the host about it.

This patch moves setting the VST3 parameter info step count into the `updateParameterInfo()` member function.
