### PR TITLE
Allow daisy-chaining when adding children to ValueTrees

### DIFF
--- a/modules/juce_data_structures/values/juce_ValueTree.cpp
+++ b/modules/juce_data_structures/values/juce_ValueTree.cpp
@@ -244,7 +244,7 @@ public:
         return children.indexOf (child.object);
     }
 
-    void addChild (SharedObject* child, int index, UndoManager* undoManager)
+    ValueTree& addChild (SharedObject* child, int index, UndoManager* undoManager)
     {
         if (child != nullptr && child->parent != this)
         {
@@ -283,9 +283,11 @@ public:
                 jassertfalse;
             }
         }
+
+        return *this;
     }
 
-    void removeChild (int childIndex, UndoManager* undoManager)
+    ValueTree& removeChild (int childIndex, UndoManager* undoManager)
     {
         if (auto child = Ptr (children.getObjectPointer (childIndex)))
         {
@@ -301,6 +303,8 @@ public:
                 undoManager->perform (new AddOrRemoveChildAction (*this, childIndex, {}));
             }
         }
+
+        return *this;
     }
 
     void removeAllChildren (UndoManager* undoManager)

--- a/modules/juce_data_structures/values/juce_ValueTree.h
+++ b/modules/juce_data_structures/values/juce_ValueTree.h
@@ -323,14 +323,16 @@ public:
         If the undoManager parameter is not nullptr, its UndoManager::perform() method will be used,
         so that this change can be undone. Be very careful not to mix undoable and non-undoable changes!
         @see appendChild, removeChild
+        @returns a reference to the value tree, so that you can daisy-chain calls to this method.
     */
-    void addChild (const ValueTree& child, int index, UndoManager* undoManager);
+    ValueTree& addChild (const ValueTree& child, int index, UndoManager* undoManager);
 
     /** Appends a new child sub-tree to this tree.
         This is equivalent to calling addChild() with an index of -1. See addChild() for more details.
         @see addChild, removeChild
+        @returns a reference to the value tree, so that you can daisy-chain calls to this method.
     */
-    void appendChild (const ValueTree& child, UndoManager* undoManager);
+    ValueTree& appendChild (const ValueTree& child, UndoManager* undoManager);
 
     /** Removes the specified child from this tree's child-list.
         If the undoManager parameter is not nullptr, its UndoManager::perform() method will be used,


### PR DESCRIPTION
Currently, it's possible to daisy-chain property setters on a value tree:

```cpp
juce::ValueTree {"Tree"}
    .setProperty("foo", 10, nullptr)
    .setProperty("bar", 20, nullptr);
```

This PR adds this behaviour to the child-adders as well, allowing a whole tree to be constructed this way:

```cpp
juce::ValueTree {"Root"}
    .setProperty("foo", 10, nullptr)
    .setProperty("bar", 20, nullptr)
    .appendChild (juce::ValueTree {"Branch"}
                      .setProperty ("x", y, nullptr)
                      .appendChild (juce::ValueTree {"Leaf"}, nullptr),
                  nullptr)
    .addChild (juce::ValueTree {"Branch"}, 0, nullptr);
```

This is useful when loading value-trees from places external to the current call site (.e.g loading state from XML) and then adding on any additional children (e.g. any state that shouldn't be persisted to a file).

It also allows for better const-ness as the tree doesn't need to be changed after initialisation:

```cpp
juce::ValueTree nonConst {"Tree"};
nonConst.appendChild (juce::ValueTree {"Data"}, nullptr);

const auto isConst = juce::ValueTree {"Tree"}
                         .appendChild (juce::ValueTree {"Data"}, nullptr);
```