### PR TITLE
Fixed input method candidate box on Windows

### DIFF
--- a/modules/juce_gui_basics/native/juce_Windowing_windows.cpp
+++ b/modules/juce_gui_basics/native/juce_Windowing_windows.cpp
@@ -4298,8 +4298,14 @@ private:
 
             case WM_IME_SETCONTEXT:
                 imeHandler.handleSetContext (h, wParam == TRUE);
+
                 lParam &= ~(LPARAM) ISC_SHOWUICOMPOSITIONWINDOW;
-                return ImmIsUIMessage (h, message, wParam, lParam);
+                // On Windows 11, directly returning from this function
+                // will cause the input method candidate box to not display correctly.
+                // The window's default message handler should be used
+                // to continue processing this message.
+                // Older version of the code is this: return ImmIsUIMessage (h, message, wParam, lParam);
+                break;
 
             case WM_IME_STARTCOMPOSITION:  imeHandler.handleStartComposition (*this); return 0;
             case WM_IME_ENDCOMPOSITION:    imeHandler.handleEndComposition (*this, h); return 0;


### PR DESCRIPTION
In standalone applications on the Windows platform, there is an issue (https://github.com/juce-framework/JUCE/issues/1318 and https://github.com/juce-framework/JUCE/issues/1482) where the input method candidate box either fails to display (on Windows 11) or displays at the incorrect position (on Windows 10).  
## Before I fix it:  
![be4d34b8e2063ab9256d275722584661](https://github.com/user-attachments/assets/5a8904f1-0c2b-470b-8b40-fcbc61460981)
![88f6eef9dc3ef265bfb772aa489cc382](https://github.com/user-attachments/assets/b25259fa-ac7f-4221-9f9d-74bb11e68f00)
## After fix:  
![2590fee222641e5e43af38da24bb63aa](https://github.com/user-attachments/assets/3b301b96-df62-4459-bd3d-60d3e65a996b)
![808f4618ae87867d57eaf1f8f42dc7c5](https://github.com/user-attachments/assets/70f47c89-19d1-4076-9bce-ca21a127a30e)
