### PR TITLE
Fix builds on non-glibc

### DIFF
--- a/modules/juce_core/juce_core.cpp
+++ b/modules/juce_core/juce_core.cpp
@@ -108,9 +108,10 @@
  #include <net/if.h>
  #include <sys/ioctl.h>
 
- #if ! (JUCE_ANDROID || JUCE_WASM)
-  #include <execinfo.h>
- #endif
+#if defined(__has_include) && __has_include(<execinfo.h>)
+ #define JUCE_HAS_EXECINFO 1
+ #include <execinfo.h>
+#endif
 #endif
 
 #if JUCE_MAC || JUCE_IOS

--- a/modules/juce_core/native/juce_SharedCode_posix.h
+++ b/modules/juce_core/native/juce_SharedCode_posix.h
@@ -175,7 +175,7 @@ inline int juce_siginterrupt ([[maybe_unused]] int sig, [[maybe_unused]] int fla
 //==============================================================================
 namespace
 {
-   #if JUCE_LINUX || (JUCE_IOS && (! TARGET_OS_MACCATALYST) && (! __DARWIN_ONLY_64_BIT_INO_T)) // (this iOS stuff is to avoid a simulator bug)
+   #if defined(__GLIBC__) || (JUCE_IOS && (! TARGET_OS_MACCATALYST) && (! __DARWIN_ONLY_64_BIT_INO_T)) // (this iOS stuff is to avoid a simulator bug)
     using juce_statStruct = struct stat64;
     #define JUCE_STAT  stat64
    #else

--- a/modules/juce_core/native/juce_SystemStats_linux.cpp
+++ b/modules/juce_core/native/juce_SystemStats_linux.cpp
@@ -206,7 +206,7 @@ String SystemStats::getComputerName()
 
 String SystemStats::getUserLanguage()
 {
-   #if JUCE_BSD
+   #if ! defined(__GLIBC__)
     if (auto langEnv = getenv ("LANG"))
         return String::fromUTF8 (langEnv).upToLastOccurrenceOf (".UTF-8", false, true);
 
@@ -218,7 +218,7 @@ String SystemStats::getUserLanguage()
 
 String SystemStats::getUserRegion()
 {
-   #if JUCE_BSD
+   #if ! defined(__GLIBC__)
     return {};
    #else
     return getLocaleValue (_NL_ADDRESS_COUNTRY_AB2);

--- a/modules/juce_core/system/juce_SystemStats.cpp
+++ b/modules/juce_core/system/juce_SystemStats.cpp
@@ -190,10 +190,7 @@ String SystemStats::getStackBacktrace()
 {
     String result;
 
-   #if JUCE_ANDROID || JUCE_WASM
-    jassertfalse; // sorry, not implemented yet!
-
-   #elif JUCE_WINDOWS
+   #if JUCE_WINDOWS
     HANDLE process = GetCurrentProcess();
     SymInitialize (process, nullptr, TRUE);
 
@@ -224,7 +221,7 @@ String SystemStats::getStackBacktrace()
         }
     }
 
-   #else
+   #elif JUCE_HAS_EXECINFO
     void* stack[128];
     auto frames = backtrace (stack, numElementsInArray (stack));
     char** frameStrings = backtrace_symbols (stack, frames);
@@ -233,6 +230,8 @@ String SystemStats::getStackBacktrace()
         result << frameStrings[i] << newLine;
 
     ::free (frameStrings);
+   #else
+    jassertfalse; // sorry, not implemented yet!
    #endif
 
     return result;


### PR DESCRIPTION
These two patches fix builds on non-glibc Linux (e.g.: musl/Linux):

- Check that `execinfo.h` exists using the `__has_include` before using it. This is more flexible than the current platform-based approach; execinfo will be used on any target where it's present and excluded if absent.
- Use `stat64` workaround only on glibc. Previously this was used unconditionally on any Linux, but this workaround is only necessary on glibc specifically.
- Also check for glibc explicitly for using glibc extensions rather than non-BSD. Same rationale.

