### PR TITLE
Fixes #1442: MacOS addToDesktop w/ nativeWindowToAttachTo handles mouseMove incorrectly

### DIFF
--- a/modules/juce_gui_basics/native/juce_NSViewComponentPeer_mac.mm
+++ b/modules/juce_gui_basics/native/juce_NSViewComponentPeer_mac.mm
@@ -745,12 +745,15 @@ public:
         NSPoint windowPos = [ev locationInWindow];
         NSPoint screenPos = [[ev window] convertRectToScreen: NSMakeRect (windowPos.x, windowPos.y, 1.0f, 1.0f)].origin;
 
-        if (isWindowAtPoint ([ev window], screenPos))
-            sendMouseEvent (ev);
-        else
+        if (isWindowAtPoint ([ev window], screenPos)) {
+            if ([[[ev window] contentView] hitTest: windowPos] == view) {
+              sendMouseEvent (ev);
+            }
+        } else {
             // moved into another window which overlaps this one, so trigger an exit
             handleMouseEvent (MouseInputSource::InputSourceType::mouse, MouseInputSource::offscreenMousePos, ModifierKeys::currentModifiers,
                               getMousePressure (ev), MouseInputSource::defaultOrientation, getMouseTime (ev));
+        }
 
         showArrowCursorIfNeeded();
     }


### PR DESCRIPTION
When handling mouseMove on MacOS, check that the current peer is the topmost NSView before forwarding the events. Without this, a Component created via addDocumentWindow() with the nativeWindowToAttachTo argument set (i.e., creating a sub-NSView) would receive incorrect mouseExit events, as both it *and* its parent component would handle these mouseMove events, rapidly sending enter/exit messages back and forth between the two windows while the mouse moved.