### PR TITLE
Fix invalid note ons on inactive zone's master channel

### DIFF
--- a/modules/juce_audio_basics/mpe/juce_MPEInstrument.cpp
+++ b/modules/juce_audio_basics/mpe/juce_MPEInstrument.cpp
@@ -680,8 +680,11 @@ bool MPEInstrument::isUsingChannel (int midiChannel) const noexcept
     if (legacyMode.isEnabled)
         return legacyMode.channelRange.contains (midiChannel);
 
-    return zoneLayout.getLowerZone().isUsing (midiChannel)
-            || zoneLayout.getUpperZone().isUsing (midiChannel);
+    const auto lowerZone = zoneLayout.getLowerZone();
+    const auto upperZone = zoneLayout.getUpperZone();
+
+    return (lowerZone.isActive() && lowerZone.isUsing (midiChannel))
+            || (upperZone.isActive() && upperZone.isUsing (midiChannel));
 }
 
 //==============================================================================


### PR DESCRIPTION
MPEZone::isUsing doesn't check if a zone is active so a master channel of an unused zone was being reported as a valid channel, resulting in invalid triggered notes.


