### PR TITLE
Grid: allow tabs/spaces in area strings

### DIFF
--- a/modules/juce_gui_basics/layout/juce_Grid.cpp
+++ b/modules/juce_gui_basics/layout/juce_Grid.cpp
@@ -429,7 +429,11 @@ struct Grid::Helpers
             Array<StringArray> strings;
 
             for (const auto& areaString : areasStrings)
-                strings.add (StringArray::fromTokens (areaString, false));
+            {
+                auto stringArray = StringArray::fromTokens (areaString, false);
+                stringArray.removeEmptyStrings (true);
+                strings.add (stringArray);
+            }
 
             if (strings.size() > 0)
             {


### PR DESCRIPTION
This assertion would trigger if there are tabs in the area strings. 

jassert (s.size() == strings[0].size()); // all rows must have the same number of columns

For readability formatting the strings to resemble the grid would make sense. 
Example_
```
grid.templateAreas = { "empty   empty   empty   empty   empty   empty   empty",
                                       "undo     redo      blank     btnA     btnB      btnC      settings",
                                        "empty   empty   empty   empty   empty   empty   empty" };
```