### PR TITLE
ARA: fix the initial source code of the ARA plugin which outputted from Projucer.

### DIFF
--- a/extras/Projucer/Source/BinaryData/Templates/jucer_AudioPluginEditorTemplate.cpp
+++ b/extras/Projucer/Source/BinaryData/Templates/jucer_AudioPluginEditorTemplate.cpp
@@ -11,7 +11,15 @@
 //==============================================================================
 %%editor_class_name%%::%%editor_class_name%% (%%filter_class_name%%& p)
     : AudioProcessorEditor (&p), audioProcessor (p)
+#if JucePlugin_Enable_ARA
+    , AudioProcessorEditorARAExtension(&p)
+#endif
 {
+#if JucePlugin_Enable_ARA
+    // for proper view embedding, ARA plug-ins must be resizable
+    setResizable(true, false);
+#endif
+
     // Make sure that before the constructor has finished, you've set the
     // editor's size to whatever you need it to be.
     setSize (400, 300);

--- a/extras/Projucer/Source/BinaryData/Templates/jucer_AudioPluginEditorTemplate.h
+++ b/extras/Projucer/Source/BinaryData/Templates/jucer_AudioPluginEditorTemplate.h
@@ -14,6 +14,9 @@
 /**
 */
 class %%editor_class_name%%  : public juce::AudioProcessorEditor
+                            #if JucePlugin_Enable_ARA
+                              , public juce::AudioProcessorEditorARAExtension
+                            #endif
 {
 public:
     %%editor_class_name%% (%%filter_class_name%%&);


### PR DESCRIPTION
I have found that the initial source code of the ARA plugin outputted from Projucer triggers a check for implementation inconsistencies, as noted in `juce_audio_plugin_client_VST3.cpp`. I have added a fix to address this issue.

`juce_audio_plugin_client_VST3.cpp` - Line 2073
```
            void createEditor (AudioProcessor& plugin)
            {
                pluginEditor.reset (plugin.createEditorIfNeeded());

               #if JucePlugin_Enable_ARA
                jassert (dynamic_cast<AudioProcessorEditorARAExtension*> (pluginEditor.get()) != nullptr);
                // for proper view embedding, ARA plug-ins must be resizable
                jassert (pluginEditor->isResizable());
               #endif

                if (pluginEditor != nullptr)
                {
```

permalink: https://github.com/juce-framework/JUCE/blob/221d1aa6cf1a9847e82b54dffda793a90b3d1d4a/modules/juce_audio_plugin_client/juce_audio_plugin_client_VST3.cpp#L2077

