### PR TITLE
Fix projucer when building with clang under linux

### DIFF
--- a/extras/Projucer/Source/Application/jucer_CommonHeaders.h
+++ b/extras/Projucer/Source/Application/jucer_CommonHeaders.h
@@ -25,11 +25,11 @@
 
 #pragma once
 
-
 //==============================================================================
-// The GCC extensions define linux somewhere in the headers, so undef it here...
-#if JUCE_GCC
- #undef linux
+// GCC extensions and LLVM define 'linux' as a macro somewhere in their headers,
+// so undef it here...
+#if JUCE_GCC || (JUCE_CLANG && LINUX)
+#undef linux
 #endif
 
 struct TargetOS


### PR DESCRIPTION
When the Projucer is built under Linux, the symbol "linux" must be undefined to avoid colliding with the TargetOS::OS::linux enumeration member.  Presently, this is only done when building with GCC.  This pull request modifies jucer_CommonHeaders.h to also under it when building with clang.
