### PR TITLE
Web Slider default values

### DIFF
--- a/modules/juce_audio_processors/utilities/juce_ParameterAttachments.cpp
+++ b/modules/juce_audio_processors/utilities/juce_ParameterAttachments.cpp
@@ -311,6 +311,7 @@ void WebSliderParameterAttachment::sendInitialUpdate()
     object->setProperty ("numSteps", numSteps);
     object->setProperty ("interval", range.interval);
     object->setProperty ("parameterIndex", parameter.getParameterIndex());
+    object->setProperty ("defaultValue", parameter.getDefaultValue());
     sliderState.emitEvent (object.get());
     attachment.sendInitialUpdate();
 }

--- a/modules/juce_gui_extra/native/javascript/index.js
+++ b/modules/juce_gui_extra/native/javascript/index.js
@@ -153,6 +153,7 @@ class SliderState {
       numSteps: 100,
       interval: 0,
       parameterIndex: -1,
+      defaultValue: 0
     };
     this.valueChangedEvent = new ListenerList();
     this.propertiesChangedEvent = new ListenerList();


### PR DESCRIPTION
This adds default parameter values to the ```juce::WebSliderParameterAttachment```, and JS frontend.

This would be useful for displaying default values in a web UI, and could be used to reset values via alt click.

Any thoughts on this would be really appreciated, possibly there is something I am overlooking as to why this can't be done/is a bad idea.

Cheers!

