### PR TITLE
Fix resizing bug for right and bottom edges in GUI Editor

### DIFF
--- a/extras/Projucer/Source/ComponentEditor/UI/jucer_RelativePositionedRectangle.h
+++ b/extras/Projucer/Source/ComponentEditor/UI/jucer_RelativePositionedRectangle.h
@@ -422,7 +422,7 @@ public:
     {
         const auto tie = [] (const PositionedRectangle& r)
         {
-            return std::tie (r.x, r.y, r.xMode, r.yMode, r.wMode, r.hMode);
+            return std::tie (r.x, r.y, r.w, r.h, r.xMode, r.yMode, r.wMode, r.hMode);
         };
 
         return tie (*this) == tie (other);


### PR DESCRIPTION
Fix Bug in GUI Editor for Component Resizing

What's Fixed
This pull request addresses a bug in the GUI editor where components such as Text Buttons and Labels could be resized by dragging the top and left edges but not the bottom and right edges.

Root Cause
The issue stemmed from omitting comparisons for w and h (width and height of the component) when modifying the comparison logic.

