### PR TITLE
Enables all colour configuration available for the TextEditor in a Label

### DIFF
--- a/modules/juce_gui_basics/widgets/juce_Label.cpp
+++ b/modules/juce_gui_basics/widgets/juce_Label.cpp
@@ -332,6 +332,10 @@ TextEditor* Label::createEditorComponent()
     copyColourIfSpecified (*this, *ed, textWhenEditingColourId, TextEditor::textColourId);
     copyColourIfSpecified (*this, *ed, backgroundWhenEditingColourId, TextEditor::backgroundColourId);
     copyColourIfSpecified (*this, *ed, outlineWhenEditingColourId, TextEditor::focusedOutlineColourId);
+    copyColourIfSpecified (*this, *ed, highlightWhenEditingColourId, TextEditor::highlightColourId);
+    copyColourIfSpecified (*this, *ed, highlightTextWhenEditingColourId, TextEditor::highlightedTextColourId);
+    copyColourIfSpecified (*this, *ed, focusedOutlineWhenEditingColourId, TextEditor::focusedOutlineColourId);
+    copyColourIfSpecified (*this, *ed, shadowColourIdWhenEditingColourId, TextEditor::shadowColourId);
 
     return ed;
 }

--- a/modules/juce_gui_basics/widgets/juce_Label.h
+++ b/modules/juce_gui_basics/widgets/juce_Label.h
@@ -118,7 +118,11 @@ public:
                                                          Leave this transparent to not have an outline. */
         backgroundWhenEditingColourId  = 0x1000283, /**< The background colour when the label is being edited. */
         textWhenEditingColourId        = 0x1000284, /**< The colour for the text when the label is being edited. */
-        outlineWhenEditingColourId     = 0x1000285  /**< An optional border colour when the label is being edited. */
+        outlineWhenEditingColourId     = 0x1000285,  /**< An optional border colour when the label is being edited. */
+        highlightWhenEditingColourId      = 0x1000286, /**< The highlight colour when the label is being edited. */
+        highlightTextWhenEditingColourId  = 0x1000287, /**<  The highlighted text colour when the label is being edited. */
+        focusedOutlineWhenEditingColourId = 0x1000288, /**< Colour for drawing a box around the edge of the component when it has focus when the label is being edited. */
+        shadowColourIdWhenEditingColourId = 0x1000289, /**< Colour for drawing an inner shadow around the edge of the editor when the label is being edited. */
     };
 
     //==============================================================================


### PR DESCRIPTION
This is the updated version of PR #900 with following JUCE's PR procedure.

In the juce::Label, there is a embedded text editor.
I found some colours of the text editor is fixed, and can not customzable.

This PR enables additonal colour configuration.
