### PR TITLE
Add OSC Extra Options

### DIFF
--- a/modules/juce_osc/juce_osc.h
+++ b/modules/juce_osc/juce_osc.h
@@ -60,6 +60,14 @@
 
 #pragma once
 #define JUCE_OSC_H_INCLUDED
+
+/** Config: JUCE_ALLOW_SPECIAL_CHARS_IN_ADDRESS
+	Enables the use of characters in adress that are not allowed by the OSC specifications (like spaces), but that are used
+	by some applications anyway (e.g. /my spaced/address)
+*/
+#ifndef JUCE_ALLOW_SPECIAL_CHARS_IN_ADDRESS 
+#define JUCE_ALLOW_SPECIAL_CHARS_IN_ADDRESS 0 
+#endif 
 /** Config: JUCE_IP_AND_PORT_DETECTION
 	If enabled, this will add remoteIP and remotePort variables to osc packets, corresponding to the sender's ip and port when receiving messages.
 */

--- a/modules/juce_osc/juce_osc.h
+++ b/modules/juce_osc/juce_osc.h
@@ -60,6 +60,12 @@
 
 #pragma once
 #define JUCE_OSC_H_INCLUDED
+/** Config: JUCE_IP_AND_PORT_DETECTION
+	If enabled, this will add remoteIP and remotePort variables to osc packets, corresponding to the sender's ip and port when receiving messages.
+*/
+#ifndef JUCE_IP_AND_PORT_DETECTION 
+#define JUCE_IP_AND_PORT_DETECTION 0 
+#endif 
 
 #include <juce_core/juce_core.h>
 #include <juce_events/juce_events.h>

--- a/modules/juce_osc/juce_osc.h
+++ b/modules/juce_osc/juce_osc.h
@@ -68,6 +68,21 @@
 #ifndef JUCE_ALLOW_SPECIAL_CHARS_IN_ADDRESS 
 #define JUCE_ALLOW_SPECIAL_CHARS_IN_ADDRESS 0 
 #endif 
+
+/** Config: JUCE_ENABLE_BROADCAST_BY_DEFAULT
+	Automatically enables broadcast on bound port in OSCReceiver
+*/
+#ifndef JUCE_ENABLE_BROADCAST_BY_DEFAULT 
+#define JUCE_ENABLE_BROADCAST_BY_DEFAULT 0 
+#endif 
+
+/** Config: JUCE_EXCLUSIVE_BINDING_BY_DEFAULT
+	If enabled, this will make the binding of this port exclusive, so no other process can bind it.
+*/
+#ifndef JUCE_EXCLUSIVE_BINDING_BY_DEFAULT 
+#define JUCE_EXCLUSIVE_BINDING_BY_DEFAULT 0 
+#endif 
+
 /** Config: JUCE_IP_AND_PORT_DETECTION
 	If enabled, this will add remoteIP and remotePort variables to osc packets, corresponding to the sender's ip and port when receiving messages.
 */

--- a/modules/juce_osc/osc/juce_OSCAddress.cpp
+++ b/modules/juce_osc/osc/juce_OSCAddress.cpp
@@ -285,7 +285,11 @@ namespace
 
         static bool isDisallowedChar (juce_wchar c) noexcept
         {
-            return CharPointer_ASCII (Traits::getDisallowedChars()).indexOf (c, false) >= 0;
+#if JUCE_ALLOW_SPECIAL_CHARS_IN_ADDRESS 
+            return false;
+#else 
+            return CharPointer_ASCII( Traits::getDisallowedChars()).indexOf (c, false) >= 0;
+#endif 
         }
 
         static bool containsOnlyAllowedPrintableASCIIChars (const String& string) noexcept

--- a/modules/juce_osc/osc/juce_OSCMessage.cpp
+++ b/modules/juce_osc/osc/juce_OSCMessage.cpp
@@ -50,6 +50,26 @@ OSCAddressPattern OSCMessage::getAddressPattern() const noexcept
     return addressPattern;
 }
 
+#if JUCE_IP_AND_PORT_DETECTION 
+String OSCMessage::getSenderIPAddress() const noexcept
+{
+    return senderIPAddress;
+}
+
+void OSCMessage::setSenderIPAddress(const String& ip) noexcept
+{
+    senderIPAddress = ip;
+}
+
+int OSCMessage::getSenderPortNumber() const noexcept
+{
+    return senderPortNumber;
+}
+void OSCMessage::setSenderPortNumber(int port) noexcept
+{
+    senderPortNumber = port;
+}
+#endif 
 //==============================================================================
 int OSCMessage::size() const noexcept
 {

--- a/modules/juce_osc/osc/juce_OSCMessage.h
+++ b/modules/juce_osc/osc/juce_OSCMessage.h
@@ -91,6 +91,16 @@ public:
     /** Returns the address pattern of the OSCMessage. */
     OSCAddressPattern getAddressPattern() const noexcept;
 
+#if JUCE_IP_AND_PORT_DETECTION 
+    /** Returns the sender's IP Address. */
+    String getSenderIPAddress() const noexcept;
+    void setSenderIPAddress(const String& ip) noexcept;
+
+    /** Returns the sender's port number. */
+    int getSenderPortNumber() const noexcept;
+    void setSenderPortNumber(int port) noexcept;
+#endif 
+
     /** Returns the number of OSCArgument objects that belong to this OSCMessage. */
     int size() const noexcept;
 
@@ -178,6 +188,11 @@ private:
     //==============================================================================
     OSCAddressPattern addressPattern;
     Array<OSCArgument> arguments;
+
+#if JUCE_IP_AND_PORT_DETECTION 
+    String senderIPAddress;
+    int senderPortNumber = 0;
+#endif 
 };
 
 

--- a/modules/juce_osc/osc/juce_OSCReceiver.cpp
+++ b/modules/juce_osc/osc/juce_OSCReceiver.cpp
@@ -354,7 +354,16 @@ struct OSCReceiver::Pimpl   : private Thread,
         if (! disconnect())
             return false;
 
-        socket.setOwned (new DatagramSocket (false));
+#if JUCE_ENABLE_BROADCAST_BY_DEFAULT 
+        DatagramSocket* datagram = new DatagramSocket(true);
+#else 
+        DatagramSocket* datagram = new DatagramSocket(false);
+#endif 
+        socket.setOwned(datagram);
+
+#if JUCE_EXCLUSIVE_BINDING_BY_DEFAULT 
+        socket->setEnablePortReuse(false);
+#endif 
 
         if (! socket->bindToPort (portNumber))
             return false;


### PR DESCRIPTION
This adds options for better OSC Management, that are disabled by default in the Projucer so nothing changes by default.

- Allow special characters in address : some software like Millumin or MaxMSP can have non conventional characters in their address. This allows receiving and parsing the message despite them being "faulty"

- Enable broadcast by default : This allows to activate broadcasting capability on OSCReceiver without having to change the class to be able to access the internal DatagramSocket of the OSCReceiver class. It is likely that users want to be able to receive from anywhere, not just from localhost.

- Exclusive Binding : This allows to disable port reuse when binding. It is likely that users want to get exclusive access to the port, and be able to be notified when a port is already used, instead of not receiving on this port because it's already bound but no error were raised.