### PR TITLE
Sheenbidi: Ignore implicit-fallthrough warning

### DIFF
--- a/modules/juce_graphics/juce_graphics_Sheenbidi.c
+++ b/modules/juce_graphics/juce_graphics_Sheenbidi.c
@@ -38,7 +38,8 @@ JUCE_BEGIN_IGNORE_WARNINGS_GCC_LIKE ("-Wsign-conversion",
                                      "-Wcast-align",
                                      "-Wunused-variable",
                                      "-Wunused-function",
-                                     "-Wstringop-overflow")
+                                     "-Wstringop-overflow",
+                                     "-Wimplicit-fallthrough")
 
 JUCE_BEGIN_IGNORE_WARNINGS_MSVC (4189 4706)
 


### PR DESCRIPTION
Fix the `Unannotated fall-through between switch labels` that appears at `JUCE/modules/juce_graphics/juce_graphics_Sheenbidi.c:49` with Xcode 16.1 when enabling CLANG_WARN_IMPLICIT_FALLTHROUGH. 

https://forum.juce.com/t/warning-clang-macos/64529
