### PR TITLE
Sample Accurate MIDI control VST3

### DIFF
--- a/modules/juce_audio_plugin_client/VST3/juce_VST3_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/VST3/juce_VST3_Wrapper.cpp
@@ -3356,7 +3356,7 @@ public:
                     if (juceVST3EditController != nullptr &&
                         juceVST3EditController->isMidiControllerParamID(vstParamID))
                     {
-                        // SURGE CHANGE - rather than just adding the last sample, add all the midi
+                        // SURGE  - rather than just adding the last sample, add all the midi
                         // events (this used to just be the numPoints==1 case)
                         if (numPoints == 1)
                         {

--- a/modules/juce_audio_plugin_client/VST3/juce_VST3_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/VST3/juce_VST3_Wrapper.cpp
@@ -3353,8 +3353,27 @@ public:
                     auto vstParamID = paramQueue->getParameterId();
 
                    #if JUCE_VST3_EMULATE_MIDI_CC_WITH_PARAMETERS
-                    if (juceVST3EditController != nullptr && juceVST3EditController->isMidiControllerParamID (vstParamID))
-                        addParameterChangeToMidiBuffer (offsetSamples, vstParamID, value);
+                    if (juceVST3EditController != nullptr &&
+                        juceVST3EditController->isMidiControllerParamID(vstParamID))
+                    {
+                        // SURGE CHANGE - rather than just adding the last sample, add all the midi
+                        // events (this used to just be the numPoints==1 case)
+                        if (numPoints == 1)
+                        {
+                            // No need to re-query
+                            addParameterChangeToMidiBuffer(offsetSamples, vstParamID, value);
+                        }
+                        else
+                        {
+                            for (auto mp = 0; mp < numPoints; ++mp)
+                            {
+                                Steinberg::int32 losampl;
+                                paramQueue->getPoint(mp, losampl, value);
+                                addParameterChangeToMidiBuffer(losampl, vstParamID, value);
+                            }
+                        }
+                        // END SURGE CHANGE
+                    }
                     else
                    #endif
                     {


### PR DESCRIPTION
Per a conversation with @reuk I'm submitting this PR so I can sign the CLA. He has
a slightly modified version of this change (probably checking error conditions! LOL) but 
asked me to do this and sign the CLA for authorship etc... reasons. 

VST3 makes all midi other than notes into parameter changes
and those become sample accurate, so everyone (u-he, old surge,
juce, etc...) who actualy want MIDI instead make 131 * 16 fake params
and read off them. BUT Juce was only reading the very last point in
a midi param since it isn't sample accurate on params. But JUCE
*is* sample accurate on MIDI. So very long block renders with pitch
bends would render improperly in some DAWs, like MultitrackStudio.

Fix that by, if you do unpack param to midi after your daw packs
midi to param, keeping the sample and putting in multiple events,
resulting in VST3 having sample accurate CC, PitchBend and Aftertouch

Thank you for submitting a pull request.

Please make sure you have read and followed our contribution guidelines (.github/contributing.md in this repository). Your pull request will not be accepted if you have not followed the instructions.

