### PR TITLE
Force repaint for Juce Linux as well when dragging starts

### DIFF
--- a/modules/juce_gui_basics/mouse/juce_DragAndDropContainer.cpp
+++ b/modules/juce_gui_basics/mouse/juce_DragAndDropContainer.cpp
@@ -494,7 +494,7 @@ void DragAndDropContainer::startDragging (const var& sourceDescription,
     dragImageComponent->sourceDetails.localPosition = sourceComponent->getLocalPoint (nullptr, lastMouseDown);
     dragImageComponent->updateLocation (false, lastMouseDown);
 
-   #if JUCE_WINDOWS
+   #if JUCE_WINDOWS || JUCE_LINUX
     // Under heavy load, the layered window's paint callback can often be lost by the OS,
     // so forcing a repaint at least once makes sure that the window becomes visible..
     if (auto* peer = dragImageComponent->getPeer())


### PR DESCRIPTION
Below is an example of the bug. When dragging from a DragAndDropContainer::startDragging under Linux, there is a short period before the image is rendered correctly:

![draganddrop_juce_ghost_image_flicker](https://github.com/juce-framework/JUCE/assets/12004932/2b732df1-3274-42b1-82e4-0141c3fed048)

Linux also loosing the layered window's paint callback.
