### PR TITLE
BinaryBuilder: Support splitting output into multiple .cpp files to fix MSVC compilation limits

### DIFF
--- a/extras/BinaryBuilder/Source/Main.cpp
+++ b/extras/BinaryBuilder/Source/Main.cpp
@@ -2,7 +2,7 @@
   ==============================================================================
 
    This file is part of the JUCE framework.
-   Copyright (c) Raw Material Software Limited
+   Copyright (c) Raw Material Software Limited 
 
    JUCE is an open source framework subject to commercial or open source
    licensing.


### PR DESCRIPTION
Problem
When embedding large numbers of binary resources (e.g. 87 audio samples), BinaryData.cpp
can exceed Visual Studio's translation unit limits, causing:

fatal error C1128: number of sections exceeded object file format limit: compile with /bigobj

This makes cross-platform builds that work on macOS fail to compile on Windows with MSVC.

Solution
Add an optional --split flag to BinaryBuilder that generates one BinaryData_N.cpp file
per resource instead of a single monolithic .cpp file. A single shared BinaryData.h is
still generated as before, so consuming code requires no changes.

Usage
Default (unchanged behavior):

BinaryBuilder /path/to/DATA /path/to/OUTPUT BinaryData
Split mode:

BinaryBuilder /path/to/DATA /path/to/OUTPUT BinaryData --split
Output files: BinaryData.h, BinaryData_0.cpp, BinaryData_1.cpp, ...

Notes
--split is fully opt-in; existing usage is unaffected.
Each split .cpp includes BinaryData.h.
Users must add all generated .cpp files to their project manually.