### PR TITLE
Make nextFFTBlockReady flag atomic.

### DIFF
--- a/examples/Audio/SimpleFFTDemo.h
+++ b/examples/Audio/SimpleFFTDemo.h
@@ -183,7 +183,7 @@ private:
     float fifo [fftSize];
     float fftData [2 * fftSize];
     int fifoIndex = 0;
-    bool nextFFTBlockReady = false;
+    std::atomic<bool> nextFFTBlockReady = false;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (SimpleFFTDemo)
 };


### PR DESCRIPTION
Simple PR.

Race condition between the audio and messenger thread on nextFFTBlockReady is addressed using atomics. 

This PR should fix any undefined behavior including memory barrier problems.
