### PR TITLE
VST3: Fix bad value returned from setBusArrangements()

### DIFF
--- a/modules/juce_audio_plugin_client/VST3/juce_VST3_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/VST3/juce_VST3_Wrapper.cpp
@@ -3279,7 +3279,7 @@ public:
         auto numOutputBuses = pluginInstance->getBusCount (false);
 
         if (numIns > numInputBuses || numOuts > numOutputBuses)
-            return false;
+            return kResultFalse;
 
         // see the following documentation to understand the correct way to react to this callback
         // https://steinbergmedia.github.io/vst3_doc/vstinterfaces/classSteinberg_1_1Vst_1_1IAudioProcessor.html#ad3bc7bac3fd3b194122669be2a1ecc42


### PR DESCRIPTION
false == kResultTrue in Steinberg SDK, so this would cause a bad arrangement to be considered valid by host app.
