### PR TITLE
add variant.isVoid() check in fromVar function

### DIFF
--- a/modules/juce_core/javascript/juce_Javascript.cpp
+++ b/modules/juce_core/javascript/juce_Javascript.cpp
@@ -60,6 +60,9 @@ struct VariantConverter<choc::value::Value>
 {
     static choc::value::Value fromVar (const var& variant)
     {
+        if (variant.isVoid())
+            return {};
+
         if (variant.isInt())
             return choc::value::Value { (int) variant };
 


### PR DESCRIPTION
This adds a check for variant.isVoid() in the fromVar function, allowing to have return type var() when calling C functions from script

This fixes the issue #1399