### PR TITLE
Update MidiMessageSequence::updateMatchedPairs to deal with note-on messages with velocity 0

### DIFF
--- a/modules/juce_audio_basics/midi/juce_MidiMessageSequence.cpp
+++ b/modules/juce_audio_basics/midi/juce_MidiMessageSequence.cpp
@@ -235,14 +235,14 @@ void MidiMessageSequence::sort() noexcept
                       [] (const MidiEventHolder* a, const MidiEventHolder* b) { return a->message.getTimeStamp() < b->message.getTimeStamp(); });
 }
 
-void MidiMessageSequence::updateMatchedPairs() noexcept
+void MidiMessageSequence::updateMatchedPairs(bool regardNoteOnEventsWithVel0AsNoteOff) noexcept
 {
     for (int i = 0; i < list.size(); ++i)
     {
         auto* meh = list.getUnchecked (i);
         auto& m1 = meh->message;
 
-        if (m1.isNoteOn())
+        if (m1.isNoteOn(!regardNoteOnEventsWithVel0AsNoteOff))
         {
             meh->noteOffObject = nullptr;
             auto note = m1.getNoteNumber();
@@ -256,13 +256,13 @@ void MidiMessageSequence::updateMatchedPairs() noexcept
 
                 if (m.getNoteNumber() == note && m.getChannel() == chan)
                 {
-                    if (m.isNoteOff())
+                    if (m.isNoteOff(regardNoteOnEventsWithVel0AsNoteOff))
                     {
                         meh->noteOffObject = meh2;
                         break;
                     }
 
-                    if (m.isNoteOn())
+                    if (m.isNoteOn(!regardNoteOnEventsWithVel0AsNoteOff))
                     {
                         auto newEvent = new MidiEventHolder (MidiMessage::noteOff (chan, note));
                         list.insert (j, newEvent);

--- a/modules/juce_audio_basics/midi/juce_MidiMessageSequence.h
+++ b/modules/juce_audio_basics/midi/juce_MidiMessageSequence.h
@@ -230,8 +230,11 @@ public:
         Call this after re-ordering messages or deleting/adding messages, and it
         will scan the list and make sure all the note-offs in the MidiEventHolder
         structures are pointing at the correct ones.
+
+        @param regardNoteOnEventWithVel0AsNoteOff   if true, note-on events with velocity 0
+                                                    will be regarded as note-off
     */
-    void updateMatchedPairs() noexcept;
+    void updateMatchedPairs(bool regardNoteOnEventsWithVel0AsNoteOff = true) noexcept;
 
     /** Forces a sort of the sequence.
         You may need to call this if you've manually modified the timestamps of some


### PR DESCRIPTION
In the current JUCE, both the `juce::MidiMessage::isNoteOn` and `juce::MidiMessage::isNoteOff` methods allow users to decide how to regard notes with velocity 0. Here, I have also added this option to the `juce::MidiMessageSequence::updateMatchedPairs` method.

When `regardNoteOnEventsWithVel0AsNoteOff` is set to `true` (the default), it will maintain the original behavior of regarding note-on events with velocity 0 as note-off events.
