### PR TITLE
Fix data race on ARAAudioSourceReader::hostReader in Logic Pro X

### DIFF
--- a/modules/juce_audio_formats/format/juce_ARAAudioReaders.cpp
+++ b/modules/juce_audio_formats/format/juce_ARAAudioReaders.cpp
@@ -121,11 +121,11 @@ bool ARAAudioSourceReader::readSamples (int* const* destSamples, int numDestChan
     const auto destSize = (bitsPerSample / 8) * (size_t) numSamples;
     const auto bufferOffset = (int) (bitsPerSample / 8) * startOffsetInDestBuffer;
 
-    if (isValid() && hostReader != nullptr)
+    if (isValid())
     {
         const ScopedTryReadLock readLock (lock);
 
-        if (readLock.isLocked())
+        if (readLock.isLocked() && hostReader != nullptr)
         {
             for (size_t i = 0; i < tmpPtrs.size(); ++i)
             {


### PR DESCRIPTION
Clang thread sanitizer detected it was simultaneously written to in didEnableAudioSourceSamplesAccess() (juce_ARAAudioReaders.cpp:107) and read from in readSamples() (juce_ARAAudioReaders.cpp:124)