### PR TITLE
Crash fix: Remove Concertina header mouse listener on destroy

### DIFF
--- a/modules/juce_gui_basics/layout/juce_ConcertinaPanel.cpp
+++ b/modules/juce_gui_basics/layout/juce_ConcertinaPanel.cpp
@@ -223,6 +223,11 @@ public:
         addAndMakeVisible (comp);
     }
 
+    ~PanelHolder() {
+        if (customHeaderComponent != nullptr)
+            customHeaderComponent->removeMouseListener (this);
+    }
+
     void paint (Graphics& g) override
     {
         if (customHeaderComponent == nullptr)
@@ -270,6 +275,9 @@ public:
 
     void setCustomHeaderComponent (Component* headerComponent, bool shouldTakeOwnership)
     {
+        if (customHeaderComponent != nullptr)
+            customHeaderComponent->removeMouseListener (this);
+
         customHeaderComponent.set (headerComponent, shouldTakeOwnership);
 
         if (headerComponent != nullptr)


### PR DESCRIPTION
This fixes a crash bug where the header component (provided that it was owned by the caller, i.e. shouldTakeOwnership=false) has a dangling mouse listener pointing to "this," which is a PanelHolder that has been destroyed. We need to remove this listener when either the PanelHolder is destroyed, or a new custom header has been set. Otherwise, if that custom header is used again, mousing over it will SIGSEGV when the mouse listener is invoked.