### PR TITLE
Fix: No device information printed caused by an error semicolon

### DIFF
--- a/modules/juce_audio_devices/native/juce_Oboe_android.cpp
+++ b/modules/juce_audio_devices/native/juce_Oboe_android.cpp
@@ -495,7 +495,7 @@ private:
 
                 startResult = stream->waitForStateChange (expectedState, &nextState, timeoutNanos);
 
-                JUCE_OBOE_LOG ("Starting Oboe stream with result: " + getOboeString (startResult);
+                JUCE_OBOE_LOG ("Starting Oboe stream with result: " + getOboeString (startResult)
                                  + "\nUses AAudio = " + String ((int) stream->usesAAudio())
                                  + "\nDirection = " + getOboeString (stream->getDirection())
                                  + "\nSharingMode = " + getOboeString (stream->getSharingMode())


### PR DESCRIPTION
Dear JUCE Development Team,

Hello! I am a beginner in programming. While I was debugging the audio output of my app, I noticed that JUCE did not print the device information after the OBOE Stream was correctly created. Upon inspecting the code, I found that a semicolon had been mistakenly added. After removing it, the device information was correctly outputted as shown in the attached screenshot.

![image](https://github.com/user-attachments/assets/d55de0d4-8dec-434a-9060-fea1cba10fdd)

JUCE is truly a fantastic open-source framework; both my mentor and I have used it extensively, and it has been tremendously helpful to us. I regret that as a beginner, I cannot contribute more valuable commits to the JUCE project. Although this error was minor and incidental, I sincerely hope it can be fixed to improve the JUCE project further.

Thank you for your hard work and dedication.

Best regards,
Yuki

