### PR TITLE
Fix scrolling when treeview only have one item bigger than the viewport

### DIFF
--- a/modules/juce_gui_basics/widgets/juce_TreeView.cpp
+++ b/modules/juce_gui_basics/widgets/juce_TreeView.cpp
@@ -646,11 +646,15 @@ private:
         {
             auto* i = owner.rootItemVisible ? owner.rootItem
                                             : owner.rootItem->subItems.getFirst();
-
+            
+            TreeViewItem* foundItem = i;
             while (i != nullptr && i->y < visibleTop)
+            {
+                foundItem = i;
                 i = getNextVisibleItem (i, true);
+            }
 
-            return i;
+            return foundItem;
         }();
 
         auto addOffscreenItemBuffer = [&visibleItems] (TreeViewItem* i, int num, bool forwards)


### PR DESCRIPTION
Fixes https://github.com/juce-framework/JUCE/issues/1118