### PR TITLE
Fix: Linux GUIs (including Projucer) unresponsive

### DIFF
--- a/modules/juce_gui_basics/native/juce_linux_Windowing.cpp
+++ b/modules/juce_gui_basics/native/juce_linux_Windowing.cpp
@@ -51,6 +51,7 @@ public:
             ++numAlwaysOnTopPeers;
 
         repainter = std::make_unique<LinuxRepaintManager> (*this);
+        updateVBlankTimer();
 
         windowH = instance->createWindow (parentToAddTo, this);
         parentWindow = parentToAddTo;
@@ -571,13 +572,10 @@ private:
     {
         if (auto* display = Desktop::getInstance().getDisplays().getDisplayForRect (bounds))
         {
-            if (display->verticalFrequencyHz)
-            {
-                const auto newIntFrequencyHz = roundToInt (*display->verticalFrequencyHz);
+            const auto newIntFrequencyHz = display->verticalFrequencyHz ? roundToInt (*display->verticalFrequencyHz) : 100;
 
-                if (vBlankManager.getTimerInterval() != newIntFrequencyHz)
-                    vBlankManager.startTimerHz (newIntFrequencyHz);
-            }
+            if (vBlankManager.getTimerInterval() != newIntFrequencyHz)
+                vBlankManager.startTimerHz (newIntFrequencyHz);
         }
     }
 


### PR DESCRIPTION
**Note that this issue also affects the pre-built Projucer from the webpage, making the GUI unresponsive on Linux.**

Just checked and the same solution has already been proposed in https://github.com/juce-framework/JUCE/issues/1159.

Well anyway, here's a PR with the same changes, and one extra which fixes an issue where the GUI won't start updating before an event is sent to the XWindow.

> This change fixes an issue where the GUI will not update at all if the refresh rate can't be determined. Since https://github.com/juce-framework/JUCE/commit/1da9ccd36c69d24af96d4fe65f9018026b8a80d6 only added getting the refresh rate from xrandr, any GUI application compiled with JUCE_USE_XRANDR=0 will not work. This change sets the refresh interval to 100 Hz (the same rate as before the vblank change) if the display object is missing the refresh rate.
> 
> Also added a call to updateVBlankTimer to avoid having to interact with the GUI in order to start the repaint timer.