### PR TITLE
Fix memory leak in WebView message handling

### DIFF
--- a/modules/juce_gui_extra/native/juce_WebBrowserComponent_windows.cpp
+++ b/modules/juce_gui_extra/native/juce_WebBrowserComponent_windows.cpp
@@ -915,6 +915,7 @@ private:
                                                          args->TryGetWebMessageAsString (std::addressof (message)) == S_OK)
                                                      {
                                                          owner.impl->handleNativeEvent (JSON::fromString (StringRef { CharPointer_UTF16 (message) }));
+                                                         CoTaskMemFree(message);
                                                      }
 
                                                      return S_OK;


### PR DESCRIPTION
Fixed a memory leak.

![image](https://github.com/user-attachments/assets/7817bf6b-ebfa-4a32-838e-31c7aa72998f)

