### PR TITLE
Enable Jack Audio on macOS and Windows

### DIFF
--- a/modules/juce_audio_devices/audio_io/juce_AudioIODeviceType.cpp
+++ b/modules/juce_audio_devices/audio_io/juce_AudioIODeviceType.cpp
@@ -100,7 +100,7 @@ void AudioIODeviceType::callDeviceChangeListeners()
  AudioIODeviceType* AudioIODeviceType::createAudioIODeviceType_ALSA()         { return nullptr; }
 #endif
 
-#if (JUCE_LINUX || JUCE_BSD) && JUCE_JACK
+#if (JUCE_LINUX || JUCE_BSD || JUCE_MAC || JUCE_WINDOWS) && JUCE_JACK
  AudioIODeviceType* AudioIODeviceType::createAudioIODeviceType_JACK()         { return new JackAudioIODeviceType(); }
 #else
  AudioIODeviceType* AudioIODeviceType::createAudioIODeviceType_JACK()         { return nullptr; }

--- a/modules/juce_audio_devices/juce_audio_devices.cpp
+++ b/modules/juce_audio_devices/juce_audio_devices.cpp
@@ -176,19 +176,6 @@
   #include "native/juce_ALSA_linux.cpp"
  #endif
 
- #if JUCE_JACK
-  /* Got an include error here? If so, you've either not got jack-audio-connection-kit
-     installed, or you've not got your paths set up correctly to find its header files.
-
-     The package you need to install to get JACK support is "libjack-dev".
-
-     If you don't have the jack-audio-connection-kit library and don't want to build
-     JUCE with low latency audio support, just set the JUCE_JACK flag to 0.
-  */
-  #include <jack/jack.h>
-  #include "native/juce_JackAudio_linux.cpp"
- #endif
-
  #if (JUCE_LINUX && JUCE_BELA)
   /* Got an include error here? If so, you've either not got the bela headers
      installed, or you've not got your paths set up correctly to find its header
@@ -256,6 +243,20 @@ namespace juce
   }
  #endif
 
+#endif
+
+//==============================================================================
+#if (JUCE_LINUX || JUCE_BSD || JUCE_MAC || JUCE_WINDOWS) && JUCE_JACK
+  /* Got an include error here? If so, you've either not got jack-audio-connection-kit
+     installed, or you've not got your paths set up correctly to find its header files.
+
+     The package you need to install to get JACK support is "libjack-dev".
+
+     If you don't have the jack-audio-connection-kit library and don't want to build
+     JUCE with low latency audio support, just set the JUCE_JACK flag to 0.
+  */
+  #include <jack/jack.h>
+  #include "native/juce_JackAudio.cpp"
 #endif
 
 #include "midi_io/juce_MidiDevices.cpp"

--- a/modules/juce_audio_devices/juce_audio_devices.h
+++ b/modules/juce_audio_devices/juce_audio_devices.h
@@ -121,7 +121,7 @@
 #endif
 
 /** Config: JUCE_JACK
-    Enables JACK audio devices (Linux only).
+    Enables JACK audio devices.
 */
 #ifndef JUCE_JACK
  #define JUCE_JACK 0

--- a/modules/juce_audio_devices/native/juce_JackAudio.cpp
+++ b/modules/juce_audio_devices/native/juce_JackAudio.cpp
@@ -42,7 +42,11 @@ static void* juce_loadJackFunction (const char* const name)
     if (juce_libjackHandle == nullptr)
         return nullptr;
 
+#if JUCE_WINDOWS
+    return GetProcAddress ((HMODULE) juce_libjackHandle, name);
+#else
     return dlsym (juce_libjackHandle, name);
+#endif
 }
 
 #define JUCE_DECL_JACK_FUNCTION(return_type, fn_name, argument_types, arguments)  \
@@ -604,8 +608,18 @@ public:
         inputNames.clear();
         outputNames.clear();
 
+#if (JUCE_LINUX || JUCE_BSD)
         if (juce_libjackHandle == nullptr)  juce_libjackHandle = dlopen ("libjack.so.0", RTLD_LAZY);
         if (juce_libjackHandle == nullptr)  juce_libjackHandle = dlopen ("libjack.so",   RTLD_LAZY);
+#elif JUCE_MAC
+        if (juce_libjackHandle == nullptr)  juce_libjackHandle = dlopen ("libjack.dylib",   RTLD_LAZY);
+#elif JUCE_WINDOWS
+    #if JUCE_64BIT
+        if (juce_libjackHandle == nullptr)  juce_libjackHandle = LoadLibraryA ("libjack64.dll");
+    #else
+        if (juce_libjackHandle == nullptr)  juce_libjackHandle = LoadLibraryA ("libjack.dll");
+    #endif
+#endif
         if (juce_libjackHandle == nullptr)  return;
 
         jack_status_t status = {};


### PR DESCRIPTION
This finally enables Jack Audio for all supported platforms.

It closes https://github.com/juce-framework/JUCE/issues/1176 and resolves numerous forum topics.