### PR TITLE
fix: Use atomic in opengl to avoid race

### DIFF
--- a/modules/juce_opengl/native/juce_OpenGL_osx.h
+++ b/modules/juce_opengl/native/juce_OpenGL_osx.h
@@ -221,7 +221,7 @@ public:
 
         // The macOS OpenGL programming guide says that numFramesPerSwap
         // can only be 0 or 1.
-        jassert (isPositiveAndBelow (numFramesPerSwap, 2));
+        jassert (isPositiveAndBelow (numFramesPerSwap.load(), 2));
 
         [renderContext setValues: (const GLint*) &numFramesPerSwap
                     forParameter: getSwapIntervalParameter()];
@@ -266,8 +266,9 @@ public:
     ReferenceCountedObjectPtr<ReferenceCountedObject> viewAttachment;
     double lastSwapTime = 0;
     std::atomic<int> minSwapTimeMs { 0 };
-    int underrunCounter = 0, numFramesPerSwap = 0;
-    double videoRefreshPeriodS = 1.0 / 60.0;
+    int underrunCounter = 0;
+    std::atomic<int> numFramesPerSwap = 0;
+    std::atomic<double> videoRefreshPeriodS = 1.0 / 60.0;
 
     //==============================================================================
     struct MouseForwardingNSOpenGLViewClass  : public ObjCClass<NSOpenGLView>


### PR DESCRIPTION
I'm not sure if my company has signed the contribution document, but I would assume so.
I don't think my user name or email was a part of it though. 