### PR TITLE
[WIP] 1053: String append performance problem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ profile
 **/doxygen/doc
 **/doxygen/build
 **/.idea
+**/out/build
 extras/Projucer/JUCECompileEngine.dylib
 
 .idea


### PR DESCRIPTION
Now the appendCharPointer method only preallocates more space if the appended data won't fit into the already preallocated space.

NOTE: I'm having trouble with tests. Apparently the getChildUrl is no longer copying the value it returns and, in consequence, the addition of the child url to the class' string it's affecting both the returned and the base URLs