### PR TITLE
Fixed classes symbol export

### DIFF
--- a/modules/juce_audio_processors/processors/juce_AudioProcessorParameterGroup.h
+++ b/modules/juce_audio_processors/processors/juce_AudioProcessorParameterGroup.h
@@ -47,7 +47,7 @@ namespace juce
 
     @tags{Audio}
 */
-class AudioProcessorParameterGroup
+class JUCE_API AudioProcessorParameterGroup
 {
 public:
     //==============================================================================

--- a/modules/juce_core/xml/juce_XmlElement.h
+++ b/modules/juce_core/xml/juce_XmlElement.h
@@ -144,7 +144,7 @@ public:
     /** A struct containing options for formatting the text when representing an
         XML element as a string.
     */
-    struct TextFormat
+    struct JUCE_API TextFormat
     {
         /** Default constructor. */
         TextFormat();

--- a/modules/juce_dsp/processors/juce_Panner.h
+++ b/modules/juce_dsp/processors/juce_Panner.h
@@ -55,7 +55,7 @@ enum class PannerRule
     @tags{DSP}
 */
 template <typename SampleType>
-class Panner
+class JUCE_API Panner
 {
 public:
     //==============================================================================

--- a/modules/juce_gui_basics/windows/juce_ScopedMessageBox.h
+++ b/modules/juce_gui_basics/windows/juce_ScopedMessageBox.h
@@ -42,7 +42,7 @@ namespace juce
 
     @tags{GUI}
 */
-class ScopedMessageBox
+class JUCE_API ScopedMessageBox
 {
 public:
     /** @internal */


### PR DESCRIPTION
Some ARA Host classes do not add the JUCE_API macro, which makes it impossible to export these symbols when compiling JUCE into a dynamic link library, resulting in the generated dynamic link library being unable to be linked.
These are some symbols other than those fixed by the previous PR #1454 .