### PR TITLE
Direct2D: Add ClearType Antialiasing back to D2D as a module option

### DIFF
--- a/modules/juce_graphics/juce_graphics.h
+++ b/modules/juce_graphics/juce_graphics.h
@@ -87,6 +87,17 @@
  #define JUCE_DISABLE_COREGRAPHICS_FONT_SMOOTHING 0
 #endif
 
+/** Config: JUCE_ENABLE_DIRECT2D_CLEARTYPE_FONT_SMOOTHING
+
+    Setting this flag will *enable* Windows ClearType subpixel font antialiasing when using
+    the Direct2D renderer, if preferred by the end user. This is off by default due to
+    issues with transparency, certain compositions and transformations so make sure the 
+    output looks acceptable for your use cases.
+*/
+#ifndef JUCE_ENABLE_DIRECT2D_CLEARTYPE_FONT_SMOOTHING
+#define JUCE_ENABLE_DIRECT2D_CLEARTYPE_FONT_SMOOTHING 0
+#endif
+
 #ifndef JUCE_INCLUDE_PNGLIB_CODE
  #define JUCE_INCLUDE_PNGLIB_CODE 1
 #endif


### PR DESCRIPTION
This is effectively an optional revert of 14d5276.

This adds Windows ClearType font antialiasing back as a disabled-by-default option `JUCE_ENABLE_DIRECT2D_CLEARTYPE_FONT_SMOOTHING` in the juce_graphics module.

While this can have issues, it seems to fair to have it as a module option for end users to decide.

Disabled example:
<img width="789" height="216" alt="billede" src="https://github.com/user-attachments/assets/26bccc93-f3d7-4bb2-a8eb-0d67dadfc01f" />

Enabled example:
<img width="711" height="221" alt="billede" src="https://github.com/user-attachments/assets/9e071b19-5999-49bb-8f98-7d247cd327fb" />

Note the web scaling makes the results look bad, it's purely to demonstrate it works.