### PR TITLE
Fix AudioPluginInstance template constructor parameter type in headless module

### DIFF
--- a/modules/juce_audio_processors_headless/processors/juce_AudioPluginInstance.h
+++ b/modules/juce_audio_processors_headless/processors/juce_AudioPluginInstance.h
@@ -170,7 +170,7 @@ protected:
     AudioPluginInstance() = default;
     AudioPluginInstance (const BusesProperties& ioLayouts) : AudioProcessor (ioLayouts) {}
     template <size_t numLayouts>
-    AudioPluginInstance (const short channelLayoutList[numLayouts][2]) : AudioProcessor (channelLayoutList) {}
+    AudioPluginInstance (const short (&channelLayoutList)[numLayouts][2]) : AudioProcessor (channelLayoutList) {}
 
 private:
     // It's not safe to add a plain AudioProcessorParameter to an AudioPluginInstance.


### PR DESCRIPTION
## Summary
The template constructor in `juce_AudioPluginInstance.h` (headless module) uses:

```cpp
template <size_t numLayouts>
AudioPluginInstance (const short channelLayoutList[numLayouts][2])
```

This parameter decays to `const short (*)[2]` (pointer to array), which doesn't match any `AudioProcessor` constructor. The `AudioProcessor` class has a matching template constructor that expects a reference to an array:

```cpp
template <size_t numLayouts>
AudioProcessor (const short (&channelLayoutList)[numLayouts][2])
```

## The Fix
Changed the parameter to use reference syntax:

```cpp
template <size_t numLayouts>
AudioPluginInstance (const short (&channelLayoutList)[numLayouts][2])
```

## Error Before Fix
```
error: no matching constructor for initialization of 'AudioProcessor'
  AudioPluginInstance (const short channelLayoutList[numLayouts][2])
    : AudioProcessor (channelLayoutList) {}

note: candidate template ignored: could not match 'short[numLayouts][2]' against 'const short (*)[2]'
  AudioProcessor (const short (&channelLayoutList)[numLayouts][2])
```

## Testing
Tested with a VST3/AU plugin project that previously failed to compile with JUCE 8.0.11 - builds successfully with this fix.