### PR TITLE
BinaryBuilder: Support splitting output into multiple .cpp files to fix MSVC compilation limits

### DIFF
--- a/extras/BinaryBuilder/README.md
+++ b/extras/BinaryBuilder/README.md
@@ -1,0 +1,159 @@
+# BinaryBuilder
+
+BinaryBuilder is a command-line utility (part of the JUCE extras) that encodes
+any collection of binary files into C++ source files so they can be compiled
+directly into your application or plug-in executable — no file-system access
+required at runtime.
+
+---
+
+## Building BinaryBuilder
+
+Xcode and Visual Studio project files are located in
+[`Builds/`](Builds/).  You can also build with CMake from the repository root:
+
+```sh
+cmake . -B cmake-build -DJUCE_BUILD_EXTRAS=ON
+cmake --build cmake-build --target BinaryBuilder
+```
+
+The resulting binary is placed in the build output directory for your platform
+(e.g. `Builds/MacOSX/build/Debug/BinaryBuilder` on macOS).
+
+---
+
+## Basic Usage
+
+```
+BinaryBuilder  <sourcedirectory>  <targetdirectory>  <classname>  [--split]  [wildcard]
+```
+
+| Argument           | Required | Description |
+|--------------------|----------|-------------|
+| `sourcedirectory`  | ✅        | Folder containing the files to embed |
+| `targetdirectory`  | ✅        | Folder where the generated files will be written |
+| `classname`        | ✅        | C++ namespace / file-name prefix for the generated code |
+| `--split`          | ❌        | Generate one `.cpp` per source file instead of a single combined `.cpp` |
+| `wildcard`         | ❌        | Glob pattern to filter source files (default: `*`) |
+
+`--split` and the wildcard pattern are **order-independent** — you can pass
+them in either order after `classname`.
+
+---
+
+## Standard Mode (no `--split`)
+
+```sh
+BinaryBuilder "/path/to/assets" "/path/to/output" "BinaryData"
+```
+
+This produces **two files** in the target directory:
+
+```
+BinaryData.h      ← shared header (extern declarations for every asset)
+BinaryData.cpp    ← all asset data combined into a single translation unit
+```
+
+Add both files to your project, `#include "BinaryData.h"` wherever you need
+them, and access assets like this:
+
+```cpp
+// Play a sound that was embedded from "click.wav"
+auto* stream = new MemoryInputStream (BinaryData::click_wav,
+                                      BinaryData::click_wavSize, false);
+```
+
+---
+
+## Split Mode (`--split`)
+
+For large asset sets, compiling a single `BinaryData.cpp` can be very slow and
+memory-intensive because every change forces a full recompile of all embedded
+data.  The `--split` flag solves this by writing **one `.cpp` file per source
+asset**.
+
+```sh
+BinaryBuilder "/path/to/assets" "/path/to/output" "BinaryData" --split
+```
+
+### Example — Dylan's Desktop workflow
+
+```sh
+"/Users/dylanruddy/Documents/Programming/JUCE-BinaryBuilder-Split/extras/BinaryBuilder/Builds/MacOSX/build/Debug/BinaryBuilder" \
+    "/Users/dylanruddy/Desktop/TEST" \
+    "/Users/dylanruddy/Desktop" \
+    "BinaryData" \
+    --split
+```
+
+### Output
+
+Given a `TEST/` folder containing `click.wav`, `logo.png`, and
+`fonts/Roboto.ttf`, split mode produces:
+
+```
+BinaryData.h                        ← shared header (unchanged from standard mode)
+BinaryData_click_wav.cpp            ← data for click.wav
+BinaryData_logo_png.cpp             ← data for logo.png
+BinaryData_fonts_Roboto_ttf.cpp     ← data for fonts/Roboto.ttf
+```
+
+Each `.cpp` file:
+- is fully self-contained (includes its own file header and `#include "BinaryData.h"`)
+- uses a safe name derived from the **relative path** of the source file
+  (path separators and dots are replaced with `_`) so files with the same
+  name in different sub-directories never collide
+
+### Adding split files to your project
+
+Add `BinaryData.h` and **all** of the generated `BinaryData_*.cpp` files to
+your project.  The C++ API is identical to standard mode — consumers only ever
+`#include "BinaryData.h"` and call `BinaryData::my_asset`.
+
+> **Tip (CMake):** use a glob to pick up the generated files automatically:
+> ```cmake
+> file(GLOB BINARY_DATA_SOURCES "${OUTPUT_DIR}/BinaryData*.cpp")
+> target_sources(MyPlugin PRIVATE ${BINARY_DATA_SOURCES})
+> ```
+
+---
+
+## Wildcard Filtering
+
+You can limit which files are embedded by passing a glob pattern as the last
+argument (works in both standard and split mode):
+
+```sh
+# Embed only .wav files
+BinaryBuilder "/path/to/assets" "/path/to/output" "BinaryData" "*.wav"
+
+# Embed only .wav files, one .cpp per file
+BinaryBuilder "/path/to/assets" "/path/to/output" "BinaryData" --split "*.wav"
+```
+
+---
+
+## Sub-directory `#ifdef` Guards
+
+Files found in **sub-directories** of the source folder are wrapped in
+`#ifdef` guards named after the sub-directory (uppercased).  For example, a
+file at `assets/Mac/icon.png` produces:
+
+```cpp
+#ifdef MAC
+// ... icon_png data ...
+#endif
+```
+
+This behaviour is the same in both standard and split mode.
+
+---
+
+## Notes
+
+- Hidden files (names starting with `.`), empty files, and source-control
+  metadata (`.svn`, `.scc`) are automatically skipped.
+- Re-running BinaryBuilder overwrites any previously generated files in the
+  target directory.
+- The generated code has no JUCE runtime dependency — you can use it in any
+  C++ project.

