### PR TITLE
VST3: Avoid re-querying parameter count while initialising parameters

### DIFF
--- a/modules/juce_audio_processors_headless/format_types/juce_VST3PluginFormatImpl.h
+++ b/modules/juce_audio_processors_headless/format_types/juce_VST3PluginFormatImpl.h
@@ -3108,7 +3108,9 @@ private:
             cachedParamValues = CachedParamValues { std::move (allIds) };
         }
 
-        for (int i = 0; i < editController->getParameterCount(); ++i)
+        const auto parameterCount = editController->getParameterCount();
+
+        for (int i = 0; i < parameterCount; ++i)
         {
             auto* param = new VST3Parameter (*this, i);
             const auto paramInfo = param->getParameterInfo();


### PR DESCRIPTION
## Summary

This changes the VST3 hosted-parameter initialisation loop to snapshot
`IEditController::getParameterCount()` once before enumerating parameters.

The existing code re-queries `getParameterCount()` in the loop condition while constructing
`VST3Parameter` wrappers and fetching parameter info. We saw Neural DSP's
`Archetype Gojira X.vst3` fail to instantiate through JUCE's VST3 hosting path until this count was
made stable for the initialisation pass.

`getAllParamIDs()` already follows the same snapshot-before-iteration pattern nearby.

Related issue: #1659

## Testing

- Ran `git diff --check`
- Verified the local change fixes loading `Archetype Gojira X.vst3` in the downstream host
