### PR TITLE
Fix crash after MessageManager deleted/recreated

### DIFF
--- a/modules/juce_gui_basics/native/juce_Windowing_windows.cpp
+++ b/modules/juce_gui_basics/native/juce_Windowing_windows.cpp
@@ -5336,19 +5336,14 @@ bool juce::detail::WindowingHelpers::isWindowOnCurrentVirtualDesktop (void* x)
     if (x == nullptr)
         return false;
 
-    static auto* desktopManager = []
-    {
-        JuceIVirtualDesktopManager* result = nullptr;
+    JuceIVirtualDesktopManager* desktopManager = nullptr;
 
-        JUCE_BEGIN_IGNORE_WARNINGS_GCC_LIKE ("-Wlanguage-extension-token")
+    JUCE_BEGIN_IGNORE_WARNINGS_GCC_LIKE ("-Wlanguage-extension-token")
 
-        if (SUCCEEDED (CoCreateInstance (__uuidof (JuceVirtualDesktopManager), nullptr, CLSCTX_ALL, IID_PPV_ARGS (&result))))
-            return result;
+    if (FAILED (CoCreateInstance (__uuidof (JuceVirtualDesktopManager), nullptr, CLSCTX_ALL, IID_PPV_ARGS (&desktopManager))))
+        return true;
 
-        JUCE_END_IGNORE_WARNINGS_GCC_LIKE
-
-        return static_cast<JuceIVirtualDesktopManager*> (nullptr);
-    }();
+    JUCE_END_IGNORE_WARNINGS_GCC_LIKE
 
     BOOL current = false;
 


### PR DESCRIPTION
If the MessageManager is deleted (via e.g. deleteInstance()) and then re-created in the same process, the next time that a top-level window is created, the process will crash because the JuceIVirtualDesktopManager COM object pointer is cached in a static variable, and the MessageManager deconstructor calls OleUninitialize() which shuts down COM, thereby invalidating the static cached pointer.

There's no reason to cache this anyway, as CoCreateInstance() returns a singleton, and this is not performance-sensitive code in a tight loop or something.

I found this bug because in my unit testing, I create and destroy the message manager for each test to ensure that the tests are hermetic. With this fix in place it works perfectly.

Thank you for submitting a pull request.

Please make sure you have read and followed our contribution guidelines (.github/contributing.md in this repository). Your pull request will not be accepted if you have not followed the instructions.

