### PR TITLE
Use lowercase dbghelp include for MinGW

### DIFF
--- a/modules/juce_core/juce_core.cpp
+++ b/modules/juce_core/juce_core.cpp
@@ -62,7 +62,7 @@
  #include <ctime>
 
  JUCE_BEGIN_IGNORE_WARNINGS_MSVC (4091)
- #include <Dbghelp.h>
+ #include <dbghelp.h>
  JUCE_END_IGNORE_WARNINGS_MSVC
 
  #if ! JUCE_DONT_AUTOLINK_TO_WIN32_LIBRARIES


### PR DESCRIPTION
## Summary

Change the Windows DbgHelp include in juce_core from `<Dbghelp.h>` to `<dbghelp.h>`.

Windows/MSVC header lookup is case-insensitive, but MinGW cross-compiles on case-sensitive filesystems provide this header as lowercase `dbghelp.h`. This mirrors the existing lowercase `uiautomation.h` include used elsewhere in JUCE.

## Verification

On Debian Trixie with `g++-mingw-w64-x86-64` and `mingw-w64-x86-64-dev`:

- `#include <Dbghelp.h>` fails with `fatal error: Dbghelp.h: No such file or directory`
- `#include <dbghelp.h>` compiles successfully
- A small test including `<windows.h>`, `<dbghelp.h>`, and `<uiautomation.h>` compiles successfully with `x86_64-w64-mingw32-g++-posix -std=c++17`
