### PR TITLE
PopupMenu: Add Item tooltipText

### DIFF
--- a/modules/juce_gui_basics/menus/juce_PopupMenu.cpp
+++ b/modules/juce_gui_basics/menus/juce_PopupMenu.cpp
@@ -120,11 +120,13 @@ struct HeaderItemComponent final : public PopupMenu::CustomComponent
 };
 
 //==============================================================================
-struct ItemComponent final : public Component
+struct ItemComponent final : public Component, public SettableTooltipClient
 {
     ItemComponent (const PopupMenu::Item& i, const PopupMenu::Options& o, MenuWindow& parent)
         : item (i), parentWindow (parent), options (o), customComp (i.customComponent)
     {
+        SettableTooltipClient::setTooltip(item.tooltipText);
+
         if (item.isSectionHeader)
             customComp = *new HeaderItemComponent (item.text, options);
 
@@ -1708,6 +1710,7 @@ PopupMenu::Item& PopupMenu::Item::operator= (Item&&) = default;
 
 PopupMenu::Item::Item (const Item& other)
   : text (other.text),
+    tooltipText(other.tooltipText),
     itemID (other.itemID),
     action (other.action),
     subMenu (createCopyIfNotNull (other.subMenu.get())),
@@ -1727,6 +1730,7 @@ PopupMenu::Item::Item (const Item& other)
 PopupMenu::Item& PopupMenu::Item::operator= (const Item& other)
 {
     text = other.text;
+    tooltipText = other.tooltipText;
     itemID = other.itemID;
     action = other.action;
     subMenu.reset (createCopyIfNotNull (other.subMenu.get()));

--- a/modules/juce_gui_basics/menus/juce_PopupMenu.h
+++ b/modules/juce_gui_basics/menus/juce_PopupMenu.h
@@ -137,6 +137,7 @@ public:
 
         /** The menu item's name. */
         String text;
+        String tooltipText = "";
 
         /** The menu item's ID.
             This must not be 0 if you want the item to be triggerable, but if you're attaching


### PR DESCRIPTION
See:

https://forum.juce.com/t/how-to-put-a-tooltip-for-a-popupmenu-item/54529

For now, it is impossible to add a tooltip for each item of a `PopupMenu` without a complex implementation of `CustomComponent`. Now we can add it by setting `tooltipText` of an `Item`. Example:

```cpp
const auto menu = comboBox.getRootMenu();
juce::PopupMenu::Item item;
item.itemID = 1;
item.text = "text";
item.tooltipText = "tooltip text";
item.isEnabled = true;
item.isTicked = false;
menu->addItem(item);
```