### PR TITLE
MPEZoneLayout: reset MidiRPNDetector once RPN message processed

### DIFF
--- a/modules/juce_audio_basics/mpe/juce_MPEZoneLayout.cpp
+++ b/modules/juce_audio_basics/mpe/juce_MPEZoneLayout.cpp
@@ -113,6 +113,7 @@ void MPEZoneLayout::processNextMidiEvent (const MidiMessage& message)
                                             message.getControllerValue()))
     {
         processRpnMessage (*parsed);
+        rpnDetector.reset();
     }
 }
 


### PR DESCRIPTION
This is to address this issue raised on the JUCE forum: [https://forum.juce.com/t/juce-mpe-mode-configuration-implementation-issue/59537](https://forum.juce.com/t/juce-mpe-mode-configuration-implementation-issue/59537)

As detailed in the MIDI spec - the MPE Configuration Message is an RPN message:

```
Message Format: [Bn 64 06] [Bn 65 00] [Bn 06 <mm>]
 n = MIDI Channel Number
 n=0: Lower Zone Master Channel
 n=F: Upper Zone Master Channel
 All other values are invalid and should be ignored
 mm = Number of Member MIDI Channels in the Zone
 mm=0: MPE is Off (No Channels)
 mm=1 to F: Assigns that number of MIDI Channels to the Zone
```

It only expects the MSB portion of the Parameter Value - and ignores the LSB. With that in mind, it would be best to reset the MidiRPNDetector object after the MSB value is received and avoid any spurious updates happening after (since otherwise the MidiRPNDetector object would remain active to receive any further MSB and LSB messages - as per the Running Status implementation)