### PR TITLE
Make updateTrackProperties work with Studio One

### DIFF
--- a/modules/juce_audio_plugin_client/juce_audio_plugin_client_VST3.cpp
+++ b/modules/juce_audio_plugin_client/juce_audio_plugin_client_VST3.cpp
@@ -880,6 +880,7 @@ class JuceVST3EditController final : public Vst::EditController,
                                     #if JucePlugin_Enable_ARA
                                      public Presonus::IPlugInViewEmbedding,
                                     #endif
+                                     public Presonus::IContextInfoHandler,
                                      public AudioProcessorListener,
                                      private ComponentRestarter::Listener
 {
@@ -1134,6 +1135,48 @@ public:
 
         JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (ProgramChangeParameter)
     };
+
+    void notifyContextInfoChange() override
+    {
+        if (! PluginHostType().isStudioOne())
+            return;
+
+        if (auto* instance = getPluginInstance())
+        {
+            bool hasUsableContextInfoChange = false;
+            AudioProcessor::TrackProperties trackProperties;
+            FUnknownPtr<Presonus::IContextInfoProvider> contextInfoProvider (componentHandler);
+            Steinberg::int32 channelColour = 0;
+            if (contextInfoProvider->getContextInfoValue (channelColour, Presonus::ContextInfo::kColor)
+                       == kResultTrue)
+            {
+                // PreSonus uses RGBA
+                uint8 r = (channelColour) &0x000000FF;
+                uint8 g = (channelColour >> 8) & 0x000000FF;
+                uint8 b = (channelColour >> 16) & 0x000000FF;
+                uint8 a = (channelColour >> 24) & 0x000000FF;
+                trackProperties.colour = std::make_optional (Colour (r, g, b, a));
+                hasUsableContextInfoChange = true;
+            }
+
+            Vst::TChar channelName[128] = {0};
+            if (contextInfoProvider->getContextInfoString (channelName, 128, Presonus::ContextInfo::kName)
+                == kResultTrue)
+            {
+                trackProperties.name = std::make_optional (toString (channelName));
+                hasUsableContextInfoChange = true;
+            }
+
+            if (! hasUsableContextInfoChange)
+                return;
+
+            if (MessageManager::getInstance()->isThisTheMessageThread())
+                instance->updateTrackProperties (trackProperties);
+            else
+                MessageManager::callAsync ([trackProperties, instance]
+                                           { instance->updateTrackProperties (trackProperties); });
+        }
+    }
 
     //==============================================================================
     tresult PLUGIN_API getCompatibleParamID (const TUID pluginToReplaceUID,
@@ -1692,6 +1735,7 @@ private:
                                              UniqueBase<Vst::IUnitInfo>{},
                                              UniqueBase<Vst::IRemapParamID>{},
                                              UniqueBase<Vst::ChannelContext::IInfoListener>{},
+                                             UniqueBase<Presonus::IContextInfoHandler>{},
                                              SharedBase<IPluginBase, Vst::IEditController>{},
                                              UniqueBase<IDependent>{},
                                             #if JucePlugin_Enable_ARA

--- a/modules/juce_audio_processors/format_types/juce_VST3Headers.h
+++ b/modules/juce_audio_processors/format_types/juce_VST3Headers.h
@@ -139,6 +139,7 @@ JUCE_BEGIN_IGNORE_WARNINGS_GCC_LIKE ("-W#warnings",
  #include <public.sdk/source/vst/vstpresetfile.h>
 
  #include "pslextensions/ipslviewembedding.h"
+ #include "pslextensions/ipslcontextinfo.h"
 #else
  // needed for VST_VERSION
  #include <pluginterfaces/vst/vsttypes.h>
@@ -211,6 +212,7 @@ JUCE_BEGIN_IGNORE_WARNINGS_GCC_LIKE ("-W#warnings",
  #endif
 
  #include "pslextensions/ipslviewembedding.h"
+ #include "pslextensions/ipslcontextinfo.h"
 
 //==============================================================================
 namespace Steinberg
@@ -238,6 +240,8 @@ namespace Steinberg
 namespace Presonus
 {
     DEF_CLASS_IID (IPlugInViewEmbedding)
+    DEF_CLASS_IID (IContextInfoHandler)
+    DEF_CLASS_IID (IContextInfoProvider)
 }
 
 #endif // JUCE_VST3HEADERS_INCLUDE_HEADERS_ONLY


### PR DESCRIPTION
Studio One requires the use of the [PreSonus Plug-In Extensions](https://github.com/fenderdigital/presonus-plugin-extensions) to get track informations such as the track name and colour. This commit makes updateTrackProperties works with Studio One like it does on other DAWs.

The change is mostly taken from this [Sound Radix JUCE fork commit](https://github.com/soundradix/JUCE/commit/6fa1cf8eecf51b75d96f89ac09b02d9c938aade3).