### PR TITLE
ValueTree::SharedObject::callListeners optimization

### DIFF
--- a/modules/juce_data_structures/values/juce_ValueTree.cpp
+++ b/modules/juce_data_structures/values/juce_ValueTree.cpp
@@ -81,7 +81,7 @@ public:
             {
                 auto* v = listenersCopy.getUnchecked (i);
 
-                if (i == 0 || valueTreesWithListeners.contains (v))
+                if (i == 0 || valueTreesWithListeners[i] == v || valueTreesWithListeners.contains (v))
                     v->listeners.callExcluding (listenerToExclude, fn);
             }
         }


### PR DESCRIPTION
This PR introduces an optimization to the `ValueTree::SharedObject::callListeners` method, improving its performance by avoiding a `valueTreesWithListeners.contains(v)` call when `valueTreesWithListeners` is not modified by one of the listeners. Instead, `valueTreesWithListeners[i] == v` is checked before. It gives a significant speedup when `numListeners` is high.

Note that if `i` is out of bounds, a `nullptr` is returned by `valueTreesWithListeners[i]` and it will compare as not equal to `v`.

This change improved significantly the performance of preset loading at Minimal Audio (internally using `juce::ValueTree::copyPropertiesAndChildrenFrom`), so we share it back. See this [PR description in our JUCE fork](https://github.com/Minimal-Audio/JUCE/pull/7) for some indicative benchmarks. 
