### PR TITLE
FR: Added helper function MidiOutput::hasPendingMessages()

### DIFF
--- a/modules/juce_audio_devices/midi_io/juce_MidiDevices.cpp
+++ b/modules/juce_audio_devices/midi_io/juce_MidiDevices.cpp
@@ -98,6 +98,11 @@ void MidiOutput::sendBlockOfMessages (const MidiBuffer& buffer,
     notify();
 }
 
+bool MidiOutput::hasPendingMessages() const
+{
+    return firstMessage != nullptr;
+}
+
 void MidiOutput::clearAllPendingMessages()
 {
     const ScopedLock sl (lock);

--- a/modules/juce_audio_devices/midi_io/juce_MidiDevices.h
+++ b/modules/juce_audio_devices/midi_io/juce_MidiDevices.h
@@ -420,6 +420,9 @@ public:
     void sendBlockOfMessages (const MidiBuffer& buffer,
                               double millisecondCounterToStartAt,
                               double samplesPerSecondForBuffer);
+    
+    /** Returns true if there are pending midi messages */
+    bool hasPendingMessages() const;
 
     /** Gets rid of any midi messages that had been added by sendBlockOfMessages(). */
     void clearAllPendingMessages();


### PR DESCRIPTION
Added a small helper function which returns true if there are MIDI messages waiting to be sent. This is useful for batch send jobs where one is waiting for a queue of messages to be sent, e.g. sysex librarians.