### PR TITLE
Typo: missing dot

### DIFF
--- a/modules/juce_audio_devices/sources/juce_AudioTransportSource.h
+++ b/modules/juce_audio_devices/sources/juce_AudioTransportSource.h
@@ -93,7 +93,7 @@ public:
     */
     void setPosition (double newPosition);
 
-    /** Returns the position that the next data block will be read from
+    /** Returns the position that the next data block will be read from.
         This is a time in seconds.
     */
     double getCurrentPosition() const;


### PR DESCRIPTION
Hey JUCE team, spotted a missing dot in doc. Thanks!

<img width="768" alt="Screenshot 2023-04-19 at 15 30 42" src="https://user-images.githubusercontent.com/1971775/233092066-aa32fb47-81d9-47e4-8424-467baca27087.png">
