### PR TITLE
Add Typescript type definitions to javascript frontend library

### DIFF
--- a/modules/juce_gui_extra/native/javascript/index.d.ts
+++ b/modules/juce_gui_extra/native/javascript/index.d.ts
@@ -1,0 +1,259 @@
+/*
+  ==============================================================================
+
+   This file is part of the JUCE framework.
+   Copyright (c) Raw Material Software Limited
+
+   JUCE is an open source framework subject to commercial or open source
+   licensing.
+
+   By downloading, installing, or using the JUCE framework, or combining the
+   JUCE framework with any other source code, object code, content or any other
+   copyrightable work, you agree to the terms of the JUCE End User Licence
+   Agreement, and all incorporated terms including the JUCE Privacy Policy and
+   the JUCE Website Terms of Service, as applicable, which will bind you. If you
+   do not agree to the terms of these agreements, we will not license the JUCE
+   framework to you, and you must discontinue the installation or download
+   process and cease use of the JUCE framework.
+
+   JUCE End User Licence Agreement: https://juce.com/legal/juce-8-licence/
+   JUCE Privacy Policy: https://juce.com/juce-privacy-policy
+   JUCE Website Terms of Service: https://juce.com/juce-website-terms-of-service/
+
+   Or:
+
+   You may also use this code under the terms of the AGPLv3:
+   https://www.gnu.org/licenses/agpl-3.0.en.html
+
+   THE JUCE FRAMEWORK IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL
+   WARRANTIES, WHETHER EXPRESSED OR IMPLIED, INCLUDING WARRANTY OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE, ARE DISCLAIMED.
+
+  ==============================================================================
+*/
+
+class ListenerList {
+  listeners: Map<number, ListenerCallbackFunction>;
+  listenerId: number;
+  addListener(fn: ListenerCallbackFunction): number;
+  removeListener(id: number): void;
+  callListeners(payload: any): void;
+}
+type ListenerCallbackFunction = (payload: any) => any;
+
+/**
+ * SliderState encapsulates data and callbacks that are synchronised with a WebSliderRelay object
+ * on the backend.
+ *
+ * Use getSliderState() to create a SliderState object. This object will be synchronised with the
+ * WebSliderRelay backend object that was created using the same unique name.
+ *
+ * @param {String} name
+ */
+class SliderState {
+  constructor(name: string);
+  name: string;
+  identifier: string;
+  scaledValue: number;
+  properties: {
+    start: number;
+    end: number;
+    skew: number;
+    name: string;
+    label: string;
+    numSteps: number;
+    interval: number;
+    parameterIndex: number;
+  };
+  valueChangedEvent: ListenerList;
+  propertiesChangedEvent: ListenerList;
+  /**
+   * Sets the normalised value of the corresponding backend parameter. This value is always in the
+   * [0, 1] range (inclusive).
+   *
+   * The meaning of this range is the same as in the case of
+   * AudioProcessorParameter::getValue() (C++).
+   *
+   * @param {String} name
+   */
+  setNormalisedValue(newValue: number): void;
+  /**
+   * This function should be called first thing when the user starts interacting with the slider.
+   */
+  sliderDragStarted(): void;
+  /**
+   * This function should be called when the user finished the interaction with the slider.
+   */
+  sliderDragEnded(): void;
+  /** Internal. */
+  private handleEvent(event: any): void;
+  /**
+   * Returns the scaled value of the parameter. This corresponds to the return value of
+   * NormalisableRange::convertFrom0to1() (C++). This value will differ from a linear
+   * [0, 1] range if a non-default NormalisableRange was set for the parameter.
+   */
+  getScaledValue(): number;
+  /**
+   * Returns the normalised value of the corresponding backend parameter. This value is always in the
+   * [0, 1] range (inclusive).
+   *
+   * The meaning of this range is the same as in the case of
+   * AudioProcessorParameter::getValue() (C++).
+   *
+   * @param {String} name
+   */
+  getNormalisedValue(): number;
+  /** Internal. */
+  private normalisedToScaledValue(normalisedValue: number): number;
+  /** Internal. */
+  private snapToLegalValue(value: number): number;
+}
+
+/**
+ * ToggleState encapsulates data and callbacks that are synchronised with a WebToggleRelay object
+ * on the backend.
+ *
+ * Use getToggleState() to create a ToggleState object. This object will be synchronised with the
+ * WebToggleRelay backend object that was created using the same unique name.
+ *
+ * @param {String} name
+ */
+class ToggleState {
+  constructor(name: string);
+  name: string;
+  identifier: string;
+  value: boolean;
+  properties: {
+    name: string;
+    parameterIndex: number;
+  };
+  valueChangedEvent: ListenerList;
+  propertiesChangedEvent: ListenerList;
+  /** Returns the value corresponding to the associated WebToggleRelay's (C++) state. */
+  getValue(): boolean;
+  /** Informs the backend to change the associated WebToggleRelay's (C++) state. */
+  setValue(newValue: boolean): void;
+  /** Internal. */
+  private handleEvent(event: any): void;
+}
+
+/**
+ * ComboBoxState encapsulates data and callbacks that are synchronised with a WebComboBoxRelay object
+ * on the backend.
+ *
+ * Use getComboBoxState() to create a ComboBoxState object. This object will be synchronised with the
+ * WebComboBoxRelay backend object that was created using the same unique name.
+ *
+ * @param {String} name
+ */
+class ComboBoxState {
+  constructor(name: string);
+  name: string;
+  identifier: string;
+  value: number;
+  properties: {
+    name: string;
+    parameterIndex: number;
+    choices: string[];
+  };
+  valueChangedEvent: ListenerList;
+  propertiesChangedEvent: ListenerList;
+  /**
+   * Returns the value corresponding to the associated WebComboBoxRelay's (C++) state.
+   *
+   * This is an index identifying which element of the properties.choices array is currently
+   * selected.
+   */
+  getChoiceIndex(): number;
+  /**
+   * Informs the backend to change the associated WebComboBoxRelay's (C++) state.
+   *
+   * This should be called with the index identifying the selected element from the
+   * properties.choices array.
+   */
+  setChoiceIndex(index: number): void;
+  /** Internal. */
+  private handleEvent(event: any): void;
+}
+
+/**
+ * This helper class is intended to aid the implementation of
+ * AudioProcessorEditor::getControlParameterIndex() for editors using a WebView interface.
+ *
+ * Create an instance of this class and call its handleMouseMove() method in each mousemove event.
+ *
+ * This class can be used to continuously report the controlParameterIndexAnnotation attribute's
+ * value related to the DOM element that is currently under the mouse pointer.
+ *
+ * This value is defined at all times as follows
+ * * the annotation attribute's value for the DOM element directly under the mouse, if it has it,
+ * * the annotation attribute's value for the first parent element, that has it,
+ * * -1 otherwise.
+ *
+ * Whenever there is a change in this value, an event is emitted to the frontend with the new value.
+ * You can use a ControlParameterIndexReceiver object on the backend to listen to these events.
+ *
+ * @param {String} controlParameterIndexAnnotation
+ */
+export class ControlParameterIndexUpdater {
+  constructor(controlParameterIndexAnnotation: string);
+  controlParameterIndexAnnotation: string;
+  lastElement: Element | null;
+  lastControlParameterIndex: number;
+  handleMouseMove(event: MouseEvent): void;
+}
+
+/**
+ * Returns a function object that calls a function registered on the JUCE backend and forwards all
+ * parameters to it.
+ *
+ * The provided name should be the same as the name argument passed to
+ * WebBrowserComponent::Options.withNativeFunction() on the backend.
+ *
+ * @param {String} name
+ */
+export function getNativeFunction(
+  name: string
+): (...args: any[]) => Promise<any>;
+
+/**
+ * Returns a SliderState object that is connected to the backend WebSliderRelay object that was
+ * created with the same name argument.
+ *
+ * To register a WebSliderRelay object create one with the right name and add it to the
+ * WebBrowserComponent::Options struct using withOptionsFrom.
+ *
+ * @param {String} name
+ */
+export function getSliderState(name: string): SliderState;
+
+/**
+ * Returns a ToggleState object that is connected to the backend WebToggleButtonRelay object that was
+ * created with the same name argument.
+ *
+ * To register a WebToggleButtonRelay object create one with the right name and add it to the
+ * WebBrowserComponent::Options struct using withOptionsFrom.
+ *
+ * @param {String} name
+ */
+export function getToggleState(name: string): ToggleState;
+
+/**
+ * Returns a ComboBoxState object that is connected to the backend WebComboBoxRelay object that was
+ * created with the same name argument.
+ *
+ * To register a WebComboBoxRelay object create one with the right name and add it to the
+ * WebBrowserComponent::Options struct using withOptionsFrom.
+ *
+ * @param {String} name
+ */
+export function getComboBoxState(name: string): ComboBoxState;
+
+/**
+ * Appends a platform-specific prefix to the path to ensure that a request sent to this address will
+ * be received by the backend's ResourceProvider.
+ * @param {String} path
+ */
+export function getBackendResourceAddress(path: string): string;
+
+export {};

