### PR TITLE
Cmake: Fix missing console app product name

### DIFF
--- a/extras/Build/CMake/JUCEUtils.cmake
+++ b/extras/Build/CMake/JUCEUtils.cmake
@@ -1996,6 +1996,7 @@ function(juce_add_console_app target)
     endif()
 
     _juce_initialise_target(${target} ${ARGN})
+    _juce_set_output_name(${target} $<TARGET_PROPERTY:${target},JUCE_PRODUCT_NAME>)
 
     if(NOT JUCE_ARG__NO_RESOURCERC)
         _juce_write_configure_time_info(${target})


### PR DESCRIPTION
Console Application never set the product_name
