### PR TITLE
Fix CoreAudio StrideIterator build failure on Xcode 15 (remove std::c…

### DIFF
--- a/modules/juce_audio_devices/native/juce_CoreAudio_mac.cpp
+++ b/modules/juce_audio_devices/native/juce_CoreAudio_mac.cpp
@@ -1115,14 +1115,17 @@ private:
         for (auto index = 0; index < numInputChans; ++index)
         {
             const auto info = inStream->channelInfo.getReference (index);
-            const auto src = StrideIterator { ((const float*) inInputData->mBuffers[info.streamNum].mData) + info.dataOffsetSamples,
-                                              info.dataStrideSamples }
-                           + (ptrdiff_t) sampleOffset;
+            auto src = StrideIterator { ((const float*) inInputData->mBuffers[info.streamNum].mData) + info.dataOffsetSamples,
+                                        info.dataStrideSamples }
+                     + (ptrdiff_t) sampleOffset;
 
-            if (src.stride == 0) // if this is zero, info is invalid
+            if (src.stride == 0)
                 continue;
 
-            std::copy (src, src + (ptrdiff_t) numSamplesInChunk, inStream->tempBuffers[(size_t) index]);
+            const auto end = src + (ptrdiff_t) numSamplesInChunk;
+
+            for (auto dst = inStream->tempBuffers[(size_t) index]; src != end; ++dst, ++src)
+                *dst = *src;
         }
 
         // only pass a timestamp for the first chunk of each buffer


### PR DESCRIPTION
Build errors on Mac 13.6.3

Edits to juce_CoreAudio_mac.cpp fixed build issue and pass all other build tests.