--- a/modules/juce_gui_extra/native/javascript/tsconfig.json
+++ b/modules/juce_gui_extra/native/javascript/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "target": "es2016",
+    "noEmit": true,
+    "allowJs": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
Hi! I have been trying out the new WebView features in v8, and I noticed that the current frontend library is incompatible with Typescript.

I am submitting this PR to add a simple type declarations file to the existing project. Without type definitions, Typescript users either cannot use the library, or must disable type checking for this library, which means they also have no access to the JSDoc documentation you've written. This fix is similar to releasing [@types](https://github.com/DefinitelyTyped/DefinitelyTyped#readme) types for javascript code, but as this library is not a published npm package I figure colocating the definitions may be the best solution, at least in the short term.

The only downside to this is that it creates an additional source of truth for function annotations (JS users see the original JSDoc comments, while Typescript users can only see them if they are in the `.d.ts` file.) The only better solution I know of is to fully migrate to Typescript, so for that reason it is very common to maintain types and JS code separately for libraries not originally written in typescript.

Most of the `index.d.ts` file was [generated automatically](https://www.typescriptlang.org/docs/handbook/declaration-files/dts-from-js.html) by the typescript compiler, plus a handful of my corrections.

Let me know if I can improve anything or if I can help answer any questions about how these definitions work. I am already using them on one project and they have been working flawlessly so far.

Thanks!
