### PR TITLE
Fix UB in VST plugins due to function prototype mismatch

### DIFF
--- a/modules/juce_audio_plugin_client/juce_audio_plugin_client_VST2.cpp
+++ b/modules/juce_audio_plugin_client/juce_audio_plugin_client_VST2.cpp
@@ -274,10 +274,10 @@ public:
 
         memset (&vstEffect, 0, sizeof (vstEffect));
         vstEffect.magic = 0x56737450 /* 'VstP' */;
-        vstEffect.dispatcher = (Vst2::AEffectDispatcherProc) dispatcherCB;
+        vstEffect.dispatcher = dispatcherCB;
         vstEffect.process = nullptr;
-        vstEffect.setParameter = (Vst2::AEffectSetParameterProc) setParameterCB;
-        vstEffect.getParameter = (Vst2::AEffectGetParameterProc) getParameterCB;
+        vstEffect.setParameter = setParameterCB;
+        vstEffect.getParameter = getParameterCB;
         vstEffect.numPrograms = jmax (1, processor->getNumPrograms());
         vstEffect.numParams = juceParameters.getNumParameters();
         vstEffect.numInputs = maxNumInChannels;
@@ -292,8 +292,8 @@ public:
         vstEffect.version = JucePlugin_VersionCode;
        #endif
 
-        vstEffect.processReplacing = (Vst2::AEffectProcessProc) processReplacingCB;
-        vstEffect.processDoubleReplacing = (Vst2::AEffectProcessDoubleProc) processDoubleReplacingCB;
+        vstEffect.processReplacing = processReplacingCB;
+        vstEffect.processDoubleReplacing = processDoubleReplacingCB;
 
         vstEffect.flags |= Vst2::effFlagsHasEditor;
 
@@ -505,7 +505,7 @@ public:
         internalProcessReplacing (inputs, outputs, sampleFrames, floatTempBuffers);
     }
 
-    static void processReplacingCB (Vst2::AEffect* vstInterface, float** inputs, float** outputs, int32 sampleFrames)
+    static void processReplacingCB (Vst2::AEffect* vstInterface, float** inputs, float** outputs, Vst2::VstInt32 sampleFrames)
     {
         getWrapper (vstInterface)->processReplacing (inputs, outputs, sampleFrames);
     }
@@ -516,7 +516,7 @@ public:
         internalProcessReplacing (inputs, outputs, sampleFrames, doubleTempBuffers);
     }
 
-    static void processDoubleReplacingCB (Vst2::AEffect* vstInterface, double** inputs, double** outputs, int32 sampleFrames)
+    static void processDoubleReplacingCB (Vst2::AEffect* vstInterface, double** inputs, double** outputs, Vst2::VstInt32 sampleFrames)
     {
         getWrapper (vstInterface)->processDoubleReplacing (inputs, outputs, sampleFrames);
     }
@@ -678,7 +678,7 @@ public:
         return 0.0f;
     }
 
-    static float getParameterCB (Vst2::AEffect* vstInterface, int32 index)
+    static float getParameterCB (Vst2::AEffect* vstInterface, Vst2::VstInt32 index)
     {
         return getWrapper (vstInterface)->getParameter (index);
     }
@@ -689,7 +689,7 @@ public:
             setValueAndNotifyIfChanged (*param, value);
     }
 
-    static void setParameterCB (Vst2::AEffect* vstInterface, int32 index, float value)
+    static void setParameterCB (Vst2::AEffect* vstInterface, Vst2::VstInt32 index, float value)
     {
         getWrapper (vstInterface)->setParameter (index, value);
     }
@@ -902,8 +902,8 @@ public:
         }
     }
 
-    static pointer_sized_int dispatcherCB (Vst2::AEffect* vstInterface, int32 opCode, int32 index,
-                                           pointer_sized_int value, void* ptr, float opt)
+    static Vst2::VstIntPtr dispatcherCB (Vst2::AEffect* vstInterface, Vst2::VstInt32 opCode, Vst2::VstInt32 index,
+                                           Vst2::VstIntPtr value, void* ptr, float opt)
     {
         auto* wrapper = getWrapper (vstInterface);
         VstOpCodeArguments args = { index, value, ptr, opt };

--- a/modules/juce_audio_processors/format_types/juce_VSTPluginFormat.cpp
+++ b/modules/juce_audio_processors/format_types/juce_VSTPluginFormat.cpp
@@ -223,7 +223,7 @@ namespace
 
 //==============================================================================
 typedef Vst2::AEffect* (VSTCALLBACK *MainCall) (Vst2::audioMasterCallback);
-static pointer_sized_int VSTCALLBACK audioMaster (Vst2::AEffect*, int32, int32, pointer_sized_int, void*, float);
+static Vst2::VstIntPtr VSTCALLBACK audioMaster (Vst2::AEffect*, Vst2::VstInt32, Vst2::VstInt32, Vst2::VstIntPtr, void*, float);
 
 //==============================================================================
 // Change this to disable logging of various VST activities
@@ -3458,7 +3458,7 @@ bool VSTPluginInstance::updateSizeFromEditor ([[maybe_unused]] int w, [[maybe_un
 
 //==============================================================================
 // entry point for all callbacks from the plugin
-static pointer_sized_int VSTCALLBACK audioMaster (Vst2::AEffect* effect, int32 opcode, int32 index, pointer_sized_int value, void* ptr, float opt)
+static Vst2::VstIntPtr VSTCALLBACK audioMaster (Vst2::AEffect* effect, Vst2::VstInt32 opcode, Vst2::VstInt32 index, Vst2::VstIntPtr value, void* ptr, float opt)
 {
     if (effect != nullptr)
         if (auto* instance = (VSTPluginInstance*) (effect->resvd2))


### PR DESCRIPTION
This fixes undefined behaviour being triggered by the fact that the function signatures used for functions in VST plugins do not match those defined in the VST SDK.

Now that that's fixed some function pointer casts could also be removed (since the function types now actually match), so I've done that as well.