### PR TITLE
File: Add std::hash() template for juce::File

### DIFF
--- a/modules/juce_core/files/juce_File.h
+++ b/modules/juce_core/files/juce_File.h
@@ -1187,3 +1187,13 @@ private:
 };
 
 } // namespace juce
+
+/** @cond */
+namespace std
+{
+    template <> struct hash<juce::File>
+    {
+        size_t operator() (const juce::File& f) const noexcept    { return (size_t) f.hashCode64(); }
+    };
+}
+/** @endcond */


### PR DESCRIPTION
I was quite surprised to discover that I can't use ```juce::File``` as a key in ```std::unordered_map```. Obviously, the workaround is to just use a string with file's full path, but I  believe it's an extra string allocation and copy, plus clutters the code, if you don't need that string for anything else. Also, it's possible to mix up relative and absolute paths by accident, which using the actual file object will help to avoid.

I've laid it out in a similar manner to ```juce::String``` and ```juce::UUID```, as they already have ```std::hash``` implementation. The actual hash function for 64-bit value was already there, so that's what I've used.

Usage:

```cpp
std::unordered_map<juce::File, int> someMap;
// ...
const int x = someMap.at (someFile);
```

instead of:

```cpp
std::unordered_map<juce::String, int> someMap;
// ...
const int x = someMap.at (someFile.getFullPathName());
```
