### PR TITLE
Documentation: Remove duplicate apt dependency

### DIFF
--- a/docs/Linux Dependencies.md
+++ b/docs/Linux Dependencies.md
@@ -53,10 +53,17 @@ or
 The full command is as follows:
 
     sudo apt update
-    sudo apt install libasound2-dev libjack-jackd2-dev \
-        ladspa-sdk \
-        libcurl4-openssl-dev  \
+    sudo apt install ladspa-sdk \
+        libcurl4-openssl-dev \
         libfreetype6-dev \
-        libx11-dev libxcomposite-dev libxcursor-dev libxext-dev libxinerama-dev libxrandr-dev libxrender-dev \
+        libglu1-mesa-dev \
+        libjack-jackd2-dev \
         libwebkit2gtk-4.0-dev \
-        libglu1-mesa-dev mesa-common-dev
+        libx11-dev \
+        libxcomposite-dev \
+        libxcursor-dev \
+        libxext-dev \
+        libxinerama-dev \
+        libxrandr-dev \
+        libxrender-dev \
+        mesa-common-dev

--- a/docs/Linux Dependencies.md
+++ b/docs/Linux Dependencies.md
@@ -57,6 +57,6 @@ The full command is as follows:
         ladspa-sdk \
         libcurl4-openssl-dev  \
         libfreetype6-dev \
-        libx11-dev libxcomposite-dev libxcursor-dev libxcursor-dev libxext-dev libxinerama-dev libxrandr-dev libxrender-dev \
+        libx11-dev libxcomposite-dev libxcursor-dev libxext-dev libxinerama-dev libxrandr-dev libxrender-dev \
         libwebkit2gtk-4.0-dev \
         libglu1-mesa-dev mesa-common-dev


### PR DESCRIPTION
- Removes duplicate apt dependency (`libxcursor-dev`)
- Splits apt dependencies onto new lines to make it easier to spot duplicates