### PR TITLE
SystemStats: Make Windows+Clang callCPUID() clear ECX like __cpuid()

### DIFF
--- a/modules/juce_core/native/juce_SystemStats_windows.cpp
+++ b/modules/juce_core/native/juce_SystemStats_windows.cpp
@@ -87,11 +87,12 @@ static void callCPUID (int result[4], uint32 type)
          lc = (uint32) result[2], ld = (uint32) result[3];
 
   asm ("mov %%ebx, %%esi \n\t"
+       "xor %%ecx, %%ecx \n\t"
        "cpuid \n\t"
        "xchg %%esi, %%ebx"
        : "=a" (la), "=S" (lb), "=c" (lc), "=d" (ld) : "a" (type)
         #if JUCE_64BIT
-     , "b" (lb), "c" (lc), "d" (ld)
+     , "b" (lb), "d" (ld)
         #endif
        );
 


### PR DESCRIPTION
This fixes AVX2 and AVX512 detection issues with clang-cl on Windows (https://forum.juce.com/t/bug-report-wrong-systemstats-hasavx2-result-with-clang-cl-64-bit/68580).
Previously, ECX could contain result from a previous callCPUID() call, so the result would be some other leaf, not EAX=7, ECX=0.