### PR TITLE
Fixed TextLayout::getStringBounds nullptr error for empty strings

### DIFF
--- a/modules/juce_graphics/fonts/juce_TextLayout.h
+++ b/modules/juce_graphics/fonts/juce_TextLayout.h
@@ -275,6 +275,11 @@ public:
     {
         TextLayout layout;
         layout.createLayout (string, std::numeric_limits<float>::max());
+
+        if (layout.getNumLines() == 0)
+        {
+            return Rectangle<float>{};
+        }
         return layout.getLine (0).getLineBounds();
     }
 


### PR DESCRIPTION
Calling TextLayout::getStringBounds() on an empty string will result in a null pointer error.