### PR TITLE
ObjCHelpers: Ignore cast-function-type-mismatch warning on Xcode

### DIFF
--- a/modules/juce_core/native/juce_ObjCHelpers_mac.h
+++ b/modules/juce_core/native/juce_ObjCHelpers_mac.h
@@ -183,7 +183,9 @@ template <typename SuperType, typename ReturnType, typename... Params>
 inline ReturnType ObjCMsgSendSuper (id self, SEL sel, Params... params)
 {
     using SuperFn = ReturnType (*) (struct objc_super*, SEL, Params...);
+    JUCE_BEGIN_IGNORE_WARNINGS_GCC_LIKE ("-Wcast-function-type-mismatch")
     const auto fn = reinterpret_cast<SuperFn> (MetaSuperFn<ReturnType>::value);
+    JUCE_END_IGNORE_WARNINGS_GCC_LIKE
 
     objc_super s = { self, [SuperType class] };
     return fn (&s, sel, params...);
@@ -346,7 +348,9 @@ struct ObjCClass
     void addMethod (SEL selector, Result (*callbackFn) (id, SEL, Args...))
     {
         const auto s = detail::makeCompileTimeStr (@encode (Result), @encode (id), @encode (SEL), @encode (Args)...);
+        JUCE_BEGIN_IGNORE_WARNINGS_GCC_LIKE ("-Wcast-function-type-mismatch")
         [[maybe_unused]] const auto b = class_addMethod (cls, selector, (IMP) callbackFn, s.data());
+        JUCE_END_IGNORE_WARNINGS_GCC_LIKE
         jassert (b);
     }
 


### PR DESCRIPTION
See: https://forum.juce.com/t/xcode-16-3-juce-8-0-7-warning-cast-function-type-mismatch/65776

Fix the cast-function-type-mismatch warnings if you are compiling for the x86_64 architecture with `-Wextra`.

You can reproduce the warnings with the AudioPluginHost example, using:
`cmake -Bbuild -G Xcode -DJUCE_BUILD_EXTRAS=ON -DJUCE_BUILD_EXAMPLES=ON -DCMAKE_XCODE_GENERATE_SCHEME=ON -DCMAKE_OSX_ARCHITECTURES=« \$(ARCHS_STANDARD) » -DCMAKE_CXX_FLAGS="-Wall -Wextra"`



