### PR TITLE
Correctness patches for Windows

### DIFF
--- a/modules/juce_core/system/juce_StandardHeader.h
+++ b/modules/juce_core/system/juce_StandardHeader.h
@@ -65,6 +65,7 @@
 #include <cmath>
 #include <condition_variable>
 #include <cstddef>
+#include <cstring>
 #include <functional>
 #include <future>
 #include <iomanip>
@@ -97,7 +98,7 @@
 // Now we'll include some common OS headers..
 JUCE_BEGIN_IGNORE_WARNINGS_MSVC (4514 4245 4100)
 
-#if JUCE_MSVC
+#if JUCE_WINDOWS
  #include <intrin.h>
 #endif
 
@@ -110,7 +111,6 @@ JUCE_BEGIN_IGNORE_WARNINGS_MSVC (4514 4245 4100)
 #endif
 
 #if JUCE_LINUX || JUCE_BSD
- #include <cstring>
  #include <signal.h>
 
  #if __INTEL_COMPILER


### PR DESCRIPTION
Hi all,

This Pull Request contains several correctness patches for Windows, which make JUCE more compiler agnostic on Windows. I am aware that only Microsoft Visual C++ is officially supported, but this makes compiling patched versions of JUCE on custom setups easier and can be helpful in the event that Microsoft Visual C++ is not available on a user's device These are small changes that improve code quality, and should not have much impact on the actual JUCE functionality

