### PR TITLE
Fixes #1294

### DIFF
--- a/modules/juce_audio_devices/native/juce_Audio_ios.cpp
+++ b/modules/juce_audio_devices/native/juce_Audio_ios.cpp
@@ -276,7 +276,7 @@ struct iOSAudioIODevice::Pimpl final : public AsyncUpdater
 
     static void setAudioSessionCategory (NSString* category)
     {
-        NSUInteger options = AVAudioSessionCategoryOptionAllowAirPlay;
+        NSUInteger options = 0;
 
        #if ! JUCE_DISABLE_AUDIO_MIXING_WITH_OTHER_APPS
         options |= AVAudioSessionCategoryOptionMixWithOthers; // Alternatively AVAudioSessionCategoryOptionDuckOthers
@@ -285,7 +285,8 @@ struct iOSAudioIODevice::Pimpl final : public AsyncUpdater
         if (category == AVAudioSessionCategoryPlayAndRecord)
         {
             options |= AVAudioSessionCategoryOptionDefaultToSpeaker
-                     | AVAudioSessionCategoryOptionAllowBluetooth;
+                     | AVAudioSessionCategoryOptionAllowBluetooth
+                     | AVAudioSessionCategoryOptionAllowAirPlay;
 
             if (@available (iOS 10.0, *))
                 options |= AVAudioSessionCategoryOptionAllowBluetoothA2DP;


### PR DESCRIPTION
https://developer.apple.com/documentation/avfaudio/avaudiosessioncategoryoptions/avaudiosessioncategoryoptionallowairplay

Apple's documentation states that "You can only explicitly set this option if the audio session’s category is set to AVAudioSessionCategoryPlayAndRecord."

Change the code so that it's only explicitly enabled in that specific category.

Thank you for submitting a pull request.

Please make sure you have read and followed our contribution guidelines (.github/contributing.md in this repository). Your pull request will not be accepted if you have not followed the instructions.

