### PR TITLE
juce::GenericInterpolator: Fixed wrong variable to assign to.

### DIFF
--- a/modules/juce_audio_basics/utilities/juce_GenericInterpolator.h
+++ b/modules/juce_audio_basics/utilities/juce_GenericInterpolator.h
@@ -404,7 +404,7 @@ private:
                             }
                             else
                             {
-                                numInputSamplesAvailable = true;
+                                exceeded = true;
                             }
                         }
                     }


### PR DESCRIPTION
I found a misstake of assigning to variable in juce::GenericInterpolator class.

Please consider correcting this with reference to PR.
