### PR TITLE
macOS: Stop disposing of objc classes at exit, as it causes rare crashes

### DIFF
--- a/modules/juce_core/native/juce_ObjCHelpers_mac.h
+++ b/modules/juce_core/native/juce_ObjCHelpers_mac.h
@@ -319,10 +319,18 @@ struct ObjCClass
 
     ~ObjCClass()
     {
-        auto kvoSubclassName = String ("NSKVONotifying_") + class_getName (cls);
-
-        if (objc_getClass (kvoSubclassName.toUTF8()) == nullptr)
-            objc_disposeClassPair (cls);
+        // Intentionally NOT calling objc_disposeClassPair(cls).
+        //
+        // ObjCClass instances are almost always function-local statics, so this
+        // destructor only fires during static destruction at process exit.
+        //
+        // At that time, if the runtime still holds *any* reference to cls, such
+        // as KVO shadows, accessibility subclasses, AppKit shadow classes, etc,
+        // it may cause a crash.
+        //
+        // Given that the OS will reclaim everything at process exit, it is not
+        // worth the risk of crashing just to "properly" dispose of the class.
+        // There is no benefit, and crashing at exit can cause grief for users.
     }
 
     ObjCClass (ObjCClass&& other) noexcept


### PR DESCRIPTION
I have found that depending on the situation, anywhere from 0.1% to 1% of my standalone JUCE application launches end up crashing at exit due to objc_disposeClassPair() being called on a class that is still referenced.

This doesn't seem to be new. I have found several forum posts over the years that relate to this problem:

* https://forum.juce.com/t/warning-message-displayed-when-exiting-the-demo-application/20904
* https://forum.juce.com/t/warning-messages-on-startup/25389
* https://forum.juce.com/t/objc-warnings-at-exit-since-catalina-switch/40712

I noticed this causing crashes for me, and built some simple tooling to launch a basic application thousands of times, and it the crashes are complete reproducible, even for a headless app that doesn't even open a physical OS window. Exactly what is required to reproduce the crash is very hard to say; I first noticed it under MallocScribble on macOS Sequoia/Tahoe (Darwin 25.3.0), so it is likely that it requires certain memory circumstances to become a crash rather than just a warning.

The thing is: all of the ObjCClass objects that JUCE uses have static lifetime. So there's really no benefit to calling objc_disposeClassPair() -- the class will be cleaned up when the process terminates. Whatever the perceived benefit of "proper cleanup" it is outweighed by the fact that it causes crashes (or user confusion due to the warnings).

The simplest solution is to just give up on objc_disposeClassPair(). I don't see any concrete downside to this, and this change will fix crashes that I see regularly as well as questions on the forums about the warnings.