### PR TITLE
Changed how HTTP headers are ended on Linux

### DIFF
--- a/modules/juce_core/native/juce_Network_linux.cpp
+++ b/modules/juce_core/native/juce_Network_linux.cpp
@@ -525,7 +525,14 @@ private:
         if (userHeaders.isNotEmpty())
             header << "\r\n" << userHeaders;
 
-        header << "\r\n\r\n";
+        if(header.toString().endsWith("\r\n"))
+        {
+            header << "\r\n";
+        }
+        else
+        {
+            header << "\r\n\r\n";
+        }
 
         if (hasPostData)
             header << postData;


### PR DESCRIPTION
This is fixing the error reported at https://forum.juce.com/t/url-header-suffix-on-linux/59985/2

Essentially the HTTP header section should end with "/r/n/r/n". The previous code was not taking into account that there might already be some of the suffix present before applying it.
