### PR TITLE
CMake: fix missing exported modules

### DIFF
--- a/extras/Build/CMake/JUCEConfig.cmake.in
+++ b/extras/Build/CMake/JUCEConfig.cmake.in
@@ -39,6 +39,7 @@ include("@PACKAGE_UTILS_INSTALL_DIR@/JUCEUtils.cmake")
 
 set(_juce_modules
     juce_analytics
+    juce_animation
     juce_audio_basics
     juce_audio_devices
     juce_audio_formats
@@ -55,6 +56,7 @@ set(_juce_modules
     juce_gui_basics
     juce_gui_extra
     juce_javascript
+    juce_midi_ci
     juce_opengl
     juce_osc
     juce_product_unlocking


### PR DESCRIPTION
It looks like some of the modules were missing from a generated list used by CMake.

I'm using the compiled and installed JUCE libraries using CMake and when I tried to add an animation exactly like the one in examples/GUI/AnimatorsDemo.h I realized that CMake can't find the target "juce::juce_animation" to link to. The reason behind is that "juce_animation" is missing from the installed JUCE/install/lib/cmake/<JUCE version>/JUCEConfig.cmake file's _juce_modules list. The module "juce_midi_ci" was also missing. This file is generated from the JUCEConfig.cmake.in input file, that's why I modified this file.
After the (proposed) modification I was able to install and then link against juce::juce_animation.