### PR TITLE
Fix jack warnings

### DIFF
--- a/modules/juce_audio_devices/native/juce_JackAudio.cpp
+++ b/modules/juce_audio_devices/native/juce_JackAudio.cpp
@@ -50,7 +50,7 @@ static void* juce_loadJackFunction (const char* const name)
 }
 
 #define JUCE_DECL_JACK_FUNCTION(return_type, fn_name, argument_types, arguments)  \
-  return_type fn_name argument_types                                              \
+  static return_type fn_name argument_types                                       \
   {                                                                               \
       using ReturnType = return_type;                                             \
       typedef return_type (*fn_type) argument_types;                              \
@@ -60,7 +60,7 @@ static void* juce_loadJackFunction (const char* const name)
   }
 
 #define JUCE_DECL_VOID_JACK_FUNCTION(fn_name, argument_types, arguments)          \
-  void fn_name argument_types                                                     \
+  static void fn_name argument_types                                              \
   {                                                                               \
       typedef void (*fn_type) argument_types;                                     \
       static fn_type fn = (fn_type) juce_loadJackFunction (#fn_name);             \

--- a/modules/juce_audio_devices/native/juce_JackAudio.cpp
+++ b/modules/juce_audio_devices/native/juce_JackAudio.cpp
@@ -86,12 +86,12 @@ JUCE_DECL_JACK_FUNCTION (const char**, jack_get_ports, (jack_client_t* client, c
 JUCE_DECL_JACK_FUNCTION (int, jack_connect, (jack_client_t* client, const char* source_port, const char* destination_port), (client, source_port, destination_port))
 JUCE_DECL_JACK_FUNCTION (const char*, jack_port_name, (const jack_port_t* port), (port))
 JUCE_DECL_JACK_FUNCTION (void*, jack_set_port_connect_callback, (jack_client_t* client, JackPortConnectCallback connect_callback, void* arg), (client, connect_callback, arg))
-JUCE_DECL_JACK_FUNCTION (jack_port_t* , jack_port_by_id, (jack_client_t* client, jack_port_id_t port_id), (client, port_id))
 JUCE_DECL_JACK_FUNCTION (int, jack_port_connected, (const jack_port_t* port), (port))
-JUCE_DECL_JACK_FUNCTION (int, jack_port_connected_to, (const jack_port_t* port, const char* port_name), (port, port_name))
 JUCE_DECL_JACK_FUNCTION (int, jack_set_xrun_callback, (jack_client_t* client, JackXRunCallback xrun_callback, void* arg), (client, xrun_callback, arg))
+#if JUCE_DEBUG
 JUCE_DECL_JACK_FUNCTION (int, jack_port_flags, (const jack_port_t* port), (port))
 JUCE_DECL_JACK_FUNCTION (jack_port_t*, jack_port_by_name, (jack_client_t* client, const char* name), (client, name))
+#endif
 JUCE_DECL_VOID_JACK_FUNCTION (jack_free, (void* ptr), (ptr))
 
 #if JUCE_DEBUG


### PR DESCRIPTION
This PR fixes an [issue](https://forum.juce.com/t/clang-warnings-with-wmissing-prototypes-due-to-jack/54617/1) posted on the JUCE forum concerning `-Wmissing-prototypes` warnings due to JACK (tested with Clang 10.0.0 & Ubuntu 20.04 - Clang 14.0.0 & Ubuntu 22.04.5 but warnings should appear on other OS.). 

```
[295/300] Building CXX object CMakeFiles/Partiels.dir/JUCE/modules/juce_audio_devices/juce_audio_devices.cpp.o
In file included from /home/runner/work/Partiels/Partiels/JUCE/modules/juce_audio_devices/juce_audio_devices.cpp:264:
/home/runner/work/Partiels/Partiels/JUCE/modules/juce_audio_devices/native/juce_JackAudio.cpp:72:42: warning: no previous prototype for function 'jack_client_open' [-Wmissing-prototypes]
JUCE_DECL_JACK_FUNCTION (jack_client_t*, jack_client_open, (const char* client_name, jack_options_t options, jack_status_t* status, ...), (client_name, options, status))
                                         ^
/home/runner/work/Partiels/Partiels/JUCE/modules/juce_audio_devices/native/juce_JackAudio.cpp:72:26: note: declare 'static' if the function is not intended to be used outside of this translation unit
JUCE_DECL_JACK_FUNCTION (jack_client_t*, jack_client_open, (const char* client_name, jack_options_t options, jack_status_t* status, ...), (client_name, options, status))
...
```

[Github Action](https://github.com/Ircam-Partiels/Partiels/actions/runs/12743505844/job/35513639191)
[job-logs.txt](https://github.com/user-attachments/files/18394497/job-logs.txt)

The commit 784ff789ca020fb11d789593ebbeb91799ded05e declares the JACK methods as  `static` to avoid these warnings. Two methods are only used in Debug mode, so they generate the `-Wunused-function` warning in Release mode. The second commit c5eb15a0d1d44aed0159704dd7485d5c5ae99a13 corrects this problem by declaring them Debug-only.