### PR TITLE
[bugfix] Fixed to properly convert multibyte text to juce::String.

### DIFF
--- a/modules/juce_core/text/juce_String.cpp
+++ b/modules/juce_core/text/juce_String.cpp
@@ -2164,7 +2164,7 @@ String String::fromUTF8 (const char* const buffer, int bufferSizeBytes)
     }
 
     jassert (CharPointer_UTF8::isValidString (buffer, bufferSizeBytes));
-    return { CharPointer_UTF8 (buffer), (size_t) bufferSizeBytes };
+    return { CharPointer_UTF8 (buffer), CharPointer_UTF8 (buffer + bufferSizeBytes) };
 }
 
 #if __cpp_char8_t


### PR DESCRIPTION
# Summary

This fixes an issue where the implementation of the `juce::String::fromUTF8` function incorrectly handles multi-byte character strings.

# Details

The current implementation may incorrectly treat parts of multi-byte character strings as invalid characters. 
For example, consider the following code:

```cpp
// Equivalent to --> auto url = juce::URL(juce::File("C:/path/to/日本語"));
auto url = juce::URL(juce::File(juce::CharPointer_UTF8("C:/path/to/\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e")));

// Return is --> file:///C%3A/path/to/%E6%97%A5%E6%9C%AC%E8%AA%9E
juce::Logger::outputDebugString(url.toString(true));

// Output is --> C:\path\to\日本語9E9E9E
juce::Logger::outputDebugString(url.getLocalFile().getFullPathName());
```

As you can see, the multi-byte characters in the file path are not properly handled, leading to incorrect encoding and data corruption.
With this fix, multi-byte character strings are properly interpreted, and the entire string is correctly decoded.

# After fix

With this fix applied, the execution result of the above code will change, and the conversion process from multi-byte character strings (including Japanese characters) to juce::String will work correctly.

```cpp
// Equivalent to --> auto url = juce::URL(juce::File("C:/path/to/日本語"));
auto url = juce::URL(juce::File(juce::CharPointer_UTF8("C:/path/to/\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e")));

// Return is --> file:///C%3A/path/to/%E6%97%A5%E6%9C%AC%E8%AA%9E
juce::Logger::outputDebugString(url.toString(true));

// Output is --> C:\path\to\日本語
juce::Logger::outputDebugString(url.getLocalFile().getFullPathName());
```

# Related Files

- `juce_String.cpp` - Modified the implementation of the `fromUTF8` function.