### PR TITLE
update device details and then restart for BLE device

### DIFF
--- a/modules/juce_audio_devices/native/juce_mac_CoreAudio.cpp
+++ b/modules/juce_audio_devices/native/juce_mac_CoreAudio.cpp
@@ -1135,6 +1135,7 @@ private:
 
             case kAudioDevicePropertyDeviceHasChanged:
             case kAudioObjectPropertyOwnedObjects:
+                intern->deviceDetailsChanged();
                 intern->deviceRequestedRestart();
                 break;
 


### PR DESCRIPTION
When using a Bluetooth audio microphone device (at any App), the SR of the speaker device automatically changed. At this time, the SR of Juce's Audio Callback and the SR of the speaker do not match.

Issue: [https://forum.juce.com/t/macos-wireless-headphones-at-some-sample-rates/54478](url)

**This is not the exact solution. It's work-around solution.**