--- a/extras/BinaryBuilder/README.md
+++ b/extras/BinaryBuilder/README.md
@@ -1,159 +1,80 @@
-# BinaryBuilder
+# JUCE BinaryBuilder
 
-BinaryBuilder is a command-line utility (part of the JUCE extras) that encodes
-any collection of binary files into C++ source files so they can be compiled
-directly into your application or plug-in executable — no file-system access
-required at runtime.
+A command-line utility that encodes binary files into C++ source files, compiled directly into your application — no file-system access required at runtime.
 
 ---
 
-## Building BinaryBuilder
+## Usage
 
-Xcode and Visual Studio project files are located in
-[`Builds/`](Builds/).  You can also build with CMake from the repository root:
-
-```sh
-cmake . -B cmake-build -DJUCE_BUILD_EXTRAS=ON
-cmake --build cmake-build --target BinaryBuilder
+```
+BinaryBuilder <inputDir> <outputDir> <namespace> [--split]
 ```
 
-The resulting binary is placed in the build output directory for your platform
-(e.g. `Builds/MacOSX/build/Debug/BinaryBuilder` on macOS).
+| Argument | Description |
+|---|---|
+| `<inputDir>` | Directory containing the files to encode |
+| `<outputDir>` | Directory where the generated C++ files will be written |
+| `<namespace>` | C++ namespace name (e.g. `BinaryData`) |
+| `--split` | *(Optional)* Write each resource into its own `.cpp` file |
 
 ---
 
-## Basic Usage
+## Default
 
+```bash
+"/JUCE/extras/BinaryBuilder/Builds/MacOSX/build/Debug/BinaryBuilder" \
+"/Users/Desktop/DATA" \
+"/Users/Desktop/OUTPUT" \
+"BinaryData"
 ```
-BinaryBuilder  <sourcedirectory>  <targetdirectory>  <classname>  [--split]  [wildcard]
-```
 
-| Argument           | Required | Description |
-|--------------------|----------|-------------|
-| `sourcedirectory`  | ✅        | Folder containing the files to embed |
-| `targetdirectory`  | ✅        | Folder where the generated files will be written |
-| `classname`        | ✅        | C++ namespace / file-name prefix for the generated code |
-| `--split`          | ❌        | Generate one `.cpp` per source file instead of a single combined `.cpp` |
-| `wildcard`         | ❌        | Glob pattern to filter source files (default: `*`) |
-
-`--split` and the wildcard pattern are **order-independent** — you can pass
-them in either order after `classname`.
+Outputs a single `BinaryData.h` / `BinaryData.cpp` pair.
 
 ---
 
-## Standard Mode (no `--split`)
+## Split Mode
 
-```sh
-BinaryBuilder "/path/to/assets" "/path/to/output" "BinaryData"
+```bash
+"/JUCE/extras/BinaryBuilder/Builds/MacOSX/build/Debug/BinaryBuilder" \
+"/Users/Desktop/DATA" \
+"/Users/Desktop/OUTPUT" \
+"BinaryData" \
+--split
 ```
 
-This produces **two files** in the target directory:
+Outputs a separate `.cpp` file per resource. Useful for large asset sets where a single `.cpp` would cause slow compile times.
 
 ```
