### PR TITLE
AudioProcessor // Stop crashing when debugging standalone in Xcode.

### DIFF
--- a/modules/juce_audio_processors/processors/juce_AudioProcessor.cpp
+++ b/modules/juce_audio_processors/processors/juce_AudioProcessor.cpp
@@ -437,9 +437,11 @@ void AudioProcessor::validateParameter (AudioProcessorParameter* param)
         See the documentation for AudioProcessorParameter(int) for more information.
     */
    #if JucePlugin_Build_AU
-    static std::once_flag flag;
-    if (wrapperType != wrapperType_Undefined && param->getVersionHint() == 0)
-        std::call_once (flag, [] { jassertfalse; });
+      #if !DEBUG
+       static std::once_flag flag;
+       if (wrapperType != wrapperType_Undefined && param->getVersionHint() == 0)
+           std::call_once (flag, [] { jassertfalse; });
+      #endif
    #endif
 }
 


### PR DESCRIPTION
This PR bypasses AU host identity validation when running in Xcode debug mode.