### PR TITLE
AudioProcessorARAExtension: Add support for ARAPlaybackRenderer::Alwa…

### DIFF
--- a/modules/juce_audio_processors/utilities/ARA/juce_AudioProcessor_ARAExtensions.cpp
+++ b/modules/juce_audio_processors/utilities/ARA/juce_AudioProcessor_ARAExtensions.cpp
@@ -55,7 +55,8 @@ bool AudioProcessorARAExtension::getTailLengthSecondsForARA (double& tailLength)
 bool AudioProcessorARAExtension::prepareToPlayForARA (double sampleRate,
                                                       int samplesPerBlock,
                                                       int numChannels,
-                                                      AudioProcessor::ProcessingPrecision precision)
+                                                      AudioProcessor::ProcessingPrecision precision,
+                                                      bool alwaysNonRealtime)
 {
 #if ARA_VALIDATE_API_CALLS
     isPrepared = true;
@@ -65,10 +66,10 @@ bool AudioProcessorARAExtension::prepareToPlayForARA (double sampleRate,
         return false;
 
     if (auto playbackRenderer = getPlaybackRenderer())
-        playbackRenderer->prepareToPlay (sampleRate, samplesPerBlock, numChannels, precision);
+        playbackRenderer->prepareToPlay (sampleRate, samplesPerBlock, numChannels, precision, alwaysNonRealtime ? ARAPlaybackRenderer::AlwaysNonRealtime::yes : ARAPlaybackRenderer::AlwaysNonRealtime::no);
 
     if (auto editorRenderer = getEditorRenderer())
-        editorRenderer->prepareToPlay (sampleRate, samplesPerBlock, numChannels, precision);
+        editorRenderer->prepareToPlay (sampleRate, samplesPerBlock, numChannels, precision, alwaysNonRealtime ? ARAPlaybackRenderer::AlwaysNonRealtime::yes : ARAPlaybackRenderer::AlwaysNonRealtime::no);
 
     return true;
 }

--- a/modules/juce_audio_processors/utilities/ARA/juce_AudioProcessor_ARAExtensions.h
+++ b/modules/juce_audio_processors/utilities/ARA/juce_AudioProcessor_ARAExtensions.h
@@ -135,7 +135,8 @@ protected:
     bool prepareToPlayForARA (double sampleRate,
                               int samplesPerBlock,
                               int numChannels,
-                              AudioProcessor::ProcessingPrecision precision);
+                              AudioProcessor::ProcessingPrecision precision,
+                              bool alwaysNonRealtime);
 
     /** Implementation helper for AudioProcessor::releaseResources().
 


### PR DESCRIPTION
The `prepareToPlay()` methods of the `juce::ARAPlaybackRenderer` and `juce::ARAEditorRenderer` classes take `ARAPlaybackRenderer::AlwaysNonRealtime` as an argument, but the `juce::AudioProcessorARAExtension::prepareToPlayForARA()` method ignores this argument and defaults to false. This PR allows you to control this argument and set it according to `juce::AudioProcessor::isNonRealtime()` for example. This can be used to decide which type of `juce::AudioFormatReader`  (Buffering or not) to use, for instance.
