### PR TITLE
fix: abstract FIFO example docs

### DIFF
--- a/modules/juce_core/containers/juce_AbstractFifo.h
+++ b/modules/juce_core/containers/juce_AbstractFifo.h
@@ -48,7 +48,7 @@ namespace juce
                 copySomeData (myBuffer + scope.startIndex1, someData, scope.blockSize1);
 
             if (scope.blockSize2 > 0)
-                copySomeData (myBuffer + scope.startIndex2, someData, scope.blockSize2);
+                copySomeData (myBuffer + scope.startIndex2, someData + scope.blockSize1, scope.blockSize2);
         }
 
         void readFromFifo (int* someData, int numItems)


### PR DESCRIPTION
in the addToFifo method, the second copySomeData should start copying from someData + scope.blockSize1 instead of someData

