### PR TITLE
WebBrowserComponent: Enable Safari Web Inspector in debug builds

### DIFF
--- a/modules/juce_gui_extra/native/juce_WebBrowserComponent_mac.mm
+++ b/modules/juce_gui_extra/native/juce_WebBrowserComponent_mac.mm
@@ -893,6 +893,10 @@ public:
                                           configuration: config.get()]);
        #endif
 
+       #if JUCE_DEBUG
+        [webView.get() setValue:@(true) forKey:@"inspectable"];
+       #endif
+
         if (const auto userAgent = browserOptions.getUserAgent(); userAgent.isNotEmpty())
             webView.get().customUserAgent = juceStringToNS (userAgent);
 


### PR DESCRIPTION
Enables inspection of the WKWebView-backed WebBrowserComponent using Safari Web Inspector.
In some cases, this provides a more convenient debugging experience than using the in-webview “Inspect” feature.

References:

[Apple Documentation – isInspectable](https://developer.apple.com/documentation/webkit/wkwebview/isinspectable?language=objc)

[WebKit Blog – Enabling the Inspection of Web Content in Apps](https://webkit.org/blog/13936/enabling-the-inspection-of-web-content-in-apps/)