### PR TITLE
Resolving Grid gap size rounding issue on Windows #1334

### DIFF
--- a/modules/juce_gui_basics/layout/juce_Grid.cpp
+++ b/modules/juce_gui_basics/layout/juce_Grid.cpp
@@ -182,11 +182,9 @@ struct Grid::Helpers
                         const auto absoluteSize = currentItem.getAbsoluteSize (relativeUnit);
 
                         if (! currentItem.isFractional())
-                            return roundingFunction (absoluteSize);
+                            return absoluteSize;
 
-                        const auto result = roundingFunction (absoluteSize - carriedError);
-                        carriedError += result - absoluteSize;
-                        return result;
+                        return absoluteSize;
                     }();
 
                     if (currentItem.isFractional())
@@ -525,13 +523,12 @@ struct Grid::Helpers
             jassert (isPositiveAndBelow (correctedColumn, tracks.columns.items.size()));
             jassert (isPositiveAndBelow (correctedRow,    tracks.rows   .items.size()));
 
-            return
-            {
-                calculation.columnTrackBounds[(size_t) correctedColumn].getStart(),
-                calculation.rowTrackBounds[(size_t) correctedRow].getStart(),
-                calculation.columnTrackBounds[(size_t) correctedColumn].getEnd() - calculation.columnTrackBounds[(size_t) correctedColumn].getStart(),
-                calculation.rowTrackBounds[(size_t) correctedRow].getEnd() - calculation.rowTrackBounds[(size_t) correctedRow].getStart()
-            };
+            auto x = roundingFunction(calculation.columnTrackBounds[col].getStart());
+            auto y = roundingFunction(calculation.rowTrackBounds[row].getStart());
+            auto w = roundingFunction(calculation.columnTrackBounds[col].getEnd() - calculation.columnTrackBounds[col].getStart());
+            auto h = roundingFunction(calculation.rowTrackBounds[row].getEnd() - calculation.rowTrackBounds[row].getStart());
+
+            return { x, y, w, h };
         }
 
         template <typename RoundingFunction>

--- a/modules/juce_gui_basics/layout/juce_Grid.cpp
+++ b/modules/juce_gui_basics/layout/juce_Grid.cpp
@@ -182,11 +182,9 @@ struct Grid::Helpers
                         const auto absoluteSize = currentItem.getAbsoluteSize (relativeUnit);
 
                         if (! currentItem.isFractional())
-                            return roundingFunction (absoluteSize);
+                            return absoluteSize;
 
-                        const auto result = roundingFunction (absoluteSize - carriedError);
-                        carriedError += result - absoluteSize;
-                        return result;
+                        return absoluteSize;
                     }();
 
                     if (currentItem.isFractional())
@@ -194,7 +192,7 @@ struct Grid::Helpers
 
                     const auto end = start + currentTrackSize;
                     outBounds.emplace_back (start, end);
-                    start = end + roundingFunction (static_cast<float> (gap.pixels));
+                    start = end + static_cast<float> (gap.pixels);
                 }
             };
 
@@ -525,13 +523,12 @@ struct Grid::Helpers
             jassert (isPositiveAndBelow (correctedColumn, tracks.columns.items.size()));
             jassert (isPositiveAndBelow (correctedRow,    tracks.rows   .items.size()));
 
-            return
-            {
-                calculation.columnTrackBounds[(size_t) correctedColumn].getStart(),
-                calculation.rowTrackBounds[(size_t) correctedRow].getStart(),
-                calculation.columnTrackBounds[(size_t) correctedColumn].getEnd() - calculation.columnTrackBounds[(size_t) correctedColumn].getStart(),
-                calculation.rowTrackBounds[(size_t) correctedRow].getEnd() - calculation.rowTrackBounds[(size_t) correctedRow].getStart()
-            };
+            auto x = roundingFunction(calculation.columnTrackBounds[col].getStart());
+            auto y = roundingFunction(calculation.rowTrackBounds[row].getStart());
+            auto w = roundingFunction(calculation.columnTrackBounds[col].getEnd() - calculation.columnTrackBounds[col].getStart());
+            auto h = roundingFunction(calculation.rowTrackBounds[row].getEnd() - calculation.rowTrackBounds[row].getStart());
+
+            return { x, y, w, h };
         }
 
         template <typename RoundingFunction>


### PR DESCRIPTION
Changed the rounding function in grid.cpp so that it only applies after the final layout has been computated.

Please make sure you have read and followed our contribution guidelines (.github/contributing.md in this repository). Your pull request will not be accepted if you have not followed the instructions.