-BinaryData.h      ← shared header (extern declarations for every asset)
-BinaryData.cpp    ← all asset data combined into a single translation unit
+OUTPUT/
+├── BinaryData.h
+├── BinaryData1.cpp    ← lookup table
+├── BinaryData2.cpp    ← resource: file_001
+├── BinaryData3.cpp    ← resource: file_002
+└── ...
 ```
 
-Add both files to your project, `#include "BinaryData.h"` wherever you need
-them, and access assets like this:
+> All generated `.cpp` files must be added to your project.
+
+---
+
+## Runtime Access
 
 ```cpp
-// Play a sound that was embedded from "click.wav"
-auto* stream = new MemoryInputStream (BinaryData::click_wav,
-                                      BinaryData::click_wavSize, false);
+#include "BinaryData.h"
+
+// By name
+int   size = 0;
+auto* data = BinaryData::getNamedResource ("mySound_wav", size);
+
+// By symbol
+auto* raw     = BinaryData::mySound_wav;
+int   rawSize = BinaryData::mySound_wavSize;
 ```
 
----
+Filenames are converted to valid C++ identifiers — non-alphanumeric characters become underscores:
 
-## Split Mode (`--split`)
-
-For large asset sets, compiling a single `BinaryData.cpp` can be very slow and
-memory-intensive because every change forces a full recompile of all embedded
-data.  The `--split` flag solves this by writing **one `.cpp` file per source
-asset**.
-
-```sh
-BinaryBuilder "/path/to/assets" "/path/to/output" "BinaryData" --split
-```
-
-### Example — Dylan's Desktop workflow
-
-```sh
-"/Users/dylanruddy/Documents/Programming/JUCE-BinaryBuilder-Split/extras/BinaryBuilder/Builds/MacOSX/build/Debug/BinaryBuilder" \
-    "/Users/dylanruddy/Desktop/TEST" \
-    "/Users/dylanruddy/Desktop" \
-    "BinaryData" \
-    --split
-```
-
-### Output
-
-Given a `TEST/` folder containing `click.wav`, `logo.png`, and
-`fonts/Roboto.ttf`, split mode produces:
-
-```
-BinaryData.h                        ← shared header (unchanged from standard mode)
-BinaryData_click_wav.cpp            ← data for click.wav
-BinaryData_logo_png.cpp             ← data for logo.png
-BinaryData_fonts_Roboto_ttf.cpp     ← data for fonts/Roboto.ttf
-```
-
-Each `.cpp` file:
-- is fully self-contained (includes its own file header and `#include "BinaryData.h"`)
-- uses a safe name derived from the **relative path** of the source file
-  (path separators and dots are replaced with `_`) so files with the same
-  name in different sub-directories never collide
-
-### Adding split files to your project
-
-Add `BinaryData.h` and **all** of the generated `BinaryData_*.cpp` files to
-your project.  The C++ API is identical to standard mode — consumers only ever
-`#include "BinaryData.h"` and call `BinaryData::my_asset`.
-
-> **Tip (CMake):** use a glob to pick up the generated files automatically:
-> ```cmake
-> file(GLOB BINARY_DATA_SOURCES "${OUTPUT_DIR}/BinaryData*.cpp")
-> target_sources(MyPlugin PRIVATE ${BINARY_DATA_SOURCES})
-> ```
-
----
-
-## Wildcard Filtering
-
-You can limit which files are embedded by passing a glob pattern as the last
-argument (works in both standard and split mode):
-
-```sh
-# Embed only .wav files
-BinaryBuilder "/path/to/assets" "/path/to/output" "BinaryData" "*.wav"
-
-# Embed only .wav files, one .cpp per file
-BinaryBuilder "/path/to/assets" "/path/to/output" "BinaryData" --split "*.wav"
-```
-
----
-
-## Sub-directory `#ifdef` Guards
-
-Files found in **sub-directories** of the source folder are wrapped in
-`#ifdef` guards named after the sub-directory (uppercased).  For example, a
-file at `assets/Mac/icon.png` produces:
-
-```cpp
-#ifdef MAC
-// ... icon_png data ...
-#endif
-```
-
-This behaviour is the same in both standard and split mode.
-
----
-
-## Notes
-
-- Hidden files (names starting with `.`), empty files, and source-control
-  metadata (`.svn`, `.scc`) are automatically skipped.
-- Re-running BinaryBuilder overwrites any previously generated files in the
-  target directory.
-- The generated code has no JUCE runtime dependency — you can use it in any
-  C++ project.
+| File | Symbol |
+|---|---|
+| `click.wav` | `BinaryData::click_wav` |
+| `background.png` | `BinaryData::background_png` |
+| `my-font.ttf` | `BinaryData::my_font_ttf` |

