### PR TITLE
iOS change method of bypassing voice processing

### DIFF
--- a/modules/juce_audio_devices/native/juce_ios_Audio.cpp
+++ b/modules/juce_audio_devices/native/juce_ios_Audio.cpp
@@ -551,15 +551,10 @@ struct iOSAudioIODevice::Pimpl      : public AsyncUpdater
 
     bool setAudioPreprocessingEnabled (bool enable)
     {
-        auto session = [AVAudioSession sharedInstance];
+        const UInt32 one = 1;
+        AudioUnitSetProperty (audioUnit, kAUVoiceIOProperty_BypassVoiceProcessing, kAudioUnitScope_Input, 1, &one, sizeof (one));
 
-        NSString* mode = (enable ? AVAudioSessionModeDefault
-                                 : AVAudioSessionModeMeasurement);
-
-        JUCE_NSERROR_CHECK ([session setMode: mode
-                                       error: &error]);
-
-        return session.mode == mode;
+        return true;
     }
 
     //==============================================================================


### PR DESCRIPTION
The implementation of `AudioIODevice::setAudioPreprocessingEnabled` in `juce_ios_Audio.cpp` uses the `AVAudioSession::setMode` method to set the `AVAudioSessionMode` of the session to `AVAudioSessionModeMeasurement`. However, this also removes the processing of output signals, causing a drastic reduction in output playback level (see https://developer.apple.com/documentation/avfaudio/avaudiosessionmodemeasurement?language=objc). While this might be desirable behaviour for specific use cases, the `setAudioPreprocessingEnabled` description in `juce_AudioIODevice.h` states that

```
/** On devices which support it, this allows automatic gain control or other
    mic processing to be disabled.
    If the device doesn't support this operation, it'll return false.
*/
```

suggesting the intention is to only bypass audio **input** preprocessing.

My proposal is to instead use the `AudioUnitProperty` `kAUVoiceIOProperty_BypassVoiceProcessing` which only disables the input processing, not the output processing. (https://developer.apple.com/documentation/audiotoolbox/1534007-voice-processing_i_o_audio_unit_proper/kauvoiceioproperty_bypassvoiceprocessing?language=objc)

If this is not desirable, then I would recommend that another method be added, `AudioIODevice::setInputProcessingEnabled`, which would do the same thing suggested above.

This is crucial to record singing/vocals on iOS, since the Automatic Gain Control in the phones introduce a ton of noise when not actively singing/talking, as in when you're waiting for the place you want to come in with your singing.