### PR TITLE
Fix build failures without SIMD

### DIFF
--- a/modules/juce_dsp/containers/juce_AudioBlock_test.cpp
+++ b/modules/juce_dsp/containers/juce_AudioBlock_test.cpp
@@ -28,8 +28,10 @@ namespace juce
 namespace dsp
 {
 
+#if JUCE_USE_SIMD
 template <typename SampleType>
 String& operator<< (String& str, SIMDRegister<SampleType>) { return str; }
+#endif
 
 template <typename SampleType>
 class AudioBlockUnitTests   : public UnitTest


### PR DESCRIPTION
The new mention of SIMDRegister here should be guarded on JUCE_USE_SIMD too, to fix the following build failures present on riscv64 and other platforms:

```
In file included from /build/juce/src/JUCE-7.0.7/modules/juce_dsp/juce_dsp.cpp:103:
/build/juce/src/JUCE-7.0.7/modules/juce_dsp/containers/juce_AudioBlock_test.cpp:32:34: error: ‘SIMDRegister’ has not been declared
   32 | String& operator<< (String& str, SIMDRegister<SampleType>) { return str; }
      |                                  ^~~~~~~~~~~~
/build/juce/src/JUCE-7.0.7/modules/juce_dsp/containers/juce_AudioBlock_test.cpp:32:46: error: expected ‘,’ or ‘...’ before ‘<’ token
   32 | String& operator<< (String& str, SIMDRegister<SampleType>) { return str; }
      |                                              ^
```