### PR TITLE
Fixes #1431: Incorrect results from exponentModulo.

### DIFF
--- a/modules/juce_core/maths/juce_BigInteger.cpp
+++ b/modules/juce_core/maths/juce_BigInteger.cpp
@@ -930,9 +930,14 @@ BigInteger BigInteger::findGreatestCommonDivisor (BigInteger n) const
 
 void BigInteger::exponentModulo (const BigInteger& exponent, const BigInteger& modulus)
 {
+    if (exponent.isZero())
+    {
+        *this = 1;
+        return;
+    }
+    
     *this %= modulus;
     auto exp = exponent;
-    exp %= modulus;
 
     if (modulus.getHighestBit() <= 32 || modulus % 2 == 0)
     {


### PR DESCRIPTION
Changes:
- Removed incorrect mod op on exponent.
- Handled base case for zero exponent.

Tests:
- Tested against modPow by [jsbn](https://github.com/creationix/jsbn)
- Tested 100 runs of random hex strings with lengths 300 - 1000 using [fast-check](https://github.com/dubzzz/fast-check): ✓ src/JuceBigInteger.test.ts (1) 1776566ms ✓ JuceBigInteger (1) 1776565ms ✓ exponentModulo (1) 1776565ms
- Double-checked counter examples on [Omni Calculator](https://www.omnicalculator.com/math/power-modulo):
	- b=x, e=0, m=y
	- b=3, e=8, m=5
	- b=0x1400000007, e=0x1400000006, m=0x1400000005

Source:
- Find the tests in this project: [@ianacaburian/generate-key-file](https://github.com/ianacaburian/generate-key-file/tree/develop)

Thank you for submitting a pull request.

Please make sure you have read and followed our contribution guidelines (.github/contributing.md in this repository). Your pull request will not be accepted if you have not followed the instructions.

