### PR TITLE
Stopped MessageThread quit messages being posted multiple times on MacOS

### DIFF
--- a/modules/juce_events/native/juce_MessageManager_mac.mm
+++ b/modules/juce_events/native/juce_MessageManager_mac.mm
@@ -360,6 +360,11 @@ void MessageManager::stopDispatchLoop()
 {
     if (isThisTheMessageThread())
     {
+        if (quitMessagePosted.get())
+        {
+            return;
+        }
+        
         quitMessagePosted = true;
         shutdownNSApp();
     }


### PR DESCRIPTION
On MacOS if multiple quit messages are posted to the message thread before the app has managed to quit an exception of type NSInternalInconsistencyException will be thrown. The easiest way to test this is to create a blank juce GUI app and call juce::JUCEApplicationBase::quit() twice in a row in the initialise() function.

This fix changes it so that if a quit message has been posted, another cannot be posted.
