### PR TITLE
BubbleComponent: Add LookAndFeel method to specify the applied compon…

### DIFF
--- a/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel_V2.cpp
+++ b/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel_V2.cpp
@@ -870,6 +870,13 @@ void LookAndFeel_V2::drawBubble (Graphics& g, BubbleComponent& comp,
     g.strokePath (p, PathStrokeType (1.0f));
 }
 
+ImageEffectFilter* LookAndFeel_V2::getBubbleEffect (BubbleComponent& comp)
+{
+    auto fx = new DropShadowEffect();
+    fx->setShadowProperties (DropShadow (Colours::black.withAlpha (0.35f), 5, Point<int>()));
+
+    return fx;
+}
 
 //==============================================================================
 Font LookAndFeel_V2::getPopupMenuFont()

--- a/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel_V2.h
+++ b/modules/juce_gui_basics/lookandfeel/juce_LookAndFeel_V2.h
@@ -150,6 +150,7 @@ public:
 
     //==============================================================================
     void drawBubble (Graphics&, BubbleComponent&, const Point<float>& tip, const Rectangle<float>& body) override;
+    ImageEffectFilter* getBubbleEffect (BubbleComponent&) override;
 
     void drawLasso (Graphics&, Component&) override;
 

--- a/modules/juce_gui_basics/misc/juce_BubbleComponent.cpp
+++ b/modules/juce_gui_basics/misc/juce_BubbleComponent.cpp
@@ -31,8 +31,8 @@ BubbleComponent::BubbleComponent()
 {
     setInterceptsMouseClicks (false, false);
 
-    shadow.setShadowProperties (DropShadow (Colours::black.withAlpha (0.35f), 5, Point<int>()));
-    setComponentEffect (&shadow);
+    effect.reset (getLookAndFeel().getBubbleEffect (*this));
+    setComponentEffect (effect.get());
 }
 
 BubbleComponent::~BubbleComponent() {}

--- a/modules/juce_gui_basics/misc/juce_BubbleComponent.h
+++ b/modules/juce_gui_basics/misc/juce_BubbleComponent.h
@@ -154,6 +154,8 @@ public:
         virtual void drawBubble (Graphics&, BubbleComponent&,
                                  const Point<float>& positionOfTip,
                                  const Rectangle<float>& body) = 0;
+
+        virtual ImageEffectFilter* getBubbleEffect (BubbleComponent&) = 0;                                 
     };
 
     //==============================================================================
@@ -178,7 +180,7 @@ private:
     Rectangle<int> content;
     Point<int> arrowTip;
     int allowablePlacements;
-    DropShadowEffect shadow;
+    std::unique_ptr<ImageEffectFilter> effect;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (BubbleComponent)
 };


### PR DESCRIPTION
…ent effect.

Hello JUCE team,

The component effect applied to a `BubbleComponent` is a design choice and should not be forced by the framework. It'd be nice if this could be let to the user to decide.

This PR is inspired by similar LnF methods like `Slider::LookAndFeelMethods::getSliderEffect()`.

The previous `BubbleComponent` shadow was moved to the default implementation for `getBubbleEffect()`.
