### PR TITLE
Android: Fix ImageDemo Permissions

### DIFF
--- a/examples/GUI/ImagesDemo.h
+++ b/examples/GUI/ImagesDemo.h
@@ -56,9 +56,6 @@ public:
     ImagesDemo()
     {
         setOpaque (true);
-        imageList.setDirectory (File::getSpecialLocation (File::userPicturesDirectory), true, true);
-        directoryThread.startThread (Thread::Priority::background);
-
         fileTree.setTitle ("Files");
         fileTree.addListener (this);
         fileTree.setColour (TreeView::backgroundColourId, Colours::grey);
@@ -81,6 +78,20 @@ public:
                                           -0.7);        // and its preferred size is 70% of the total available space
 
         setSize (500, 500);
+
+        RuntimePermissions::request (RuntimePermissions::readMediaImages,
+                                     [this] (bool granted)
+                                     {
+                                         if (! granted)
+                                         {
+                                             AlertWindow::showMessageBoxAsync (MessageBoxIconType::WarningIcon,
+                                                                               "Permissions warning",
+                                                                               "External storage access permission not granted, some files"
+                                                                               " may be inaccessible.");
+                                         }
+                                         imageList.setDirectory (File::getSpecialLocation (File::userPicturesDirectory), true, true);
+                                         directoryThread.startThread (Thread::Priority::background);
+                                     });
     }
 
     ~ImagesDemo() override

--- a/modules/juce_core/native/juce_Files_android.cpp
+++ b/modules/juce_core/native/juce_Files_android.cpp
@@ -297,7 +297,7 @@ private:
 
             if (jniCheckHasExceptionOccurredAndClear())
             {
-                // An exception has occurred, have you acquired RuntimePermission::readExternalStorage permission?
+                // An exception has occurred, have you acquired RuntimePermissions::readExternalStorage permission?
                 jassertfalse;
                 return {};
             }


### PR DESCRIPTION
### Problem:
ImageDemo failed to load image files on Android upon clean installation of DemoRunner.   

### Fix:
This pull request fixes this issue by checking for permissions prior to attempting to read image files.  
It also corrects a comment typo.

### Tested:
Android API: 34