### PR TITLE
Fix architecture detection on ppc64le

### DIFF
--- a/extras/Build/CMake/juce_runtime_arch_detection.cpp
+++ b/extras/Build/CMake/juce_runtime_arch_detection.cpp
@@ -62,7 +62,11 @@
 #elif defined(__ppc__) || defined(__ppc) || defined(__powerpc__) || defined(_ARCH_COM) || defined(_ARCH_PWR) || defined(_ARCH_PPC) || defined(_M_MPPC) || defined(_M_PPC)
 
   #if defined(__ppc64__) || defined(__powerpc64__) || defined(__64BIT__)
-    #error JUCE_ARCH ppc64
+    #ifdef __LITTLE_ENDIAN__
+      #error JUCE_ARCH ppc64le
+    #else
+      #error JUCE_ARCH ppc64
+    #endif
   #else
     #error JUCE_ARCH ppc
   #endif


### PR DESCRIPTION
[juce\_runtime\_arch\_detection.cpp](https://github.com/juce-framework/JUCE/blob/6056c686b8264d00022825005262618e0f0ade00/extras/Build/CMake/juce_runtime_arch_detection.cpp#L65) currently identifies `ppc64le` as `ppc64`, which causes JUCE to use the directory name `ppc64-linux` for VST 3 plugin contents. However, VST 3 [specifies that `uname -m` should be used](https://steinbergmedia.github.io/vst3_dev_portal/pages/Technical+Documentation/Locations+Format/Plugin+Format.html#for-the-linux-platform) as the first component of the directory name, which on 64-bit little-endian PowerPC is `ppc64le`.

Currently, this causes problems when building VST 3 plugins on this platform, as the VST 3 SDK expects the module directory to be named `ppc64le-linux`.

This PR adds an additional endianness check when 64-bit PowerPC is detected, outputting `ppc64` or `ppc64le` as appropriate.