### PR TITLE
Fix warnings in plugins in Xcode 14.2 when JUCE_VST3_CAN_REPLACE_VST2 is enabled

### DIFF
--- a/modules/juce_audio_plugin_client/utility/juce_PluginUtilities.cpp
+++ b/modules/juce_audio_plugin_client/utility/juce_PluginUtilities.cpp
@@ -56,7 +56,7 @@ namespace juce
       const auto juce_strcat  = [] (auto&& head, auto&&... tail) { strcat_s  (head, numElementsInArray (head), tail...); };
       const auto juce_sscanf  = [] (auto&&... args)              { sscanf_s  (args...); };
      #else
-      const auto juce_sprintf = [] (auto&&... args)              { sprintf   (args...); };
+      #define    juce_sprintf(dst, ...)                          snprintf (dst, sizeof(dst), __VA_ARGS__)
       const auto juce_strcpy  = [] (auto&&... args)              { strcpy    (args...); };
       const auto juce_strcat  = [] (auto&&... args)              { strcat    (args...); };
       const auto juce_sscanf  = [] (auto&&... args)              { sscanf    (args...); };


### PR DESCRIPTION
Relevant forum thread: https://forum.juce.com/t/plugins-no-longer-build-cleanly-with-xcode-14-1/53603