### PR TITLE
Fixed symbol export of AnimatedAppComponent

### DIFF
--- a/modules/juce_gui_extra/misc/juce_AnimatedAppComponent.h
+++ b/modules/juce_gui_extra/misc/juce_AnimatedAppComponent.h
@@ -36,7 +36,7 @@ namespace juce
 
     @tags{GUI}
 */
-class AnimatedAppComponent   : public Component,
+class JUCE_API  AnimatedAppComponent   : public Component,
                                private Timer
 {
 public:


### PR DESCRIPTION
Fixed the symbol error of juce::AnimatedAppComponent on dll build.

