### PR TITLE
Add support for the musl libc.

### DIFF
--- a/modules/juce_core/juce_core.cpp
+++ b/modules/juce_core/juce_core.cpp
@@ -102,7 +102,7 @@
  #include <net/if.h>
  #include <sys/ioctl.h>
 
- #if ! (JUCE_ANDROID || JUCE_WASM)
+ #if ! (JUCE_ANDROID || JUCE_WASM || JUCE_MUSL)
   #include <execinfo.h>
  #endif
 #endif

--- a/modules/juce_core/native/juce_SharedCode_posix.h
+++ b/modules/juce_core/native/juce_SharedCode_posix.h
@@ -166,7 +166,7 @@ int juce_siginterrupt ([[maybe_unused]] int sig, [[maybe_unused]] int flag)
 //==============================================================================
 namespace
 {
-   #if JUCE_LINUX || (JUCE_IOS && (! TARGET_OS_MACCATALYST) && (! __DARWIN_ONLY_64_BIT_INO_T)) // (this iOS stuff is to avoid a simulator bug)
+   #if JUCE_GLIBC || (JUCE_IOS && (! TARGET_OS_MACCATALYST) && (! __DARWIN_ONLY_64_BIT_INO_T)) // (this iOS stuff is to avoid a simulator bug)
     using juce_statStruct = struct stat64;
     #define JUCE_STAT  stat64
    #else

--- a/modules/juce_core/native/juce_SystemStats_linux.cpp
+++ b/modules/juce_core/native/juce_SystemStats_linux.cpp
@@ -198,22 +198,22 @@ String SystemStats::getComputerName()
 
 String SystemStats::getUserLanguage()
 {
-   #if JUCE_BSD
+   #if JUCE_GLIBC
+    return getLocaleValue (_NL_ADDRESS_LANG_AB);
+   #else
     if (auto langEnv = getenv ("LANG"))
         return String::fromUTF8 (langEnv).upToLastOccurrenceOf (".UTF-8", false, true);
 
     return {};
-   #else
-    return getLocaleValue (_NL_ADDRESS_LANG_AB);
    #endif
 }
 
 String SystemStats::getUserRegion()
 {
-   #if JUCE_BSD
-    return {};
-   #else
+   #if JUCE_GLIBC
     return getLocaleValue (_NL_ADDRESS_COUNTRY_AB2);
+   #else
+    return {};
    #endif
 }
 

--- a/modules/juce_core/system/juce_SystemStats.cpp
+++ b/modules/juce_core/system/juce_SystemStats.cpp
@@ -178,7 +178,7 @@ String SystemStats::getStackBacktrace()
 {
     String result;
 
-   #if JUCE_ANDROID || JUCE_MINGW || JUCE_WASM
+   #if JUCE_ANDROID || JUCE_MINGW || JUCE_WASM || JUCE_MUSL
     jassertfalse; // sorry, not implemented yet!
 
    #elif JUCE_WINDOWS

--- a/modules/juce_core/system/juce_TargetPlatform.h
+++ b/modules/juce_core/system/juce_TargetPlatform.h
@@ -33,6 +33,7 @@
     - Either JUCE_LITTLE_ENDIAN or JUCE_BIG_ENDIAN.
     - Either JUCE_INTEL or JUCE_ARM
     - Either JUCE_GCC or JUCE_CLANG or JUCE_MSVC
+    - Either JUCE_GLIBC or JUCE_MUSL will be defined on Linux depending on the system's libc implementation.
 */
 
 //==============================================================================
@@ -182,6 +183,14 @@
     #define JUCE_ARM 1
   #elif __MMX__ || __SSE__ || __amd64__
     #define JUCE_INTEL 1
+  #endif
+
+  #if JUCE_LINUX
+    #ifdef __GLIBC__
+      #define JUCE_GLIBC 1
+    #else
+      #define JUCE_MUSL 1
+    #endif
   #endif
 #endif
 


### PR DESCRIPTION
JUCE currently uses multiple glibc-specific features when JUCE_LINUX is defined. Instead, this pull request adds two new macros in juce_TargetPlatform.h: JUCE_GLIBC and JUCE_MUSL. JUCE_GLIBC is defined if the system is using glibc (detected through the __GLIBC__ macro which should be defined on all glibc systems), and JUCE_MUSL is defined otherwise. This pull request also conditions the usage of execinfo.h (only available on glibc), the usage of the stat64 interface (being removed in the next release of musl, currently only available when _LARGEFILE64_SOURCE is defined), and the usage of _NL_ADDRESS_LANG_AB and _NL_ADDRESS_COUNTRY_AB2 (locales are not supported by musl) behind JUCE_GLIBC instead of JUCE_LINUX.