### PR TITLE
Allow initialization of PropertiesFile::Options using C++11 initializer list and C++20 designated initializer

### DIFF
--- a/modules/juce_data_structures/app_properties/juce_PropertiesFile.cpp
+++ b/modules/juce_data_structures/app_properties/juce_PropertiesFile.cpp
@@ -47,16 +47,6 @@ namespace PropertyFileConstants
 }
 
 //==============================================================================
-PropertiesFile::Options::Options()
-    : commonToAllUsers (false),
-      ignoreCaseOfKeyNames (false),
-      doNotSave (false),
-      millisecondsBeforeSaving (3000),
-      storageFormat (PropertiesFile::storeAsXML),
-      processLock (nullptr)
-{
-}
-
 File PropertiesFile::Options::getDefaultFile() const
 {
     // mustn't have illegal characters in this name..

--- a/modules/juce_data_structures/app_properties/juce_PropertiesFile.h
+++ b/modules/juce_data_structures/app_properties/juce_PropertiesFile.h
@@ -68,11 +68,6 @@ public:
     /** Structure describing properties file options */
     struct JUCE_API  Options
     {
-        /** Creates an empty Options structure.
-            You'll need to fill-in the data members appropriately before using this structure.
-        */
-        Options();
-
         /** The name of your application - this is used to help generate the path and filename
             at which the properties file will be stored. */
         String applicationName;
@@ -113,43 +108,42 @@ public:
         String osxLibrarySubFolder;
 
         /** If true, the file will be created in a location that's shared between users.
-            The default constructor initialises this value to false.
+            Defaults to false.
         */
-        bool commonToAllUsers;
+        bool commonToAllUsers = false;
 
         /** If true, this means that property names are matched in a case-insensitive manner.
             See the PropertySet constructor for more info.
-            The default constructor initialises this value to false.
+            Defaults to false.
         */
-        bool ignoreCaseOfKeyNames;
+        bool ignoreCaseOfKeyNames = false;
 
-        /** If set to true, this prevents the file from being written to disk. */
-        bool doNotSave;
+        /** If set to true, this prevents the file from being written to disk. Defaults to false. */
+        bool doNotSave = false;
 
         /** If this is zero or greater, then after a value is changed, the object will wait
             for this amount of time and then save the file. If this zero, the file will be
             written to disk immediately on being changed (which might be slow, as it'll re-write
             synchronously each time a value-change method is called). If it is less than zero,
             the file won't be saved until save() or saveIfNeeded() are explicitly called.
-            The default constructor sets this to a reasonable value of a few seconds, so you
-            only need to change it if you need a special case.
+            It defaults to a reasonable value of a few seconds, so you only need to change it if
+            you need a special case.
         */
-        int millisecondsBeforeSaving;
+        int millisecondsBeforeSaving = 3000;
 
         /** Specifies whether the file should be written as XML, binary, etc.
-            The default constructor sets this to storeAsXML, so you only need to set it explicitly
+            Defaults to storeAsXML, so you only need to set it explicitly
             if you want to use a different format.
         */
-        StorageFormat storageFormat;
+        StorageFormat storageFormat = PropertiesFile::storeAsXML;
 
         /** An optional InterprocessLock object that will be used to prevent multiple threads or
             processes from writing to the file at the same time. The PropertiesFile will keep a
             pointer to this object but will not take ownership of it - the caller is responsible for
             making sure that the lock doesn't get deleted before the PropertiesFile has been deleted.
-            The default constructor initialises this value to nullptr, so you don't need to touch it
-            unless you want to use a lock.
+            Defaults to nullptr, so you don't need to touch it unless you want to use a lock.
         */
-        InterProcessLock* processLock;
+        InterProcessLock* processLock = nullptr;
 
         /** This can be called to suggest a file that should be used, based on the values
             in this structure.


### PR DESCRIPTION
The presence of a default Ctor for PropertiesFile::Options, prevents initialization of this struct using C++11 Initializer List, or C++20 designated initializers.

This means that PropertiesFile::Option properties need to be set manually, every time referencing the variable that holds the Option resulting in quite repetitive code. Ie:

```cpp
juce::PropertiesFile::Options userSettingsFileOptions;
userSettingsFileOptions.applicationName     = "MyApp";
userSettingsFileOptions.filenameSuffix      = ".bin";
userSettingsFileOptions.folderName          = "myAppSettingDir";
userSettingsFileOptions.osxLibrarySubFolder = "Application Support";
userSettingsFileOptions.storageFormat       = PropertiesFile::storeAsBinary;
// ...
juce::ApplicationProperties userSettings;
userSettings.setStorageParameters(userSettingsFileOptions);
```

While using the C++11 initializer list requires all aggregate member values to be specified in order, it results in a bit less repetitive code:

```cpp
juce::ApplicationProperties userSettings;
userSettings.setStorageParameters(juce::PropertiesFile::Options {
    "MyApp",
    ".bin",
    "myAppSettingsDir",
    "Application Support",
    true,
    true,
    false,
    3000,
    PropertiesFile::StorageFormat::storeAsBinary
});
```

By allowing the use of C++20 designated initializer the code can be made terser (and more readable) than the one required when using C++11 initializer list.

```cpp
juce::ApplicationProperties userSettings;
userSettings.setStorageParameters(juce::PropertiesFile::Options {
    .applicationName     = "MyApp",
    .filenameSuffix      = ".bin",
    .folderName          = "myAppSettingsDir",
    .osxLibrarySubFolder = "Application Support",
    .storageFormat       = juce::PropertiesFile::StorageFormat::storeAsBinary
});
```