### PR TITLE
iOS: Reload input view instead of restarting when changing text input target

### DIFF
--- a/modules/juce_gui_basics/native/juce_UIViewComponentPeer_ios.mm
+++ b/modules/juce_gui_basics/native/juce_UIViewComponentPeer_ios.mm
@@ -2293,11 +2293,10 @@ void UIViewComponentPeer::grabFocus()
 
 void UIViewComponentPeer::textInputRequired (Point<int>, TextInputTarget&)
 {
-    // We need to restart the text input session so that the keyboard can change types if necessary.
     if ([hiddenTextInput.get() isFirstResponder])
-        [hiddenTextInput.get() resignFirstResponder];
-
-    [hiddenTextInput.get() becomeFirstResponder];
+        [hiddenTextInput.get() reloadInputViews];
+    else
+        [hiddenTextInput.get() becomeFirstResponder];
 }
 
 void UIViewComponentPeer::closeInputMethodContext()


### PR DESCRIPTION
Restarting the text input session causes the keyboard to hide and show unnecessarily - no need for that as reloading the input views is enough to update the keyboard type.

