### PR TITLE
_juce_get_module_definitions filter excludes entries with escaped semicolons

### DIFF
--- a/extras/Build/CMake/JUCEUtils.cmake
+++ b/extras/Build/CMake/JUCEUtils.cmake
@@ -275,7 +275,7 @@ function(_juce_get_module_definitions target filter out_var)
     set(compile_defs $<TARGET_GENEX_EVAL:${target},$<TARGET_PROPERTY:${target},COMPILE_DEFINITIONS>>)
 
     if(filter)
-        set(${out_var} $<FILTER:${compile_defs},EXCLUDE,JucePlugin_Build_|JUCE_SHARED_CODE> PARENT_SCOPE)
+        set(${out_var} $<FILTER:${compile_defs},EXCLUDE,JucePlugin_Build_|JUCE_SHARED_CODE|\;> PARENT_SCOPE)
     else()
         set(${out_var} ${compile_defs} PARENT_SCOPE)
     endif()


### PR DESCRIPTION
Before this tweak, a juce plugin target which had a `target_compile_definitions` entry with an escaped semicolon `\;` would end up generating format-specific targets which not only had a preprocessor definition matching the entry, but also extraneous definitions of the escaped-semicolon-split parts of that entry. For example, an entry of `"MY_MACRO=f()\;g();"` would end up with the extraneous preprocessor definitions `MY_MACRO=f()` and `g()`, in addition to the desired `MY_MACRO=f();g();`

This is because of how CMake handles escaped semicolons in lists, see e.g. https://gitlab.kitware.com/cmake/cmake/-/issues/20317