### PR TITLE
Fixed typo in juce::SamplerSound documentation

### DIFF
--- a/modules/juce_audio_formats/sampler/juce_Sampler.h
+++ b/modules/juce_audio_formats/sampler/juce_Sampler.h
@@ -43,7 +43,7 @@ namespace juce
     into memory.
 
     To use it, create a Synthesiser, add some SamplerVoice objects to it, then
-    give it some SampledSound objects to play.
+    give it some SamplerSound objects to play.
 
     @see SamplerVoice, Synthesiser, SynthesiserSound
 


### PR DESCRIPTION
Fixed typo in juce::SamplerSound documentation: the docs mentionned "SampledSound" instead of "SamplerSound"

