### PR TITLE
Don't try to use nonexistent libpng optimizations

### DIFF
--- a/modules/juce_graphics/image_formats/juce_PNGLoader.cpp
+++ b/modules/juce_graphics/image_formats/juce_PNGLoader.cpp
@@ -266,6 +266,9 @@ namespace pnglibNamespace
   #define PNG_LINKAGE_FUNCTION
 
   #define PNG_ARM_NEON_OPT 0
+  #define PNG_POWERPC_VSX_OPT 0
+  #define PNG_INTEL_SSE_OPT 0
+  #define PNG_MIPS_MSA_OPT 0
 
   #if ! defined (PNG_USER_WIDTH_MAX)
    #define PNG_USER_WIDTH_MAX 1000000


### PR DESCRIPTION
Fixes #1094.

The embedded copy of libpng in [juce\_graphics/image\_formats](https://github.com/juce-framework/JUCE/tree/6c32c4df87ae34f7387445cf2ef9410db62c438c/modules/juce_graphics/image_formats) doesn't contain code for processor-specific hardware optimizations, but it may still try to use them in some cases, resulting in linker errors.

juce\_PNGLoader.cpp already [sets `PNG_ARM_NEON_OPT` to 0](https://github.com/juce-framework/JUCE/blob/6c32c4df87ae34f7387445cf2ef9410db62c438c/modules/juce_graphics/image_formats/juce_PNGLoader.cpp#L268) to disable optimizations on ARM, but this should be done for all architectures, especially PowerPC, where builds currently fail (#1094):

<details>
<summary>Linker failure on ppc64le</summary>
<pre></code>$ cmake .. -DJUCE_BUILD_HELPER_TOOLS=ON
-- The C compiler identification is GNU 13.2.0
-- The CXX compiler identification is GNU 13.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found PkgConfig: /usr/bin/pkg-config (found version "1.8.1") 
-- Checking for module 'alsa'
--   Found alsa, version 1.2.10
-- Checking for module 'freetype2'
--   Found freetype2, version 26.1.20
-- Checking for module 'gl'
--   Found gl, version 1.2
-- Checking for module 'libcurl'
--   Found libcurl, version 8.4.0
-- Checking for modules 'webkit2gtk-4.0;gtk+-x11-3.0'
--   Package 'webkit2gtk-4.0', required by 'virtual:world', not found
-- Configuring done (1.5s)
-- Generating done (0.0s)
-- Build files have been written to: /tmp/JUCE/build
$ make -j20
[ 12%] Building CXX object extras/Build/juceaide/CMakeFiles/juceaide.dir/__/__/__/modules/juce_graphics/juce_graphics.cpp.o
[ 25%] Building CXX object extras/Build/juceaide/CMakeFiles/juceaide.dir/__/__/__/modules/juce_gui_basics/juce_gui_basics.cpp.o
[ 50%] Building CXX object extras/Build/juceaide/CMakeFiles/juceaide.dir/__/juce_build_tools/juce_build_tools.cpp.o
[ 62%] Building CXX object extras/Build/juceaide/CMakeFiles/juceaide.dir/__/__/__/modules/juce_core/juce_core.cpp.o
[ 62%] Building CXX object extras/Build/juceaide/CMakeFiles/juceaide.dir/__/__/__/modules/juce_events/juce_events.cpp.o
[ 75%] Building CXX object extras/Build/juceaide/CMakeFiles/juceaide.dir/__/__/__/modules/juce_data_structures/juce_data_structures.cpp.o
[ 87%] Building CXX object extras/Build/juceaide/CMakeFiles/juceaide.dir/Main.cpp.o
/tmp/JUCE/extras/Build/juceaide/Main.cpp: In lambda function:
/tmp/JUCE/extras/Build/juceaide/Main.cpp:581:5: warning: control reaches end of non-void function [-Wreturn-type]
  581 |     });
      |     ^
[100%] Linking CXX executable juceaide_artefacts/juceaide
/usr/bin/ld: CMakeFiles/juceaide.dir/__/__/__/modules/juce_graphics/juce_graphics.cpp.o: in function `juce::pnglibNamespace::png_init_filter_functions(juce::pnglibNamespace::png_struct_def*)':
juce_graphics.cpp:(.text+0x8304c): undefined reference to `juce::pnglibNamespace::png_init_filter_functions_vsx(juce::pnglibNamespace::png_struct_def*, unsigned int)'
collect2: error: ld returned 1 exit status
make[2]: *** [extras/Build/juceaide/CMakeFiles/juceaide.dir/build.make:194: extras/Build/juceaide/juceaide_artefacts/juceaide] Error 1
make[1]: *** [CMakeFiles/Makefile2:131: extras/Build/juceaide/CMakeFiles/juceaide.dir/all] Error 2
make: *** [Makefile:136: all] Error 2</code></pre>
</details>

On x86, this isn't strictly necessary, because [libpng optimizations are opt-in for x86](https://github.com/pnggroup/libpng/blob/v1.6.37/pngpriv.h#L208), rather than opt-out as with all other architectures, but for completeness and robustness it is also included here.

The macros to disable optimizations on other platforms come [straight from libpng's own build files](https://github.com/pnggroup/libpng/blob/v1.6.37/configure#L13500); this is how it disables optimizations when compiled without support for them. `PNG_ARM_NEON_OPT` is already one of those macros; this PR simply adds the other three.
