### PR TITLE
TableListBox: Allow TableListBoxModel to control whether items may be…

### DIFF
--- a/modules/juce_gui_basics/widgets/juce_TableListBox.cpp
+++ b/modules/juce_gui_basics/widgets/juce_TableListBox.cpp
@@ -196,7 +196,7 @@ public:
     void mouseDrag (const MouseEvent& e) override
     {
         if (isEnabled()
-             && owner.getModel() != nullptr
+             && auto* m = owner.getModel()
              && e.mouseWasDraggedSinceMouseDown()
              && ! isDragging)
         {
@@ -209,12 +209,12 @@ public:
 
             if (rowsToDrag.size() > 0)
             {
-                auto dragDescription = owner.getModel()->getDragSourceDescription (rowsToDrag);
+                auto dragDescription = m->getDragSourceDescription (rowsToDrag);
 
                 if (! (dragDescription.isVoid() || (dragDescription.isString() && dragDescription.toString().isEmpty())))
                 {
                     isDragging = true;
-                    owner.startDragAndDrop (e, rowsToDrag, dragDescription, true);
+                    owner.startDragAndDrop (e, rowsToDrag, dragDescription, m->mayDragToExternalWindows());
                 }
             }
         }

--- a/modules/juce_gui_basics/widgets/juce_TableListBox.h
+++ b/modules/juce_gui_basics/widgets/juce_TableListBox.h
@@ -186,6 +186,11 @@ public:
         @see getDragSourceCustomData, DragAndDropContainer::startDragging
     */
     virtual var getDragSourceDescription (const SparseSet<int>& currentlySelectedRows);
+
+    /** Called when starting a drag operation on a table row to determine whether the item may be
+        dragged to other windows. Returns true by default.
+    */
+    virtual bool mayDragToExternalWindows() const   { return true; }
 };
 
 


### PR DESCRIPTION
… dragged to other windows

Hi JUCE team, here's a simple PR so the recently added mayBeDragToExternalWindows() to ListBoxModel can also be used in TableListBoxModel.

Sorry about the previous PR noise...
