### PR TITLE
Add a method to launch a child worker process with additionnal command line arguments

### DIFF
--- a/modules/juce_events/interprocess/juce_ConnectedChildProcess.cpp
+++ b/modules/juce_events/interprocess/juce_ConnectedChildProcess.cpp
@@ -166,13 +166,27 @@ bool ChildProcessCoordinator::sendMessageToWorker (const MemoryBlock& mb)
 bool ChildProcessCoordinator::launchWorkerProcess (const File& executable, const String& commandLineUniqueID,
                                                    int timeoutMs, int streamFlags)
 {
-    killWorkerProcess();
-
-    auto pipeName = "p" + String::toHexString (Random().nextInt64());
-
     StringArray args;
     args.add (executable.getFullPathName());
-    args.add (getCommandLinePrefix (commandLineUniqueID) + pipeName);
+
+    return launchWorkerProcess(args, commandLineUniqueID, timeoutMs, streamFlags);
+}
+
+bool ChildProcessCoordinator::launchWorkerProcess(const StringArray& arguments, const String& commandLineUniqueID,
+                                                  int timeoutMs, int streamFlags)
+{
+    killWorkerProcess();
+
+    auto pipeName = "p" + String::toHexString(Random().nextInt64());
+
+    StringArray args;
+    args.add(arguments[0]);
+    args.add(getCommandLinePrefix(commandLineUniqueID) + pipeName);
+    if (arguments.size() > 1)
+    {
+        args.addArray(arguments.begin() + 1, arguments.end());
+    }
+
 
     childProcess = [&]() -> std::shared_ptr<ChildProcess>
     {

--- a/modules/juce_events/interprocess/juce_ConnectedChildProcess.h
+++ b/modules/juce_events/interprocess/juce_ConnectedChildProcess.h
@@ -186,6 +186,32 @@ public:
                               int timeoutMs = 0,
                               int streamFlags = ChildProcess::wantStdOut | ChildProcess::wantStdErr);
 
+    /** Attempts to launch and connect to a worker process by command line.
+
+        The first argument should be the name of the executable file, followed by any other
+        arguments that are needed.
+        This will start the given executable, passing it a special command-line
+        parameter as first argument based around the commandLineUniqueID string, which must be a
+        short alphanumeric string (no spaces!) that identifies your app. The exe
+        that gets launched must respond by calling ChildProcessWorker::initialiseFromCommandLine()
+        in its startup code, and must use a matching ID to commandLineUniqueID.
+
+        The timeoutMs parameter lets you specify how long the child process is allowed
+        to go without sending a ping before it is considered to have died and
+        handleConnectionLost() will be called. Passing <= 0 for this timeout makes
+        it use a default value.
+
+        If this all works, the method returns true, and you can begin sending and
+        receiving messages with the worker process.
+
+        If a child process is already running, this will call killWorkerProcess() and
+        start a new one.
+    */                              
+    bool launchWorkerProcess(const StringArray& arguments,
+                             const String& commandLineUniqueID,
+                             int timeoutMs = 0,
+                             int streamFlags = ChildProcess::wantStdOut | ChildProcess::wantStdErr);
+
     [[deprecated ("Replaced by launchWorkerProcess.")]]
     bool launchSlaveProcess (const File& executableToLaunch,
                              const String& commandLineUniqueID,


### PR DESCRIPTION
Hi ! I was missing the ability to launch monitored child processes while passing down additionnal command-line arguments. This adds a method to do just that

The signature is a mix between the existing ChildProcessCoordinator::launchWorkerProcess(const File& exec, const String& cmdLineUID, int timeout, int streamFlags) and ChildProcess' `ChildProcess::start(const StringArray& args, int streamFlags`  

The unique ID is placed as first argument

