### PR TITLE
[Bugfix] Add missing early return in AudioSubsectionReader::readSamples()

### DIFF
--- a/modules/juce_audio_formats/format/juce_AudioSubsectionReader.cpp
+++ b/modules/juce_audio_formats/format/juce_AudioSubsectionReader.cpp
@@ -56,6 +56,9 @@ bool AudioSubsectionReader::readSamples (int* const* destSamples, int numDestCha
     clearSamplesBeyondAvailableLength (destSamples, numDestChannels, startOffsetInDestBuffer,
                                        startSampleInFile, numSamples, length);
 
+    if (numSamples <= 0)
+        return true;
+
     return source->readSamples (destSamples, numDestChannels, startOffsetInDestBuffer,
                                 startSampleInFile + startSample, numSamples);
 }


### PR DESCRIPTION
Looks like a very old regression since 27895cb6bd49dbe493f136801e9c43ee8c5f366f

In case `clearSamplesBeyondAvailableLength()` returns a negative number of samples, we need to avoid calling `readSamples()` on the source reader. One reason is that it's possible the source reader `readSamples()` will also call `clearSamplesBeyondAvailableLength()`, which can end up calling `zeromem()` with that negative number of samples, causing a crash. (that would happen in case `samplesAvailable`'s value would be an even lower negative number, causing the condition `(samplesAvailable < numSamples)` to evaluate to true).