### PR TITLE
feat: add forEach method to ProcessorChain

### DIFF
--- a/modules/juce_dsp/processors/juce_ProcessorChain.h
+++ b/modules/juce_dsp/processors/juce_ProcessorChain.h
@@ -96,6 +96,12 @@ public:
                                 processors);
     }
 
+    /** Call the given function on each processor */
+    template <typename Fn>
+    void forEach(Fn &&fn) {
+      detail::forEachInTuple([&](auto &proc, auto) { fn(proc); }, processors);
+    }
+
 private:
     template <typename Context, typename Proc, size_t Ix>
     void processOne (const Context& context, Proc& proc, std::integral_constant<size_t, Ix>) noexcept


### PR DESCRIPTION
This pull request adds `forEach` method to the `ProcessorChain`. 

This allows for calling custom functions on each processor defined without the need to manually use the `get` method for each of them.