### PR TITLE
FIR filter not resetting position member leading to out of bounds access

### DIFF
--- a/modules/juce_dsp/processors/juce_FIRFilter.h
+++ b/modules/juce_dsp/processors/juce_FIRFilter.h
@@ -109,6 +109,8 @@ namespace juce::dsp::FIR
 
                 for (size_t i = 0; i < size; ++i)
                     fifo[i] = SampleType {0};
+
+		pos = 0;
             }
         }
 


### PR DESCRIPTION
signed JUCE CLA attached:
[JUCE_CLA_signed.pdf](https://github.com/user-attachments/files/19822064/JUCE_CLA_signed.pdf)

When merged, this PR will fix an out of bounds access in the FIR Filter class. The `reset()` function does not reset the `pos` variable, which leads to an out of bounds access in the case when the length of the filter coefficients has changed.


