### PR TITLE
Fix signature of __JUCE__.EventListenerList.removeEventListener

### DIFF
--- a/modules/juce_gui_extra/misc/juce_WebBrowserComponent.cpp
+++ b/modules/juce_gui_extra/misc/juce_WebBrowserComponent.cpp
@@ -120,7 +120,7 @@ if (
       return [eventId, id];
     }
 
-    removeEventListener([eventId, id]) {
+    removeEventListener(eventId, id) {
       if (this.eventListeners.has(eventId)) {
         this.eventListeners.get(eventId).removeListener(id);
       }

--- a/modules/juce_gui_extra/native/javascript/check_native_interop.js
+++ b/modules/juce_gui_extra/native/javascript/check_native_interop.js
@@ -105,7 +105,7 @@ if (
       return [eventId, id];
     }
 
-    removeEventListener([eventId, id]) {
+    removeEventListener(eventId, id) {
       if (this.eventListeners.has(eventId)) {
         this.eventListeners.get(eventId).removeListener(id);
       }


### PR DESCRIPTION
Fix `__JUCE__.backend.removeEventListener` not working correctly due to the mismatch of calling and the signature of `__JUCE__.EventListenerList.removeEventListener`.

Corresponding issue: https://github.com/juce-framework/JUCE/issues/1500