### PR TITLE
Fix include paths inconsistency in case vst2 sdk path is set

### DIFF
--- a/extras/Build/CMake/JUCEModuleSupport.cmake
+++ b/extras/Build/CMake/JUCEModuleSupport.cmake
@@ -498,7 +498,8 @@ function(juce_add_module module_path)
 
         target_include_directories(juce_vst3_headers INTERFACE
             "$<$<TARGET_EXISTS:juce_vst3_sdk>:$<TARGET_PROPERTY:juce_vst3_sdk,INTERFACE_INCLUDE_DIRECTORIES>>"
-            "$<$<NOT:$<TARGET_EXISTS:juce_vst3_sdk>>:${base_path}/juce_audio_processors/format_types/VST3_SDK>")
+            "$<$<NOT:$<TARGET_EXISTS:juce_vst3_sdk>>:${base_path}/juce_audio_processors/format_types/VST3_SDK>"
+            "$<$<TARGET_EXISTS:juce_vst2_sdk>:$<TARGET_PROPERTY:juce_vst2_sdk,INTERFACE_INCLUDE_DIRECTORIES>>")
 
         target_link_libraries(juce_audio_processors INTERFACE juce_vst3_headers)
 

--- a/extras/Build/CMake/JUCEUtils.cmake
+++ b/extras/Build/CMake/JUCEUtils.cmake
@@ -1965,7 +1965,6 @@ function(_juce_initialise_target target)
 
     target_include_directories(${target} PRIVATE
         $<TARGET_PROPERTY:${target},JUCE_GENERATED_SOURCES_DIRECTORY>)
-    target_link_libraries(${target} PUBLIC $<$<TARGET_EXISTS:juce_vst2_sdk>:juce_vst2_sdk>)
 
     get_target_property(is_pluginhost_au ${target} JUCE_PLUGINHOST_AU)
 
@@ -2291,10 +2290,7 @@ function(juce_set_vst2_sdk_path path)
 
     add_library(juce_vst2_sdk INTERFACE IMPORTED GLOBAL)
 
-    # This is a bit of a hack, but we really need the VST2 paths to always follow the VST3 paths.
-    target_include_directories(juce_vst2_sdk INTERFACE
-        $<TARGET_PROPERTY:juce::juce_vst3_headers,INTERFACE_INCLUDE_DIRECTORIES>
-        "${path}")
+    target_include_directories(juce_vst2_sdk INTERFACE "${path}")
 endfunction()
 
 function(juce_set_vst3_sdk_path path)


### PR DESCRIPTION
All include paths set by JUCE are regular, non-system ones, -except- if a vst2 sdk path is set, in which case both the vst2 sdk path and the vst3 sdk path (custom or not) become system includes. This commit removes the exceptional behavior.

The sdks include paths order (VST3 preceding VST2) is kept.

Note: The approach in the commit assumes noone would need a `juce_vst2_headers` target in addition to the `juce_vst3_headers` one. If that's not the case, it's easy to modify the commit to instead define such an additional target.