### PR TITLE
juce_core: Fix infinite allocation loop in AllocationHooks

### DIFF
--- a/modules/juce_core/memory/juce_AllocationHooks.cpp
+++ b/modules/juce_core/memory/juce_AllocationHooks.cpp
@@ -33,10 +33,8 @@ static AllocationHooks& getAllocationHooksForThread()
 
 void notifyAllocationHooksForThread()
 {
-    getAllocationHooksForThread().listenerList.call ([] (AllocationHooks::Listener& l)
-    {
-        l.newOrDeleteCalled();
-    });
+    if (auto* l = getAllocationHooksForThread().listener)
+        l->newOrDeleteCalled();
 }
 
 }
@@ -84,12 +82,12 @@ namespace juce
 UnitTestAllocationChecker::UnitTestAllocationChecker (UnitTest& test)
     : unitTest (test)
 {
-    getAllocationHooksForThread().addListener (this);
+    getAllocationHooksForThread().setListener (this);
 }
 
 UnitTestAllocationChecker::~UnitTestAllocationChecker() noexcept
 {
-    getAllocationHooksForThread().removeListener (this);
+    getAllocationHooksForThread().setListener (nullptr);
     unitTest.expectEquals ((int) calls, 0, "new or delete was incorrectly called while allocation checker was active");
 }
 

--- a/modules/juce_core/memory/juce_AllocationHooks.h
+++ b/modules/juce_core/memory/juce_AllocationHooks.h
@@ -34,12 +34,11 @@ public:
         virtual void newOrDeleteCalled() noexcept = 0;
     };
 
-    void addListener    (Listener* l)          { listenerList.add (l); }
-    void removeListener (Listener* l) noexcept { listenerList.remove (l); }
+    void setListener (Listener* l) { listener = l; }
 
 private:
     friend void notifyAllocationHooksForThread();
-    ListenerList<Listener> listenerList;
+    Listener* listener = nullptr;
 };
 
 //==============================================================================


### PR DESCRIPTION
`AllocationHooks` has a `ListenerList` member variable which was recently updated to allocate on instantiation of its internal listeners list:
`const SharedListeners listeners = std::make_shared<ArrayType>();` 

Call to `std::make_shared` allocates which results in an infinite loop: `operator new` is called which attempts to access the static `AllocationHooks` object which does not yet exist - so the constructor gets called again, which then calls `operator new` again, and so round and round it goes - which unfortunately renders that feature unusable at the moment.

As nice as maintaining a unified approach to handling listeners would be, I don't think there's much need to support multiple listeners as `AllocationHooks` primary reason for existence is `UnitTestAllocationChecker` so I've simplified it to handle a single `Listener` only. 