### PR TITLE
Correct VST3_CATEGORIES defaults in CMake API docs

### DIFF
--- a/docs/CMake API.md
+++ b/docs/CMake API.md
@@ -585,7 +585,7 @@ attributes directly to these creation functions, rather than adding them later.
   `Delay`, `Distortion`, `Drum`, `Dynamics`, `EQ`, `External`, `Filter`, `Generator`, `Mastering`,
   `Modulation`, `Mono`, `Network`, `NoOfflineProcess`, `OnlyOfflineProcess`, `OnlyRT`,
   `Pitch Shift`, `Restoration`, `Reverb`, `Sampler`, `Spatial`, `Stereo`, `Surround`, `Synth`,
-  `Tools`, `Up-Downmix`. Defaults to `Synth` if `IS_SYNTH` is `TRUE`. Otherwise defaults to `Fx`.
+  `Tools`, `Up-Downmix`. Defaults to `Instrument` and `Synth` if `IS_SYNTH` is `TRUE`. Otherwise defaults to `Fx`.
 
 `AU_MAIN_TYPE`
 - Should be one of: `kAudioUnitType_Effect`, `kAudioUnitType_FormatConverter`,


### PR DESCRIPTION
This change updates the CMake API documentation so that the default VST3_CATEGORIES mention both Instrument and Synth when IS_SYNTH is TRUE.

According to the _juce_set_fallback_properties function in extras/Build/CMake/JUCEUtils.cmake, when IS_SYNTH is TRUE the default VST3_CATEGORIES are Instrument and Synth:

```cmake
if(is_synth)
    _juce_set_property_if_not_set(${target} VST3_CATEGORIES Instrument Synth)
else()
    _juce_set_property_if_not_set(${target} VST3_CATEGORIES Fx)
endif()
```

However, the CMake API documentation currently mentions only Synth as the default in this case.
This change updates the docs so that the described defaults match the implementation.
