### PR TITLE
Added multiply/multiplied/divide/divided methods to Vector3D

### DIFF
--- a/modules/juce_opengl/geometry/juce_Vector3D.h
+++ b/modules/juce_opengl/geometry/juce_Vector3D.h
@@ -26,58 +26,64 @@
 namespace juce
 {
 
-//==============================================================================
-/**
-    A three-coordinate vector.
+	//==============================================================================
+	/**
+		A three-coordinate vector.
 
-    @tags{OpenGL}
-*/
-template <typename Type>
-class Vector3D
-{
-public:
-    Vector3D() noexcept                                        : x(), y(), z() {}
-    Vector3D (Type xValue, Type yValue, Type zValue) noexcept  : x (xValue), y (yValue), z (zValue) {}
-    Vector3D (const Vector3D& other) noexcept                  : x (other.x), y (other.y), z (other.z) {}
-    Vector3D& operator= (Vector3D other) noexcept              { x = other.x;  y = other.y;  z = other.z; return *this; }
+		@tags{OpenGL}
+	*/
+	template <typename Type>
+	class Vector3D
+	{
+	public:
+		Vector3D() noexcept : x(), y(), z() {}
+		Vector3D(Type xValue, Type yValue, Type zValue) noexcept : x(xValue), y(yValue), z(zValue) {}
+		Vector3D(const Vector3D& other) noexcept : x(other.x), y(other.y), z(other.z) {}
+		Vector3D& operator= (Vector3D other) noexcept { x = other.x;  y = other.y;  z = other.z; return *this; }
 
-    /** Returns a vector that lies along the X axis. */
-    static Vector3D xAxis() noexcept                        { return { (Type) 1, 0, 0 }; }
-    /** Returns a vector that lies along the Y axis. */
-    static Vector3D yAxis() noexcept                        { return { 0, (Type) 1, 0 }; }
-    /** Returns a vector that lies along the Z axis. */
-    static Vector3D zAxis() noexcept                        { return { 0, 0, (Type) 1 }; }
+		/** Returns a vector that lies along the X axis. */
+		static Vector3D xAxis() noexcept { return { (Type)1, 0, 0 }; }
+		/** Returns a vector that lies along the Y axis. */
+		static Vector3D yAxis() noexcept { return { 0, (Type)1, 0 }; }
+		/** Returns a vector that lies along the Z axis. */
+		static Vector3D zAxis() noexcept { return { 0, 0, (Type)1 }; }
 
-    Vector3D& operator+= (Vector3D other) noexcept          { x += other.x;  y += other.y;  z += other.z;  return *this; }
-    Vector3D& operator-= (Vector3D other) noexcept          { x -= other.x;  y -= other.y;  z -= other.z;  return *this; }
-    Vector3D& operator*= (Type scaleFactor) noexcept        { x *= scaleFactor;  y *= scaleFactor;  z *= scaleFactor;  return *this; }
-    Vector3D& operator/= (Type scaleFactor) noexcept        { x /= scaleFactor;  y /= scaleFactor;  z /= scaleFactor;  return *this; }
+		Vector3D& operator+= (Vector3D other) noexcept { x += other.x;  y += other.y;  z += other.z;  return *this; }
+		Vector3D& operator-= (Vector3D other) noexcept { x -= other.x;  y -= other.y;  z -= other.z;  return *this; }
+		Vector3D& operator*= (Type scaleFactor) noexcept { x *= scaleFactor;  y *= scaleFactor;  z *= scaleFactor;  return *this; }
+		Vector3D& operator/= (Type scaleFactor) noexcept { x /= scaleFactor;  y /= scaleFactor;  z /= scaleFactor;  return *this; }
 
-    Vector3D operator+ (Vector3D other) const noexcept      { return { x + other.x, y + other.y, z + other.z }; }
-    Vector3D operator- (Vector3D other) const noexcept      { return { x - other.x, y - other.y, z - other.z }; }
-    Vector3D operator* (Type scaleFactor) const noexcept    { return { x * scaleFactor, y * scaleFactor, z * scaleFactor }; }
-    Vector3D operator/ (Type scaleFactor) const noexcept    { return { x / scaleFactor, y / scaleFactor, z / scaleFactor }; }
-    Vector3D operator-() const noexcept                     { return { -x, -y, -z }; }
+		Vector3D operator+ (Vector3D other) const noexcept { return { x + other.x, y + other.y, z + other.z }; }
+		Vector3D operator- (Vector3D other) const noexcept { return { x - other.x, y - other.y, z - other.z }; }
+		Vector3D operator* (Type scaleFactor) const noexcept { return { x * scaleFactor, y * scaleFactor, z * scaleFactor }; }
+		Vector3D operator/ (Type scaleFactor) const noexcept { return { x / scaleFactor, y / scaleFactor, z / scaleFactor }; }
+		Vector3D operator-() const noexcept { return { -x, -y, -z }; }
 
-    /** Returns the dot-product of these two vectors. */
-    Type operator* (Vector3D other) const noexcept          { return x * other.x + y * other.y + z * other.z; }
+		/*Multiply and divide in method to avoid using * and / operators (* is used for dot product) */
+		void multiply(Vector3D other) const noexcept { x *= other.x;  y *= other.y, z *= other.z; }
+		Vector3D multiplied(Vector3D other) const noexcept { return { x * other.x, y * other.y, z * other.z }; }
+		void divide(Vector3D other) const noexcept { x /= other.x; y /= other.y; z /= other.z };
+		Vector3D divided(Vector3D other) const noexcept { return { x / other.x, y / other.y, z / other.z }; }
 
-    /** Returns the cross-product of these two vectors. */
-    Vector3D operator^ (Vector3D other) const noexcept      { return { y * other.z - z * other.y, z * other.x - x * other.z, x * other.y - y * other.x }; }
+		/** Returns the dot-product of these two vectors. */
+		Type operator* (Vector3D other) const noexcept { return x * other.x + y * other.y + z * other.z; }
 
-    Type length() const noexcept                            { return std::sqrt (lengthSquared()); }
-    Type lengthSquared() const noexcept                     { return x * x + y * y + z * z; }
+		/** Returns the cross-product of these two vectors. */
+		Vector3D operator^ (Vector3D other) const noexcept { return { y * other.z - z * other.y, z * other.x - x * other.z, x * other.y - y * other.x }; }
 
-    Vector3D normalised() const noexcept                    { return *this / length(); }
+		Type length() const noexcept { return std::sqrt(lengthSquared()); }
+		Type lengthSquared() const noexcept { return x * x + y * y + z * z; }
 
-    /** Returns true if the vector is practically equal to the origin. */
-    bool lengthIsBelowEpsilon() const noexcept
-    {
-        auto epsilon = std::numeric_limits<Type>::epsilon();
-        return ! (x < -epsilon || x > epsilon || y < -epsilon || y > epsilon || z < -epsilon || z > epsilon);
-    }
+		Vector3D normalised() const noexcept { return *this / length(); }
 
-    Type x, y, z;
-};
+		/** Returns true if the vector is practically equal to the origin. */
+		bool lengthIsBelowEpsilon() const noexcept
+		{
+			auto epsilon = std::numeric_limits<Type>::epsilon();
+			return !(x < -epsilon || x > epsilon || y < -epsilon || y > epsilon || z < -epsilon || z > epsilon);
+		}
+
+		Type x, y, z;
+	};
 
 } // namespace juce


### PR DESCRIPTION
This adds methods to easily multiply and divide 2 vectors without using operators as they are already used for dot operation.
The commit shows modification on the whole file but it's just reformatted automatically through Visual Studio, the lines that have changed are 62 to 66