### PR TITLE
Add Integer detection when converting from QuickJS to JUCE

### DIFF
--- a/modules/juce_javascript/choc/javascript/choc_javascript_QuickJS.h
+++ b/modules/juce_javascript/choc/javascript/choc_javascript_QuickJS.h
@@ -8912,7 +8912,13 @@ static inline JS_BOOL JS_IsNumber(JSValueConst v)
     return tag == JS_TAG_INT || JS_TAG_IS_FLOAT64(tag);
 }
 
-static inline JS_BOOL JS_IsBigInt(JSContext *ctx, JSValueConst v)
+static inline JS_BOOL JS_IsInteger(JSValueConst v)
+{
+    int tag = JS_VALUE_GET_TAG(v);
+    return tag == JS_TAG_INT;
+}
+
+static inline JS_BOOL JS_IsBigInt(JSValueConst v)
 {
     int tag = JS_VALUE_GET_TAG(v);
     return tag == JS_TAG_BIG_INT;
@@ -20782,7 +20788,7 @@ inline int JS_ToInt64(JSContext *ctx, int64_t *pres, JSValueConst val)
 
 inline int JS_ToInt64Ext(JSContext *ctx, int64_t *pres, JSValueConst val)
 {
-    if (JS_IsBigInt(ctx, val))
+    if (JS_IsBigInt(val))
         return JS_ToBigInt64(ctx, pres, val);
     else
         return JS_ToInt64(ctx, pres, val);

--- a/modules/juce_javascript/detail/juce_QuickJSHelpers.h
+++ b/modules/juce_javascript/detail/juce_QuickJSHelpers.h
@@ -253,7 +253,7 @@ static var tryQuickJSToJuce (const qjs::QuickJSContext::ValuePtr& ptr,
         {
             int64_t i = 0;
             JS_ToBigInt64 (ptr.context, std::addressof (i), ptr.value);
-            return i;
+            return var((juce::int64)i);
         }if(JS_IsInteger(ptr.value))
         {
             int32_t i = 0;

--- a/modules/juce_javascript/detail/juce_QuickJSHelpers.h
+++ b/modules/juce_javascript/detail/juce_QuickJSHelpers.h
@@ -249,9 +249,22 @@ static var tryQuickJSToJuce (const qjs::QuickJSContext::ValuePtr& ptr,
 
     if (JS_IsNumber (ptr.value))
     {
-        double d = 0;
-        JS_ToFloat64 (ptr.context, std::addressof (d), ptr.value);
-        return d;
+        if(JS_IsBigInt(ptr.value))
+        {
+            int64_t i = 0;
+            JS_ToBigInt64 (ptr.context, std::addressof (i), ptr.value);
+            return i;
+        }if(JS_IsInteger(ptr.value))
+        {
+            int32_t i = 0;
+            JS_ToInt32 (ptr.context, std::addressof (i), ptr.value);
+            return i;
+        }
+        {
+            double d = 0;
+            JS_ToFloat64 (ptr.context, std::addressof (d), ptr.value);
+            return d;
+        }
     }
 
     if (JS_IsBool (ptr.value))


### PR DESCRIPTION
This allows to keep integer data type when calling functions from javascript to Juce