### PR TITLE
Update juce 7.0.2

### DIFF
--- a/modules/juce_audio_processors/processors/juce_AudioProcessor.cpp
+++ b/modules/juce_audio_processors/processors/juce_AudioProcessor.cpp
@@ -1503,7 +1503,6 @@ void AudioProcessorListener::audioProcessorParameterChangeGestureEnd   (AudioPro
 //==============================================================================
 AudioProcessorParameter::~AudioProcessorParameter()
 {
-    destructionBroadcaster.sendSynchronousChangeMessage();
    #if JUCE_DEBUG && ! JUCE_DISABLE_AUDIOPROCESSOR_BEGIN_END_GESTURE_CHECKING
     // This will fail if you've called beginChangeGesture() without having made
     // a corresponding call to endChangeGesture...

--- a/modules/juce_audio_processors/processors/juce_AudioProcessor.cpp
+++ b/modules/juce_audio_processors/processors/juce_AudioProcessor.cpp
@@ -1503,6 +1503,7 @@ void AudioProcessorListener::audioProcessorParameterChangeGestureEnd   (AudioPro
 //==============================================================================
 AudioProcessorParameter::~AudioProcessorParameter()
 {
+    destructionBroadcaster.sendSynchronousChangeMessage();
    #if JUCE_DEBUG && ! JUCE_DISABLE_AUDIOPROCESSOR_BEGIN_END_GESTURE_CHECKING
     // This will fail if you've called beginChangeGesture() without having made
     // a corresponding call to endChangeGesture...

--- a/modules/juce_audio_processors/processors/juce_AudioProcessorParameter.h
+++ b/modules/juce_audio_processors/processors/juce_AudioProcessorParameter.h
@@ -36,7 +36,7 @@ class AudioProcessor;
 
     @tags{Audio}
 */
-class JUCE_API  AudioProcessorParameter
+class JUCE_API  AudioProcessorParameter : public DestructionBroadcaster
 {
 public:
     AudioProcessorParameter() noexcept = default;
@@ -340,11 +340,6 @@ public:
     /** @internal */
     void sendValueChangedMessageToListeners (float newValue);
     
-    juce::ChangeBroadcaster &getDestructionBroadcaster()
-    {
-        return destructionBroadcaster;
-    }
-
 private:
     //==============================================================================
     friend class AudioProcessor;
@@ -356,8 +351,6 @@ private:
     Array<Listener*> listeners;
     mutable StringArray valueStrings;
     
-    ChangeBroadcaster destructionBroadcaster;
-
    #if JUCE_DEBUG
     bool isPerformingGesture = false;
    #endif

--- a/modules/juce_audio_processors/processors/juce_AudioProcessorParameter.h
+++ b/modules/juce_audio_processors/processors/juce_AudioProcessorParameter.h
@@ -339,6 +339,11 @@ public:
     //==============================================================================
     /** @internal */
     void sendValueChangedMessageToListeners (float newValue);
+    
+    juce::ChangeBroadcaster &getDestructionBroadcaster()
+    {
+        return destructionBroadcaster;
+    }
 
 private:
     //==============================================================================
@@ -350,6 +355,8 @@ private:
     CriticalSection listenerLock;
     Array<Listener*> listeners;
     mutable StringArray valueStrings;
+    
+    ChangeBroadcaster destructionBroadcaster;
 
    #if JUCE_DEBUG
     bool isPerformingGesture = false;

--- a/modules/juce_events/broadcasters/juce_ChangeBroadcaster.h
+++ b/modules/juce_events/broadcasters/juce_ChangeBroadcaster.h
@@ -22,6 +22,38 @@
 
 namespace juce
 {
+class DestructionListener
+{
+   public:
+    /** Destructor. */
+    virtual ~DestructionListener() = default;
+
+    virtual void callback() = 0;
+};
+class DestructionBroadcaster
+{
+   public:
+    /** Destructor. */
+    ~DestructionBroadcaster()
+    {
+        listeners.call([](DestructionListener &l) { l.callback(); });
+    }
+    /** Registers a listener to receive change callbacks from this broadcaster.
+        Trying to add a listener that's already on the list will have no effect.
+    */
+    void addDestructionListener(DestructionListener *l) { listeners.add(l); }
+
+    /** Unregisters a listener from the list.
+        If the listener isn't on the list, this won't have any effect.
+    */
+    void removeDestructionListener(DestructionListener *l)
+    {
+        listeners.remove(l);
+    }
+
+   private:
+    ListenerList<DestructionListener> listeners;
+};
 
 //==============================================================================
 /**
@@ -31,7 +63,7 @@ namespace juce
 
     @tags{Events}
 */
-class JUCE_API  ChangeBroadcaster
+class JUCE_API  ChangeBroadcaster : public DestructionBroadcaster
 {
 public:
     //==============================================================================


### PR DESCRIPTION
JUCE を 7.0.2 ベースに更新

これまで Swift のビルド処理のために JUCE の CMake に手を加えていたが、その変更は最新の JUCE でコンフリクトするようだった。現在は Swift のビルドは JUCE ではやらないようになっていてこの変更は不要になっていたので、これは取り除いた