### PR TITLE
JSON: catch trailing commas

### DIFF
--- a/modules/juce_core/javascript/juce_JSON.cpp
+++ b/modules/juce_core/javascript/juce_JSON.cpp
@@ -301,7 +301,7 @@ struct JSONParser
             auto c = readChar();
 
             if (c == '}')
-                break;
+                throwError ("Unexpected trailing comma", errorLocation);
 
             if (c == 0)
                 throwError ("Unexpected EOF in object declaration", startOfObjectDecl);
@@ -342,9 +342,10 @@ struct JSONParser
         for (;;)
         {
             skipWhitespace();
-
+            auto errorLocation = currentLocation;
+          
             if (matchIf (']'))
-                break;
+                throwError ("Unexpected trailing comma", errorLocation);
 
             if (isEOF())
                 throwError ("Unexpected EOF in array declaration", startOfArrayDecl);


### PR DESCRIPTION
The if statements will only trigger if `}` or `]` directly follow a `,`. JSON disallows trailing commas, so this should throw a syntax error.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas

Thank you for submitting a pull request.

Please make sure you have read and followed our contribution guidelines (.github/contributing.md in this repository). Your pull request will not be accepted if you have not followed the instructions.

