### PR TITLE
Android: Allow setting an app style

### DIFF
--- a/modules/juce_core/native/juce_android_JNIHelpers.h
+++ b/modules/juce_core/native/juce_android_JNIHelpers.h
@@ -590,9 +590,16 @@ DECLARE_JNI_CLASS (AndroidViewGroup, "android/view/ViewGroup")
  METHOD (getDecorView, "getDecorView",       "()Landroid/view/View;") \
  METHOD (setFlags,     "setFlags",           "(II)V") \
  METHOD (clearFlags,   "clearFlags",         "(I)V") \
- METHOD (getInsetsController, "getInsetsController", "()Landroid/view/WindowInsetsController;")
+ METHOD (setStatusBarColor, "setStatusBarColor", "(I)V") \
+ METHOD (setNavigationBarColor, "setNavigationBarColor", "(I)V")
 
 DECLARE_JNI_CLASS (AndroidWindow, "android/view/Window")
+#undef JNI_CLASS_MEMBERS
+
+#define JNI_CLASS_MEMBERS(METHOD, STATICMETHOD, FIELD, STATICFIELD, CALLBACK) \
+ METHOD (getInsetsController, "getInsetsController", "()Landroid/view/WindowInsetsController;")
+
+DECLARE_JNI_CLASS_WITH_MIN_SDK (AndroidWindow30, "android/view/Window", 30)
 #undef JNI_CLASS_MEMBERS
 
 #define JNI_CLASS_MEMBERS(METHOD, STATICMETHOD, FIELD, STATICFIELD, CALLBACK) \ 

--- a/modules/juce_core/native/juce_android_JNIHelpers.h
+++ b/modules/juce_core/native/juce_android_JNIHelpers.h
@@ -589,9 +589,16 @@ DECLARE_JNI_CLASS (AndroidViewGroup, "android/view/ViewGroup")
 #define JNI_CLASS_MEMBERS(METHOD, STATICMETHOD, FIELD, STATICFIELD, CALLBACK) \
  METHOD (getDecorView, "getDecorView",       "()Landroid/view/View;") \
  METHOD (setFlags,     "setFlags",           "(II)V") \
- METHOD (clearFlags,   "clearFlags",         "(I)V")
+ METHOD (clearFlags,   "clearFlags",         "(I)V") \
+ METHOD (getInsetsController, "getInsetsController", "()Landroid/view/WindowInsetsController;")
 
 DECLARE_JNI_CLASS (AndroidWindow, "android/view/Window")
+#undef JNI_CLASS_MEMBERS
+
+#define JNI_CLASS_MEMBERS(METHOD, STATICMETHOD, FIELD, STATICFIELD, CALLBACK) \ 
+ METHOD (setSystemBarsAppearance, "setSystemBarsAppearance", "(II)V")
+
+DECLARE_JNI_CLASS_WITH_MIN_SDK (AndroidWindowInsetsController, "android/view/WindowInsetsController", 30)
 #undef JNI_CLASS_MEMBERS
 
 #define JNI_CLASS_MEMBERS(METHOD, STATICMETHOD, FIELD, STATICFIELD, CALLBACK) \

--- a/modules/juce_gui_basics/native/juce_android_Windowing.cpp
+++ b/modules/juce_gui_basics/native/juce_android_Windowing.cpp
@@ -1825,6 +1825,29 @@ public:
     };
 
 private:
+    void appStyleChanged() override
+    {
+        if (getAndroidSDKVersion() < 30)
+            return;
+    
+        constexpr auto APPEARANCE_LIGHT_STATUS_BARS = 0x00000008;
+        constexpr auto APPEARANCE_LIGHT_NAVIGATION_BARS = 0x00000010;
+    
+        LocalRef<jobject> activity (getMainActivity());
+
+        if (activity != nullptr)
+        {
+            auto* env = getEnv();
+            
+            LocalRef<jobject> mainWindow (env->CallObjectMethod (activity.get(), AndroidActivity.getWindow));
+            LocalRef<jobject> controller (env->CallObjectMethod (mainWindow.get(), AndroidWindow.getInsetsController));
+
+            env->CallVoidMethod (controller.get(), AndroidWindowInsetsController.setSystemBarsAppearance, style == Style::light ? APPEARANCE_LIGHT_STATUS_BARS : 0, APPEARANCE_LIGHT_STATUS_BARS);
+
+            env->CallVoidMethod (controller.get(), AndroidWindowInsetsController.setSystemBarsAppearance, style == Style::light ? APPEARANCE_LIGHT_NAVIGATION_BARS : 0, APPEARANCE_LIGHT_NAVIGATION_BARS);
+        }
+    }         
+
     template <auto Member>
     static void mouseCallbackWrapper (JNIEnv*, AndroidComponentPeer& t, jint i, jfloat x, jfloat y, jlong time) { return (t.*Member) (i, Point<float> { x, y }, time); }
 

--- a/modules/juce_gui_basics/native/juce_android_Windowing.cpp
+++ b/modules/juce_gui_basics/native/juce_android_Windowing.cpp
@@ -1832,6 +1832,9 @@ private:
     
         constexpr auto APPEARANCE_LIGHT_STATUS_BARS = 0x00000008;
         constexpr auto APPEARANCE_LIGHT_NAVIGATION_BARS = 0x00000010;
+        
+        constexpr auto WHITE = 0xffffffff;
+        constexpr auto BLACK = 0xff000000;
     
         LocalRef<jobject> activity (getMainActivity());
 
@@ -1840,11 +1843,15 @@ private:
             auto* env = getEnv();
             
             LocalRef<jobject> mainWindow (env->CallObjectMethod (activity.get(), AndroidActivity.getWindow));
-            LocalRef<jobject> controller (env->CallObjectMethod (mainWindow.get(), AndroidWindow.getInsetsController));
+            LocalRef<jobject> controller (env->CallObjectMethod (mainWindow.get(), AndroidWindow30.getInsetsController));
 
             env->CallVoidMethod (controller.get(), AndroidWindowInsetsController.setSystemBarsAppearance, style == Style::light ? APPEARANCE_LIGHT_STATUS_BARS : 0, APPEARANCE_LIGHT_STATUS_BARS);
 
             env->CallVoidMethod (controller.get(), AndroidWindowInsetsController.setSystemBarsAppearance, style == Style::light ? APPEARANCE_LIGHT_NAVIGATION_BARS : 0, APPEARANCE_LIGHT_NAVIGATION_BARS);
+            
+            env->CallVoidMethod (mainWindow.get(), AndroidWindow.setStatusBarColor, style == Style::light ? WHITE : BLACK);
+            
+            env->CallVoidMethod (mainWindow.get(), AndroidWindow.setNavigationBarColor, style == Style::light ? WHITE : BLACK);
         }
     }         
 


### PR DESCRIPTION
Setting the app style ensures that the status bar and navigation buttons can be seen over the app background.
This feature was available on iOS but it is equally necessary on Android when using modern themes. 
Works with API level 30 and above and has no effect on lower level API's.

