### PR TITLE
Android: Fixed navigation bars appearing in kiosk mode when application is resumed

### DIFF
--- a/modules/juce_gui_basics/native/juce_android_Windowing.cpp
+++ b/modules/juce_gui_basics/native/juce_android_Windowing.cpp
@@ -895,7 +895,7 @@ public:
     void handleAppResumedCallback()
     {
         if (isKioskModeComponent())
-            setNavBarsHidden (navBarsHidden);
+            setNavBarsHidden (navBarsHidden, true);
     }
 
     //==============================================================================
@@ -1334,9 +1334,9 @@ private:
         return (shouldBeFullScreen && isKioskModeComponent());
     }
 
-    void setNavBarsHidden (bool hidden)
+    void setNavBarsHidden (bool hidden, bool forced)
     {
-        if (navBarsHidden != hidden)
+        if (navBarsHidden != hidden || forced)
         {
             navBarsHidden = hidden;
 

--- a/modules/juce_gui_basics/native/juce_android_Windowing.cpp
+++ b/modules/juce_gui_basics/native/juce_android_Windowing.cpp
@@ -1334,9 +1334,9 @@ private:
         return (shouldBeFullScreen && isKioskModeComponent());
     }
 
-    void setNavBarsHidden (bool hidden, bool forced)
+    void setNavBarsHidden (bool hidden, bool force)
     {
-        if (navBarsHidden != hidden || forced)
+        if (navBarsHidden != hidden || force)
         {
             navBarsHidden = hidden;
 


### PR DESCRIPTION
Original issue:
- On older devices the navigation bars may appear when the application is resumed from the background (Android 6.0 - Nexus 6.0)

Changes:
- Added `force` parameter to make sure navigation bars are updated even if it was already set