### PR TITLE
Fix javascript bad interrupt

### DIFF
--- a/modules/juce_core/javascript/juce_Javascript.cpp
+++ b/modules/juce_core/javascript/juce_Javascript.cpp
@@ -719,10 +719,10 @@ public:
         return var::undefined();
     }
 
-    Result execute (const String& code, RelativeTime maxExecTime)
+    Result execute (const String& code, RelativeTime maxExecutionTime)
     {
         auto result = Result::ok();
-        evaluate (code, &result, maxExecTime);
+        evaluate (code, &result, maxExecutionTime);
         return result;
     }
 

--- a/modules/juce_core/javascript/juce_Javascript.cpp
+++ b/modules/juce_core/javascript/juce_Javascript.cpp
@@ -688,13 +688,14 @@ public:
         wrapper.release();
     }
 
-    var evaluate (const String& code, Result* errorMessage, RelativeTime maxExecTime)
+    var evaluate (const String& code, Result* errorMessage, RelativeTime maxExecutionTime)
     {
         shouldStop = false;
 
         timeAtLastStart = Time::getMillisecondCounterHiRes();
+        maxExecTime = maxExecutionTime;
 
-        engine.setInterruptHandler ([this, maxExecTime]()
+        engine.setInterruptHandler ([this]()
                                     {
                                         if (shouldStop)
                                             return 1;
@@ -725,9 +726,10 @@ public:
         return result;
     }
 
-    var callFunction (const Identifier& function, const var::NativeFunctionArgs& args, Result* errorMessage, RelativeTime maxExecTime)
+    var callFunction (const Identifier& function, const var::NativeFunctionArgs& args, Result* errorMessage, RelativeTime maxExecutionTime)
     {
         timeAtLastStart = Time::getMillisecondCounterHiRes();
+        maxExecTime = maxExecutionTime;
 
         auto* ctx = engine.getQuickJSContext();
         const auto functionStr = function.toString();
@@ -780,6 +782,7 @@ private:
         This allows to update the interrupt check when using callFunction() after execute() without having to always override the interrupt handler
     */
     double timeAtLastStart = 0;
+    RelativeTime maxExecTime;
 };
 
 //==============================================================================


### PR DESCRIPTION
This proposes a fix for the issue #1445 
 
The execute() function sets an interrupt in the engine that is then checked whenever a function is called using callFunction, but the interval in the interrupt check function is calculated depending on the time at execute(), not the time at callFunction(), resulting in an inevitable interrupt if we keep calling functions after having calling execute() once.

This fix store a "timeAtLastStart" variable that replaces the lambda-local "started" argument. This way, it is effectively updated everytime an evaluate / execute / callFunction is used, without having to redefine the engine interrupt handler everytime.

A more complete and possibly elegant implementation would be to keep track of which thread has called what and have different checks for each thread, so they can be treated independently. But this fix is way simpler and should be good for most cases. 