### PR TITLE
Code analysis issues

### DIFF
--- a/modules/juce_audio_plugin_client/juce_audio_plugin_client_Unity.cpp
+++ b/modules/juce_audio_plugin_client/juce_audio_plugin_client_Unity.cpp
@@ -273,7 +273,6 @@ private:
     //==============================================================================
     void setMinimised (bool) override                                 {}
     bool isMinimised() const override                                 { return false; }
-    bool isShowing() const override                                   { return true; }
     void setFullScreen (bool) override                                {}
     bool isFullScreen() const override                                { return false; }
     bool setAlwaysOnTop (bool) override                               { return false; }

--- a/modules/juce_audio_utils/gui/juce_MidiKeyboardComponent.cpp
+++ b/modules/juce_audio_utils/gui/juce_MidiKeyboardComponent.cpp
@@ -158,7 +158,9 @@ void MidiKeyboardComponent::updateNoteUnderMouse (Point<float> pos, bool isDown,
     const auto newNote = noteInfo.note;
     const auto oldNote = mouseOverNotes.getUnchecked (fingerNum);
     const auto oldNoteDown = mouseDownNotes.getUnchecked (fingerNum);
-    const auto eventVelocity = useMousePositionForVelocity ? noteInfo.velocity * velocity : velocity;
+    // SURGE PATCH: Don't double scale velocity
+    const auto eventVelocity = useMousePositionForVelocity ? noteInfo.velocity /* * velocity */ : velocity;
+    // END SURGE PATCH
 
     if (oldNote != newNote)
     {

--- a/modules/juce_core/javascript/choc/containers/choc_Value.h
+++ b/modules/juce_core/javascript/choc/containers/choc_Value.h
@@ -2838,7 +2838,7 @@ inline void Value::changeMember (uint32_t index, const Type& newType, void* newD
 
         for (uint32_t i = 0; i < numElements; ++i)
         {
-            auto member = value.type.getObjectMember (i);
+            const auto &member = value.type.getObjectMember (i);
             newCopy.addMember (member.name, i == index ? ValueView (newType, newData, newDictionary) : value[i]);
         }
 

--- a/modules/juce_core/javascript/choc/javascript/choc_javascript_QuickJS.h
+++ b/modules/juce_core/javascript/choc/javascript/choc_javascript_QuickJS.h
@@ -6023,8 +6023,8 @@ static int compute_stack_size(const uint8_t *bc_buf, int bc_buf_len)
     pos = 0;
     while (pos < bc_buf_len) {
         opcode = bc_buf[pos];
-        len = reopcode_info[opcode].size;
         assert(opcode < REOP_COUNT);
+        len = reopcode_info[opcode].size;
         assert((pos + len) <= bc_buf_len);
         switch(opcode) {
         case REOP_push_i32:

--- a/modules/juce_core/juce_core.cpp
+++ b/modules/juce_core/juce_core.cpp
@@ -79,6 +79,7 @@
  #endif
 
  #if JUCE_WASM
+  #include <emscripten.h>
   #include <stdio.h>
   #include <sys/types.h>
   #include <sys/socket.h>

--- a/modules/juce_core/juce_core.cpp
+++ b/modules/juce_core/juce_core.cpp
@@ -109,7 +109,7 @@
  #include <net/if.h>
  #include <sys/ioctl.h>
 
- #if ! (JUCE_ANDROID || JUCE_WASM)
+ #if ! (JUCE_ANDROID || JUCE_WASM || JUCE_MUSL)
   #include <execinfo.h>
  #endif
 #endif

--- a/modules/juce_core/native/juce_SharedCode_posix.h
+++ b/modules/juce_core/native/juce_SharedCode_posix.h
@@ -178,7 +178,7 @@ inline int juce_siginterrupt ([[maybe_unused]] int sig, [[maybe_unused]] int fla
 //==============================================================================
 namespace
 {
-   #if JUCE_LINUX || (JUCE_IOS && (! TARGET_OS_MACCATALYST) && (! __DARWIN_ONLY_64_BIT_INO_T)) // (this iOS stuff is to avoid a simulator bug)
+   #if JUCE_GLIBC || (JUCE_IOS && (! TARGET_OS_MACCATALYST) && (! __DARWIN_ONLY_64_BIT_INO_T)) // (this iOS stuff is to avoid a simulator bug)
     using juce_statStruct = struct stat64;
     #define JUCE_STAT  stat64
    #else

--- a/modules/juce_core/native/juce_SystemStats_linux.cpp
+++ b/modules/juce_core/native/juce_SystemStats_linux.cpp
@@ -210,22 +210,22 @@ String SystemStats::getComputerName()
 
 String SystemStats::getUserLanguage()
 {
-   #if JUCE_BSD
+   #if JUCE_GLIBC
+    return getLocaleValue (_NL_ADDRESS_LANG_AB);
+   #else
     if (auto langEnv = getenv ("LANG"))
         return String::fromUTF8 (langEnv).upToLastOccurrenceOf (".UTF-8", false, true);
 
     return {};
-   #else
-    return getLocaleValue (_NL_ADDRESS_LANG_AB);
    #endif
 }
 
 String SystemStats::getUserRegion()
 {
-   #if JUCE_BSD
-    return {};
-   #else
+   #if JUCE_GLIBC
     return getLocaleValue (_NL_ADDRESS_COUNTRY_AB2);
+   #else
+    return {};
    #endif
 }
 

--- a/modules/juce_core/system/juce_SystemStats.cpp
+++ b/modules/juce_core/system/juce_SystemStats.cpp
@@ -190,7 +190,7 @@ String SystemStats::getStackBacktrace()
 {
     String result;
 
-   #if JUCE_ANDROID || JUCE_WASM
+   #if JUCE_ANDROID || JUCE_MINGW || JUCE_WASM || JUCE_MUSL
     jassertfalse; // sorry, not implemented yet!
 
    #elif JUCE_WINDOWS

--- a/modules/juce_core/system/juce_TargetPlatform.h
+++ b/modules/juce_core/system/juce_TargetPlatform.h
@@ -45,6 +45,7 @@
     - Either JUCE_LITTLE_ENDIAN or JUCE_BIG_ENDIAN.
     - Either JUCE_INTEL or JUCE_ARM
     - Either JUCE_GCC or JUCE_CLANG or JUCE_MSVC
+    - Either JUCE_GLIBC or JUCE_MUSL will be defined on Linux depending on the system's libc implementation.
 */
 
 //==============================================================================
@@ -195,6 +196,14 @@
     #define JUCE_ARM 1
   #elif __MMX__ || __SSE__ || __amd64__
     #define JUCE_INTEL 1
+  #endif
+
+  #if JUCE_LINUX
+    #ifdef __GLIBC__
+      #define JUCE_GLIBC 1
+    #else
+      #define JUCE_MUSL 1
+    #endif
   #endif
 #endif
 

--- a/modules/juce_core/system/juce_TargetPlatform.h
+++ b/modules/juce_core/system/juce_TargetPlatform.h
@@ -76,6 +76,8 @@
   #define       JUCE_ANDROID 1
 #elif defined (__FreeBSD__) || defined (__OpenBSD__)
   #define       JUCE_BSD 1
+#elif defined (__wasm__)
+  #define       JUCE_WASM 1
 #elif defined (LINUX) || defined (__linux__)
   #define       JUCE_LINUX 1
 #elif defined (__APPLE_CPP__) || defined (__APPLE_CC__)
@@ -89,8 +91,6 @@
   #else
     #define     JUCE_MAC 1
   #endif
-#elif defined (__wasm__)
-  #define       JUCE_WASM 1
 #else
   #error "Unknown platform!"
 #endif

--- a/modules/juce_dsp/juce_dsp.cpp
+++ b/modules/juce_dsp/juce_dsp.cpp
@@ -88,7 +88,9 @@
 #include "widgets/juce_Chorus.cpp"
 
 #if JUCE_USE_SIMD
- #if JUCE_INTEL
+ #if JUCE_INTEL || defined(__riscv) || defined(__EMSCRIPTEN__)
+ // falkTX patch to 6.* was this so ... add those ORs above
+ // #if defined(__i386__) || defined(__amd64__) || defined(_M_X64) || defined(_X86_) || defined(_M_IX86) || defined(__riscv) || defined(__EMSCRIPTEN__)
   #ifdef __AVX2__
    #include "native/juce_SIMDNativeOps_avx.cpp"
   #else

--- a/modules/juce_dsp/juce_dsp.h
+++ b/modules/juce_dsp/juce_dsp.h
@@ -67,7 +67,7 @@
 #include <juce_audio_basics/juce_audio_basics.h>
 #include <juce_audio_formats/juce_audio_formats.h>
 
-#if defined (_M_X64) || defined (__amd64__) || defined (__SSE2__) || (defined (_M_IX86_FP) && _M_IX86_FP == 2)
+#if defined(_M_X64) || defined(__amd64__) || defined(__SSE2__) || (defined(_M_IX86_FP) && _M_IX86_FP == 2) || defined(__riscv) || defined(__EMSCRIPTEN__)
 
  #if defined (_M_X64) || defined (__amd64__)
   #ifndef __SSE2__
@@ -234,7 +234,7 @@ namespace util
  #include "native/juce_SIMDNativeOps_fallback.h"
 
  // include the correct native file for this build target CPU
- #if defined (__i386__) || defined (__amd64__) || defined (_M_X64) || defined (_X86_) || defined (_M_IX86)
+ #if defined(__i386__) || defined(__amd64__) || defined(_M_X64) || defined(_X86_) || defined(_M_IX86) || defined(__riscv) || defined(__EMSCRIPTEN__)
   #ifdef __AVX2__
    #include "native/juce_SIMDNativeOps_avx.h"
   #else

--- a/modules/juce_graphics/fonts/harfbuzz/hb-directwrite.cc
+++ b/modules/juce_graphics/fonts/harfbuzz/hb-directwrite.cc
@@ -168,8 +168,11 @@ _hb_directwrite_shaper_face_data_create (hb_face_t *face)
   } HB_STMT_END
 
   data->dwrite_dll = LoadLibrary (TEXT ("DWRITE"));
-  if (unlikely (!data->dwrite_dll))
-    FAIL ("Cannot find DWrite.DLL");
+  if ( unlikely( !data->dwrite_dll ) )
+  {
+    delete data;
+    FAIL("Cannot find DWrite.DLL");
+  }
 
   t_DWriteCreateFactory p_DWriteCreateFactory;
 

--- a/modules/juce_gui_basics/components/juce_Component.cpp
+++ b/modules/juce_gui_basics/components/juce_Component.cpp
@@ -343,7 +343,7 @@ bool Component::isShowing() const
         return parentComponent->isShowing();
 
     if (auto* peer = getPeer())
-        return peer->isShowing();
+        return ! peer->isMinimised();
 
     return false;
 }

--- a/modules/juce_gui_basics/menus/juce_PopupMenu.cpp
+++ b/modules/juce_gui_basics/menus/juce_PopupMenu.cpp
@@ -686,6 +686,12 @@ struct MenuWindow final : public Component
         {
             dismissMenu (nullptr);
         }
+        // surge patch to work around reaper issue described in #7281
+        else if (key.isKeyCode(KeyPress::F10Key) && key.getModifiers().isShiftDown())
+        {
+            dismissMenu (nullptr);
+        }
+        // end surge patch
         else
         {
             return false;

--- a/modules/juce_gui_basics/native/accessibility/juce_UIAHelpers_windows.h
+++ b/modules/juce_gui_basics/native/accessibility/juce_UIAHelpers_windows.h
@@ -87,7 +87,7 @@ inline JUCE_COMRESULT addHandlersToArray (const std::vector<const AccessibilityH
 
     *pRetVal = SafeArrayCreateVector (VT_UNKNOWN, 0, (ULONG) numHandlers);
 
-    if (pRetVal != nullptr)
+    if (*pRetVal != nullptr)
     {
         for (LONG i = 0; i < (LONG) numHandlers; ++i)
         {

--- a/modules/juce_gui_basics/native/accessibility/juce_UIATextProvider_windows.h
+++ b/modules/juce_gui_basics/native/accessibility/juce_UIATextProvider_windows.h
@@ -82,9 +82,11 @@ public:
     {
         return withTextInterface (pRetVal, [&] (const AccessibilityTextInterface& textInterface)
         {
+            HRESULT hr;
+
             *pRetVal = SafeArrayCreateVector (VT_UNKNOWN, 0, 1);
 
-            if (pRetVal != nullptr)
+            if (*pRetVal != nullptr)
             {
                 auto selection = textInterface.getSelection();
                 auto hasSelection = ! selection.isEmpty();
@@ -95,15 +97,16 @@ public:
                                                                   hasSelection ? selection.getEnd()   : cursorPos });
 
                 LONG pos = 0;
-                auto hr = SafeArrayPutElement (*pRetVal, &pos, static_cast<IUnknown*> (rangeProvider));
-
-                if (FAILED (hr))
-                    return E_FAIL;
+                hr = SafeArrayPutElement (*pRetVal, &pos, static_cast<IUnknown*> (rangeProvider));
 
                 rangeProvider->Release();
             }
+            else
+            {
+                hr = E_FAIL;
+            }
 
-            return S_OK;
+            return hr;
         });
     }
 
@@ -111,22 +114,25 @@ public:
     {
         return withTextInterface (pRetVal, [&] (const AccessibilityTextInterface& textInterface)
         {
-            *pRetVal = SafeArrayCreateVector (VT_UNKNOWN, 0, 1);
+            HRESULT hr;
 
-            if (pRetVal != nullptr)
+            *pRetVal = SafeArrayCreateVector(VT_UNKNOWN, 0, 1);
+
+            if (*pRetVal != nullptr)
             {
                 auto* rangeProvider = new UIATextRangeProvider (*this, { 0, textInterface.getTotalNumCharacters() });
 
                 LONG pos = 0;
-                auto hr = SafeArrayPutElement (*pRetVal, &pos, static_cast<IUnknown*> (rangeProvider));
-
-                if (FAILED (hr))
-                    return E_FAIL;
+                hr = SafeArrayPutElement (*pRetVal, &pos, static_cast<IUnknown*> (rangeProvider));
 
                 rangeProvider->Release();
             }
+            else
+            {
+                hr = E_FAIL;
+            }
 
-            return S_OK;
+            return hr;
         });
     }
 

--- a/modules/juce_gui_basics/native/juce_FileChooser_windows.cpp
+++ b/modules/juce_gui_basics/native/juce_FileChooser_windows.cpp
@@ -451,25 +451,28 @@ private:
 
             LPITEMIDLIST list = SHBrowseForFolder (&bi);
 
-            if (! SHGetPathFromIDListW (list, files))
+            if ( list != nullptr )
             {
-                files[0] = 0;
-                returnedString.clear();
-            }
+                if (!SHGetPathFromIDListW(list, files))
+                {
+                    files[0] = 0;
+                    returnedString.clear();
+                }
 
-            LPMALLOC al;
+                LPMALLOC al;
 
-            if (list != nullptr && SUCCEEDED (SHGetMalloc (&al)))
-                al->Free (list);
+                if (SUCCEEDED(SHGetMalloc(&al)))
+                    al->Free(list);
 
-            if (files[0] != 0)
-            {
-                File result (String (files.get()));
+                if (files[0] != 0)
+                {
+                    File result(String(files.get()));
 
-                if (returnedString.isNotEmpty())
-                    result = result.getSiblingFile (returnedString);
+                    if (returnedString.isNotEmpty())
+                        result = result.getSiblingFile(returnedString);
 
-                selections.add (URL (result));
+                    selections.add(URL(result));
+                }
             }
         }
         else

--- a/modules/juce_gui_basics/native/juce_NSViewComponentPeer_mac.mm
+++ b/modules/juce_gui_basics/native/juce_NSViewComponentPeer_mac.mm
@@ -465,11 +465,6 @@ public:
         return [window isMiniaturized];
     }
 
-    bool isShowing() const override
-    {
-        return [window isVisible] && ! isMinimised();
-    }
-
     NSWindowCollectionBehavior getCollectionBehavior (bool forceFullScreen) const
     {
         if (forceFullScreen)

--- a/modules/juce_gui_basics/native/juce_UIViewComponentPeer_ios.mm
+++ b/modules/juce_gui_basics/native/juce_UIViewComponentPeer_ios.mm
@@ -408,7 +408,6 @@ public:
     void setAlpha (float newAlpha) override;
     void setMinimised (bool) override                         {}
     bool isMinimised() const override                         { return false; }
-    bool isShowing() const override                           { return true; }
     void setFullScreen (bool shouldBeFullScreen) override;
     bool isFullScreen() const override                        { return fullScreen; }
     bool contains (Point<int> localPos, bool trueIfInAChildWindow) const override;

--- a/modules/juce_gui_basics/native/juce_Windowing_android.cpp
+++ b/modules/juce_gui_basics/native/juce_Windowing_android.cpp
@@ -1462,11 +1462,6 @@ public:
         return false;
     }
 
-    bool isShowing() const override
-    {
-        return true;
-    }
-
     void setFullScreen (bool shouldBeFullScreen) override
     {
         if (shouldNavBarsBeHidden (shouldBeFullScreen))

--- a/modules/juce_gui_basics/native/juce_Windowing_linux.cpp
+++ b/modules/juce_gui_basics/native/juce_Windowing_linux.cpp
@@ -204,11 +204,6 @@ public:
         return XWindowSystem::getInstance()->isMinimised (windowH);
     }
 
-    bool isShowing() const override
-    {
-        return XWindowSystem::getInstance()->isMinimised (windowH);
-    }
-
     void setFullScreen (bool shouldBeFullScreen) override
     {
         auto r = lastNonFullscreenBounds; // (get a copy of this before de-minimising)

--- a/modules/juce_gui_basics/native/juce_Windowing_windows.cpp
+++ b/modules/juce_gui_basics/native/juce_Windowing_windows.cpp
@@ -1720,11 +1720,6 @@ public:
         return wp.showCmd == SW_SHOWMINIMIZED;
     }
 
-    bool isShowing() const override
-    {
-        return IsWindowVisible (hwnd) && ! isMinimised();
-    }
-
     void setFullScreen (bool shouldBeFullScreen) override
     {
         const ScopedValueSetter<bool> scope (shouldIgnoreModalDismiss, true);

--- a/modules/juce_gui_basics/native/juce_Windowing_windows.cpp
+++ b/modules/juce_gui_basics/native/juce_Windowing_windows.cpp
@@ -1788,8 +1788,9 @@ public:
 
         const auto screenPos = convertLogicalScreenPointToPhysical (localPos + getScreenPosition(), hwnd);
 
-        if (trueIfInAChildWindow)
-            return getClientRectInScreen().contains (screenPos);
+        // Surge diff while waiting for 803 revert
+        // if (trueIfInAChildWindow)
+        //    return getClientRectInScreen().contains (screenPos);
 
         auto w = WindowFromPoint (D2DUtilities::toPOINT (screenPos));
 

--- a/modules/juce_gui_basics/windows/juce_ComponentPeer.h
+++ b/modules/juce_gui_basics/windows/juce_ComponentPeer.h
@@ -244,9 +244,6 @@ public:
     /** True if the window is currently minimised. */
     virtual bool isMinimised() const = 0;
 
-    /** True if the window is being displayed on-screen. */
-    virtual bool isShowing() const = 0;
-
     /** Enable/disable fullscreen mode for the window. */
     virtual void setFullScreen (bool shouldBeFullScreen) = 0;
 

--- a/modules/juce_gui_extra/code_editor/juce_LuaCodeTokeniser.cpp
+++ b/modules/juce_gui_extra/code_editor/juce_LuaCodeTokeniser.cpp
@@ -190,6 +190,10 @@ struct LuaTokeniserFunctions
 
         case '?':
         case '~':
+        // SURGE ADDITION
+        case '#':
+        case '/':
+        // END SURGE ADDITION
             source.skip();
             return LuaTokeniser::tokenType_operator;
 


### PR DESCRIPTION
assert opcode before it's used.
Don't fail to delete memory even though it's unlikely to occur.
Handle situation when SHBrowseForFolder is cancelled (returns null).
Several places appear to be checking the wrong thing after calling SafeArrayCreateVector.