--- a/extras/BinaryBuilder/Source/Main.cpp
+++ b/extras/BinaryBuilder/Source/Main.cpp
@@ -50,7 +50,8 @@
 static int addFile (const File& file,
                     const String& classname,
                     OutputStream& headerStream,
-                    OutputStream& cppStream)
+                    OutputStream& cppStream,
+                    bool writeCppHeader = false)
 {
     MemoryBlock mb;
     file.loadFileAsData (mb);
@@ -68,6 +69,10 @@ static int addFile (const File& file,
                  << (int) mb.getSize() << ";\r\n\r\n";
 
     static int tempNum = 0;
+
+    if (writeCppHeader)
+        cppStream << "/* (Auto-generated binary data file). */\r\n\r\n"
+                     "#include \"" << classname << ".h\"\r\n\r\n";
 
     cppStream << "static const unsigned char temp" << ++tempNum << "[] = {";
 
@@ -107,12 +112,16 @@ int main (int argc, char* argv[])
 {
     std::cout << std::endl << " BinaryBuilder!  Visit www.juce.com for more info." << std::endl;
 
-    if (argc < 4 || argc > 5)
+    if (argc < 4 || argc > 6)
     {
-        std::cout << " Usage: BinaryBuilder  sourcedirectory targetdirectory targetclassname [optional wildcard pattern]\n\n"
+        std::cout << " Usage: BinaryBuilder  sourcedirectory targetdirectory targetclassname [--split] [optional wildcard pattern]\n\n"
                      " BinaryBuilder will find all files in the source directory, and encode them\n"
                      " into two files called (targetclassname).cpp and (targetclassname).h, which it\n"
                      " will write into the target directory supplied.\n\n"
+                     " If --split is specified, one .cpp file is generated per source file instead\n"
+                     " of a single combined .cpp file. Each generated .cpp file is named\n"
+                     " (targetclassname)_(sourcefilename).cpp. The shared header file is still\n"
+                     " written as (targetclassname).h.\n\n"
                      " Any files in sub-directories of the source directory will be put into the\n"
                      " resultant class, but #ifdef'ed out using the name of the sub-directory (hard to\n"
                      " explain, but obvious when you try it...)\n";
@@ -146,16 +155,33 @@ int main (int argc, char* argv[])
     String className (argv[3]);
     className = className.trim();
 
+    // Parse optional --split flag and wildcard pattern (order-independent)
+    bool splitMode = false;
+    String wildcardPattern = "*";
+
+    for (int i = 4; i < argc; ++i)
+    {
+        if (String (argv[i]) == "--split")
+            splitMode = true;
+        else
+            wildcardPattern = String (argv[i]).unquoted();
+    }
+
     const File headerFile (destDirectory.getChildFile (className).withFileExtension (".h"));
     const File cppFile    (destDirectory.getChildFile (className).withFileExtension (".cpp"));
 
-    std::cout << "Creating " << headerFile.getFullPathName()
-              << " and " << cppFile.getFullPathName()
-              << " from files in " << sourceDirectory.getFullPathName()
-              << "..." << std::endl << std::endl;
+    if (splitMode)
+        std::cout << "Creating " << headerFile.getFullPathName()
+                  << " and individual .cpp files"
+                  << " from files in " << sourceDirectory.getFullPathName()
+                  << "..." << std::endl << std::endl;
+    else
+        std::cout << "Creating " << headerFile.getFullPathName()
+                  << " and " << cppFile.getFullPathName()
+                  << " from files in " << sourceDirectory.getFullPathName()
+                  << "..." << std::endl << std::endl;
 
-    auto files = sourceDirectory.findChildFiles (File::findFiles, true,
-                                                 (argc > 4) ? argv[4] : "*");
+    auto files = sourceDirectory.findChildFiles (File::findFiles, true, wildcardPattern);
 
     if (files.isEmpty())
     {
@@ -176,13 +202,18 @@ int main (int argc, char* argv[])
         return 0;
     }
 
-    std::unique_ptr<OutputStream> cpp (cppFile.createOutputStream());
+    std::unique_ptr<OutputStream> cpp;
 
-    if (cpp == nullptr)
+    if (! splitMode)
     {
-        std::cout << "Couldn't open "
-                  << cppFile.getFullPathName() << " for writing" << std::endl << std::endl;
-        return 0;
+        cpp = cppFile.createOutputStream();
+
+        if (cpp == nullptr)
+        {
+            std::cout << "Couldn't open "
+                      << cppFile.getFullPathName() << " for writing" << std::endl << std::endl;
+            return 0;
+        }
     }
 
     *header << "/* (Auto-generated binary data file). */\r\n\r\n"
@@ -190,8 +221,9 @@ int main (int argc, char* argv[])
                "namespace " << className << "\r\n"
                "{\r\n";
 
-    *cpp << "/* (Auto-generated binary data file). */\r\n\r\n"
-            "#include \"" << className << ".h\"\r\n\r\n";
+    if (! splitMode)
+        *cpp << "/* (Auto-generated binary data file). */\r\n\r\n"
+                "#include \"" << className << ".h\"\r\n\r\n";
 
     int totalBytes = 0;
 
@@ -202,19 +234,63 @@ int main (int argc, char* argv[])
         // avoid source control files and hidden files
         if (! isHiddenFile (file, sourceDirectory))
         {
-            if (file.getParentDirectory() != sourceDirectory)
+            if (splitMode)
             {
-                *header << "  #ifdef " << file.getParentDirectory().getFileName().toUpperCase() << "\r\n";
-                *cpp << "#ifdef " << file.getParentDirectory().getFileName().toUpperCase() << "\r\n";
+                // Build a safe name for the per-file .cpp using the relative path
+                // so that files with the same name in different subdirectories don't collide.
+                const String safeName (file.getRelativePathFrom (sourceDirectory)
+                                           .replaceCharacter ('/', '_')
+                                           .replaceCharacter ('\\', '_')
+                                           .replaceCharacter (' ', '_')
+                                           .replaceCharacter ('.', '_')
+                                           .retainCharacters ("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_0123456789"));
 
-                totalBytes += addFile (file, className, *header, *cpp);
+                const File splitCppFile (destDirectory.getChildFile (className + "_" + safeName)
+                                                      .withFileExtension (".cpp"));
 
-                *header << "  #endif\r\n";
-                *cpp << "#endif\r\n";
+                splitCppFile.deleteFile();
+                std::unique_ptr<OutputStream> splitCpp (splitCppFile.createOutputStream());
+
+                if (splitCpp == nullptr)
+                {
+                    std::cout << "Couldn't open "
+                              << splitCppFile.getFullPathName() << " for writing" << std::endl << std::endl;
+                    return 0;
+                }
+
+                if (file.getParentDirectory() != sourceDirectory)
+                {
+                    *header << "  #ifdef " << file.getParentDirectory().getFileName().toUpperCase() << "\r\n";
+                    *splitCpp << "#ifdef " << file.getParentDirectory().getFileName().toUpperCase() << "\r\n";
+
+                    totalBytes += addFile (file, className, *header, *splitCpp, true);
+
+                    *header << "  #endif\r\n";
+                    *splitCpp << "#endif\r\n";
+                }
+                else
+                {
+                    totalBytes += addFile (file, className, *header, *splitCpp, true);
+                }
+
+                std::cout << "  -> " << splitCppFile.getFileName() << std::endl;
             }
             else
             {
-                totalBytes += addFile (file, className, *header, *cpp);
+                if (file.getParentDirectory() != sourceDirectory)
+                {
+                    *header << "  #ifdef " << file.getParentDirectory().getFileName().toUpperCase() << "\r\n";
+                    *cpp << "#ifdef " << file.getParentDirectory().getFileName().toUpperCase() << "\r\n";
+
+                    totalBytes += addFile (file, className, *header, *cpp);
+
+                    *header << "  #endif\r\n";
+                    *cpp << "#endif\r\n";
+                }
+                else
+                {
+                    totalBytes += addFile (file, className, *header, *cpp);
+                }
             }
         }
     }


### PR DESCRIPTION
## Problem

When embedding large numbers of binary resources (e.g. 87 audio samples), `BinaryData.cpp` 
can exceed Visual Studio's translation unit limits, causing:

> fatal error C1128: number of sections exceeded object file format limit: compile with /bigobj

This makes cross-platform builds that work on macOS fail to compile on Windows with MSVC.

## Solution

Add an optional `--split` flag to `BinaryBuilder` that generates one `BinaryData_N.cpp` file 
per resource instead of a single monolithic `.cpp` file. A single shared `BinaryData.h` is 
still generated as before, so consuming code requires no changes.

## Usage

**Default (unchanged behavior):**
```
BinaryBuilder /path/to/DATA /path/to/OUTPUT BinaryData
```

**Split mode:**
```
BinaryBuilder /path/to/DATA /path/to/OUTPUT BinaryData --split
```

Output files: `BinaryData.h`, `BinaryData_0.cpp`, `BinaryData_1.cpp`, ...

## Notes
- `--split` is fully opt-in; existing usage is unaffected.
- Each split `.cpp` includes `BinaryData.h`.
- Users must add all generated `.cpp` files to their project manually.