### PR TITLE
Fix a rare crash on shutdown due to MidiInput / CriticalSection destruction order

### DIFF
--- a/modules/juce_audio_devices/audio_io/juce_AudioDeviceManager.cpp
+++ b/modules/juce_audio_devices/audio_io/juce_AudioDeviceManager.cpp
@@ -206,6 +206,7 @@ AudioDeviceManager::AudioDeviceManager()
 
 AudioDeviceManager::~AudioDeviceManager()
 {
+    enabledMidiInputs.clear();
     currentAudioDevice.reset();
     defaultMidiOutput.reset();
 }


### PR DESCRIPTION
This crash presents as:

> EXCEPTION_ACCESS_VIOLATION_WRITE / 0x24: Fatal Error: EXCEPTION_ACCESS_VIOLATION_WRITE / 0x24
>   ?, in RtlpWaitOnCriticalSection
>   ?, in RtlpEnterCriticalSectionContended
>   ?, in RtlEnterCriticalSection
>   ?, in juce::AudioDeviceManager::CallbackHandler::handleIncomingMidiMessage
>   ?, in `juce::MidiInput::Impl::consume'::`8'::<T>::operator()
> ...
> (20 additional frame(s) were not displayed)

It's due to the order in which `enabledMidiInputs` and `midiCallbackLock` are declared in the header: `midiCallbackLock` is destroyed *before* `enabledMidiInputs`. So the midi input callback can race and access the already-destroyed CriticalSection, causing this crash.