### PR TITLE
Fixed activeEditor wild pointer issue when destroying plug-in window in AudioPluginHost

### DIFF
--- a/extras/AudioPluginHost/Source/UI/PluginWindow.h
+++ b/extras/AudioPluginHost/Source/UI/PluginWindow.h
@@ -215,6 +215,7 @@ public:
 
     ~PluginWindow() override
     {
+        node->getProcessor()->editorBeingDeleted(node->getProcessor()->getActiveEditor());
         clearContentComponent();
     }
 


### PR DESCRIPTION
## Problem description:

When I debugged my plug-in on 8.0.12 version, I found that the plug-in window opened normally the first time, but only a default window opened the second time.At first I thought there was something wrong with my plug-in code.So i debug AudioPluginHost's internal plugin,and found the same situation.

First Open:
<img width="800" height="600" alt="image" src="https://github.com/user-attachments/assets/03639846-f34e-4717-bee8-941ee5302db6" />

Close the plugin window and reopen:

<img width="800" height="600" alt="image" src="https://github.com/user-attachments/assets/56068ae0-23ee-4feb-9abd-9265e8e5a729" />

This happens with all plugins that have an editor.Not a specific one.

## Problem analysis:

So i debug AudioPluginHost project.When I open the plugin window the second time, this place will report an error:

<img width="648" height="432" alt="Snipaste_2026-01-29_17-17-18" src="https://github.com/user-attachments/assets/0da26676-e81e-4506-8228-d15767ef2b29" />

And the activeEditor member seens invalid.

<img width="827" height="197" alt="image" src="https://github.com/user-attachments/assets/fd3e4217-a6bb-41c3-b1a3-25b35eeba57e" />

activeEditor is a raw pointer member of AudioProcessor class.

<img width="483" height="108" alt="image" src="https://github.com/user-attachments/assets/d405242e-0114-431c-b05e-df73b038ee6e" />


So i debug 7.0.12 version,no matter how many times I open the plug-in window, it always displays correctly.And the activeEditor member is a safe pointer:

<img width="563" height="95" alt="image" src="https://github.com/user-attachments/assets/c59ce294-6c48-45db-b627-8ff1b0591ca6" />

And in AudioProcessor::createEditorIfNeeded(),it always a pretty null pointer

<img width="742" height="341" alt="image" src="https://github.com/user-attachments/assets/73972541-3523-4844-841f-c3f825b3747e" />

So i think in version 8.0.12, the object pointed to by the activeEditor pointer has been destroyed, but the activeEditor is not set to null, resulting in a wild pointer.

## My solution

So I use the editorBeingDeleted() function, with AudioProcessor's own editor as an argument, to set the AudioProcessor's activeEditor member to null before deleting the plug-in editor.As below.
