### PR TITLE
Add disableInternalMouseEvents flag in Component

### DIFF
--- a/modules/juce_gui_basics/components/juce_Component.cpp
+++ b/modules/juce_gui_basics/components/juce_Component.cpp
@@ -1073,6 +1073,16 @@ void Component::getInterceptsMouseClicks (bool& allowsClicksOnThisComponent,
     allowsClicksOnChildComponents = flags.allowChildMouseClicksFlag;
 }
 
+void Component::setDisableInternalMouseEvents(bool disableInternalMouseEvents) noexcept
+{
+	flags.disableInternalMouseEventsFlag = disableInternalMouseEvents;
+}
+
+bool Component::getDisableInternalMouseEvents() const noexcept
+{
+    return flags.disableInternalMouseEventsFlag;
+}
+
 bool Component::contains (Point<int> point)
 {
     return contains (point.toFloat());
@@ -2107,7 +2117,7 @@ void Component::internalMouseEnter (MouseInputSource source, Point<float> relati
                                     false);
 
     HierarchyChecker checker (this, me);
-    mouseEnter (me);
+    if(!flags.disableInternalMouseEventsFlag) mouseEnter (me);
 
     flags.cachedMouseInsideComponent = true;
 
@@ -2144,7 +2154,7 @@ void Component::internalMouseExit (MouseInputSource source, Point<float> relativ
                                     false);
 
     HierarchyChecker checker (this, me);
-    mouseExit (me);
+    if (!flags.disableInternalMouseEventsFlag) mouseExit (me);
 
     if (checker.shouldBailOut())
         return;
@@ -2211,7 +2221,7 @@ void Component::internalMouseDown (MouseInputSource source,
     if (flags.repaintOnMouseActivityFlag)
         repaint();
 
-    mouseDown (me);
+    if (!flags.disableInternalMouseEventsFlag) mouseDown (me);
 
     if (checker.shouldBailOut())
         return;
@@ -2250,7 +2260,7 @@ void Component::internalMouseUp (MouseInputSource source,
     if (flags.repaintOnMouseActivityFlag)
         repaint();
 
-    mouseUp (me);
+    if (!flags.disableInternalMouseEventsFlag) mouseUp (me);
 
     if (checker.shouldBailOut())
         return;
@@ -2267,7 +2277,7 @@ void Component::internalMouseUp (MouseInputSource source,
     if (me.getNumberOfClicks() >= 2)
     {
         if (checker.nearestNonNullParent() == this)
-            mouseDoubleClick (checker.eventWithNearestParent());
+            if (!flags.disableInternalMouseEventsFlag) mouseDoubleClick (checker.eventWithNearestParent());
 
         if (checker.shouldBailOut())
             return;
@@ -2294,7 +2304,7 @@ void Component::internalMouseDrag (MouseInputSource source, const detail::Pointe
 
         HierarchyChecker checker (this, me);
 
-        mouseDrag (me);
+        if (!flags.disableInternalMouseEventsFlag) mouseDrag (me);
 
         if (checker.shouldBailOut())
             return;
@@ -2328,7 +2338,7 @@ void Component::internalMouseMove (MouseInputSource source, Point<float> relativ
 
         HierarchyChecker checker (this, me);
 
-        mouseMove (me);
+        if (!flags.disableInternalMouseEventsFlag) mouseMove (me);
 
         if (checker.shouldBailOut())
             return;

--- a/modules/juce_gui_basics/components/juce_Component.h
+++ b/modules/juce_gui_basics/components/juce_Component.h
@@ -987,6 +987,22 @@ public:
                                    bool& allowsClicksOnChildComponents) const noexcept;
 
 
+    /** 
+    *  Disables internal mouse events for this component.
+
+        This method allows you to disable the internal event callback of mouse events for the component.
+        When disabled, the component will only call events from its listeners.
+
+        @see getDisableInternalMouseEvents
+    */
+    void setDisableInternalMouseEvents(bool disableInternalMouseEvents) noexcept;
+
+    /** Retrieves the current state of the disable internal mouse events flags.
+
+         @see setDisableInternalMouseEvents
+    */
+    bool getDisableInternalMouseEvents() const noexcept;
+
     /** Returns true if a given point lies within this component or one of its children.
 
         Never override this method! Use hitTest to create custom hit regions.
@@ -2660,6 +2676,7 @@ private:
         bool opaqueFlag                   : 1;
         bool ignoresMouseClicksFlag       : 1;
         bool allowChildMouseClicksFlag    : 1;
+		bool disableInternalMouseEventsFlag : 1;
         bool wantsKeyboardFocusFlag       : 1;
         bool isFocusContainerFlag         : 1;
         bool isKeyboardFocusContainerFlag : 1;


### PR DESCRIPTION
Discussion on the forum about this here :
https://forum.juce.com/t/duplicate-events-when-using-addmouselistener-this/64201/10

This adds support for a component to listen for mouse event with proper propagation and "originalComponent" assignation to both itself and its children recursively,  without duplicating the events when they are coming from the component itself.

usage : 
this->addMouseListener(this, true); //add recursive listening to all nested children and to this component
setDisableInternalMouseEvents(true); //avoids the component to also dispatch an event, because it will be sent anyway with the mouseListener