### PR TITLE
Check pointer after casting in juce_ios_Audio.cpp dispatchAudioUnitPropertyChange

### DIFF
--- a/modules/juce_audio_devices/native/juce_ios_Audio.cpp
+++ b/modules/juce_audio_devices/native/juce_ios_Audio.cpp
@@ -1168,7 +1168,10 @@ struct iOSAudioIODevice::Pimpl      : public AsyncUpdater
     static void dispatchAudioUnitPropertyChange (void* data, AudioUnit unit, AudioUnitPropertyID propertyID,
                                                  AudioUnitScope scope, AudioUnitElement element)
     {
-        static_cast<Pimpl*> (data)->handleAudioUnitPropertyChange (unit, propertyID, scope, element);
+        if (auto* pimpl = static_cast<Pimpl*> (data))
+        {
+            pimpl->handleAudioUnitPropertyChange (unit, propertyID, scope, element);
+        }
     }
 
     static double getTimestampForMIDI()


### PR DESCRIPTION
I got a crash report from this function at some point last week. There might be something else going on, but I'm wondering if this is a sensible check anyway? 