### PR TITLE
Fix dark mode notification on macOS

### DIFF
--- a/modules/juce_gui_basics/native/juce_mac_Windowing.mm
+++ b/modules/juce_gui_basics/native/juce_mac_Windowing.mm
@@ -501,34 +501,59 @@ bool Desktop::isDarkModeActive() const
                 isEqualToString: nsStringLiteral ("Dark")];
 }
 
-JUCE_BEGIN_IGNORE_WARNINGS_GCC_LIKE ("-Wundeclared-selector")
-static const auto darkModeSelector = @selector (darkModeChanged:);
-static const auto keyboardVisibilitySelector = @selector (keyboardVisiblityChanged:);
-JUCE_END_IGNORE_WARNINGS_GCC_LIKE
-
 class Desktop::NativeDarkModeChangeDetectorImpl
 {
 public:
     NativeDarkModeChangeDetectorImpl()
     {
         static DelegateClass delegateClass;
-        delegate.reset ([delegateClass.createInstance() init]);
-        observer.emplace (delegate.get(), darkModeSelector, @"AppleInterfaceThemeChangedNotification", nil);
+        
+        delegate = [delegateClass.createInstance() init];
+        object_setInstanceVariable (delegate, "owner", this);
+        
+        JUCE_BEGIN_IGNORE_WARNINGS_GCC_LIKE ("-Wundeclared-selector")
+        [[NSDistributedNotificationCenter defaultCenter] addObserver: delegate
+                                                            selector: @selector (darkModeChanged:)
+                                                                name: @"AppleInterfaceThemeChangedNotification"
+                                                              object: nil];
+        JUCE_END_IGNORE_WARNINGS_GCC_LIKE
     }
-
+    
+    ~NativeDarkModeChangeDetectorImpl()
+    {
+        object_setInstanceVariable (delegate, "owner", nullptr);
+        [[NSDistributedNotificationCenter defaultCenter] removeObserver: delegate];
+        [delegate release];
+    }
+    
+    void darkModeChanged()
+    {
+        Desktop::getInstance().darkModeChanged();
+    }
+    
 private:
     struct DelegateClass  : public ObjCClass<NSObject>
     {
         DelegateClass()  : ObjCClass<NSObject> ("JUCEDelegate_")
         {
-            addMethod (darkModeSelector, [] (id, SEL, NSNotification*) { Desktop::getInstance().darkModeChanged(); });
+            addIvar<NativeDarkModeChangeDetectorImpl*> ("owner");
+            
+            JUCE_BEGIN_IGNORE_WARNINGS_GCC_LIKE ("-Wundeclared-selector")
+            addMethod (@selector (darkModeChanged:), darkModeChanged);
+            JUCE_END_IGNORE_WARNINGS_GCC_LIKE
+            
             registerClass();
         }
+        
+        static void darkModeChanged (id self, SEL, NSNotification*)
+        {
+            if (auto* owner = getIvar<NativeDarkModeChangeDetectorImpl*> (self, "owner"))
+                owner->darkModeChanged();
+        }
     };
-
-    NSUniquePtr<NSObject> delegate;
-    Optional<ScopedNotificationCenterObserver> observer;
-
+    
+    id delegate = nil;
+    
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (NativeDarkModeChangeDetectorImpl)
 };
 


### PR DESCRIPTION
The issue has been described on the JUCE Forum: [thread](https://forum.juce.com/t/dark-mode-changes-not-received-on-macos-13/54211/1).

This PR reverts the [commit](https://github.com/juce-framework/JUCE/commit/8cab4cf5bb81ee1e683f733c71a6c3b1813fde11#diff-0eb57154a3593ebb93563bfc4634194f279c846ffd47258c7e9e5ab3ae16d0b4). that introduced the bug with some minor adaptations to fix the conflicts with later modifications.

