### PR TITLE
Fix for MOTU gen5 ASIO. 

### DIFF
--- a/modules/juce_audio_devices/native/juce_ASIO_windows.cpp
+++ b/modules/juce_audio_devices/native/juce_ASIO_windows.cpp
@@ -499,6 +499,9 @@ public:
             JUCE_ASIO_LOG_ERROR ("create buffers 2", err);
 
             asioObject->disposeBuffers();
+            err = asioObject->getChannels (&totalNumInputChans, &totalNumOutputChans);
+            jassert (err == ASE_OK);
+            totalBuffers = resetBuffers (inputChannels, outputChannels);
             err = asioObject->createBuffers (bufferInfos, totalBuffers, currentBlockSizeSamples, &callbacks);
         }
 


### PR DESCRIPTION
This change concerns MOTU gen5 audio devices (ultralite mk5 18x22) failing to report correct channel enumeration on first try after sample rate change from lower to higher (enough to limit number of adat channels). This issue leads to wrong channel count, failed buffer allocation, and ultimately heap corruption.

