### PR TITLE
New feature: add-file functionality to Projucer

### DIFF
--- a/extras/Projucer/Source/Application/jucer_CommandLine.cpp
+++ b/extras/Projucer/Source/Application/jucer_CommandLine.cpp
@@ -152,6 +152,11 @@ namespace
                 modules.tryToFixMissingDependencies (m);
         }
 
+        void addFile (const File& file)
+        {
+            project->getMainGroup().addFileRetainingSortOrder (file, true);
+        }
+
         std::unique_ptr<Project> project;
     };
 
@@ -169,6 +174,23 @@ namespace
                   << proj.project->getFile().getFullPathName() << std::endl;
 
         proj.save (justSaveResources, args.containsOption ("--fix-missing-dependencies"));
+    }
+
+    static void addFile (const ArgumentList& args)
+    {
+        args.checkMinNumArguments (3);
+        LoadedProject proj (args[1]);
+        auto fileToAdd = args[2].resolveAsExistingFile();
+
+        std::cout << "Adding File: "
+                  << fileToAdd.getFileName() << std::endl;
+
+        proj.addFile (fileToAdd.getFullPathName());
+
+        std::cout << "Re-saving file: "
+                  << proj.project->getFile().getFullPathName() << std::endl;
+
+        proj.save (false, args.containsOption ("--fix-missing-dependencies"));
     }
 
     //==============================================================================
@@ -824,6 +846,8 @@ namespace
                   << std::endl
                   << "Usage: " << std::endl
                   << std::endl
+                  << " " << appName << " --add-file project_file path_to_file_to_add" << std::endl
+                  << "    Adds an existing file or directory to a project." << std::endl
                   << " " << appName << " --resave project_file" << std::endl
                   << "    Resaves all files and resources in a project. Add the \"--fix-missing-dependencies\" option to automatically fix any missing module dependencies." << std::endl
                   << std::endl
@@ -906,6 +930,7 @@ int performCommandLine (const ArgumentList& args)
         if (matchCommand ("help"))                     { showHelp();                            return 0; }
         if (matchCommand ("h"))                        { showHelp();                            return 0; }
         if (matchCommand ("resave"))                   { resaveProject (args, false);           return 0; }
+        if (matchCommand ("add-file"))                 { addFile (args);                        return 0; }
         if (matchCommand ("resave-resources"))         { resaveProject (args, true);            return 0; }
         if (matchCommand ("get-version"))              { getVersion (args);                     return 0; }
         if (matchCommand ("set-version"))              { setVersion (args);                     return 0; }


### PR DESCRIPTION
Added new subcommand to Projucer command line.

Projucer --add-file jucerfile.jucer path/to/file/or/directory/to/add/project

Feature request https://forum.juce.com/t/projucer-add-folder-file-via-command-line/50732



