### PR TITLE
Update VST3 module paths on Linux; ./lib64, debian/ubuntu multiarch, /opt

### DIFF
--- a/modules/juce_audio_processors/format_types/juce_VST3PluginFormat.cpp
+++ b/modules/juce_audio_processors/format_types/juce_VST3PluginFormat.cpp
@@ -638,10 +638,90 @@ void VST3PluginFormat::createPluginInstance (const PluginDescription& descriptio
                                              int,
                                              PluginCreationCallback callback)
 {
+<<<<<<< HEAD
     createVst3InstanceImpl<VST3PluginInstance> (*this,
                                                 { new VST3HostContextWithContextMenu, IncrementRef::no },
                                                 description,
                                                 callback);
+=======
+    for (const auto& file : getLibraryPaths (description.fileOrIdentifier))
+    {
+        if (auto result = createVST3Instance (*this, description, file))
+        {
+            callback (std::move (result), {});
+            return;
+        }
+    }
+
+    callback (nullptr, TRANS ("Unable to load XXX plug-in file").replace ("XXX", "VST-3"));
+}
+
+bool VST3PluginFormat::requiresUnblockedMessageThreadDuringCreation (const PluginDescription&) const
+{
+    return false;
+}
+
+bool VST3PluginFormat::fileMightContainThisPluginType (const String& fileOrIdentifier)
+{
+    auto f = File::createFileWithoutCheckingPath (fileOrIdentifier);
+
+    return f.hasFileExtension (".vst3") && f.exists();
+}
+
+String VST3PluginFormat::getNameOfPluginFromIdentifier (const String& fileOrIdentifier)
+{
+    return fileOrIdentifier; //Impossible to tell because every VST3 is a type of shell...
+}
+
+bool VST3PluginFormat::pluginNeedsRescanning (const PluginDescription& description)
+{
+    return File (description.fileOrIdentifier).getLastModificationTime() != description.lastFileModTime;
+}
+
+bool VST3PluginFormat::doesPluginStillExist (const PluginDescription& description)
+{
+    return File (description.fileOrIdentifier).exists();
+}
+
+StringArray VST3PluginFormat::searchPathsForPlugins (const FileSearchPath& directoriesToSearch, const bool recursive, bool)
+{
+    StringArray results;
+
+    for (int i = 0; i < directoriesToSearch.getNumPaths(); ++i)
+        recursiveFileSearch (results, directoriesToSearch[i], recursive);
+
+    return results;
+}
+
+void VST3PluginFormat::recursiveFileSearch (StringArray& results, const File& directory, const bool recursive)
+{
+    for (const auto& iter : RangedDirectoryIterator (directory, false, "*", File::findFilesAndDirectories))
+    {
+        auto f = iter.getFile();
+        bool isPlugin = false;
+
+        if (fileMightContainThisPluginType (f.getFullPathName()))
+        {
+            isPlugin = true;
+            results.add (f.getFullPathName());
+        }
+
+        if (recursive && (! isPlugin) && f.isDirectory())
+            recursiveFileSearch (results, f, true);
+    }
+}
+
+FileSearchPath VST3PluginFormat::getDefaultLocationsToSearch()
+{
+   #if JUCE_WINDOWS
+    const auto localAppData = File::getSpecialLocation (File::windowsLocalAppData)        .getFullPathName();
+    const auto programFiles = File::getSpecialLocation (File::globalApplicationsDirectory).getFullPathName();
+    return FileSearchPath (localAppData + "\\Programs\\Common\\VST3;" + programFiles + "\\Common Files\\VST3");
+   #elif JUCE_MAC
+    return FileSearchPath ("~/Library/Audio/Plug-Ins/VST3;/Library/Audio/Plug-Ins/VST3");
+   #else
+    return FileSearchPath ("~/.vst3/;/usr/lib/vst3/;/usr/lib64/vst3/;/usr/local/lib/vst3/;/usr/local/lib64/vst3/;/opt/vst3/");
+   #endif
 }
 
 JUCE_END_NO_SANITIZE

--- a/modules/juce_audio_processors/format_types/juce_VST3PluginFormat.cpp
+++ b/modules/juce_audio_processors/format_types/juce_VST3PluginFormat.cpp
@@ -638,12 +638,11 @@ void VST3PluginFormat::createPluginInstance (const PluginDescription& descriptio
                                              int,
                                              PluginCreationCallback callback)
 {
-<<<<<<< HEAD
     createVst3InstanceImpl<VST3PluginInstance> (*this,
                                                 { new VST3HostContextWithContextMenu, IncrementRef::no },
                                                 description,
                                                 callback);
-=======
+
     for (const auto& file : getLibraryPaths (description.fileOrIdentifier))
     {
         if (auto result = createVST3Instance (*this, description, file))

--- a/modules/juce_audio_processors/format_types/juce_VST3PluginFormat.cpp
+++ b/modules/juce_audio_processors/format_types/juce_VST3PluginFormat.cpp
@@ -720,7 +720,8 @@ FileSearchPath VST3PluginFormat::getDefaultLocationsToSearch()
    #elif JUCE_MAC
     return FileSearchPath ("~/Library/Audio/Plug-Ins/VST3;/Library/Audio/Plug-Ins/VST3");
    #else
-    return FileSearchPath ("~/.vst3/;/usr/lib/vst3/;/usr/lib64/vst3/;/usr/local/lib/vst3/;/usr/local/lib64/vst3/;/opt/vst3/");
+    // NOTE: Keep this list in sync with VST3_SDK/public.sdk/source/vst/hosting/module_linux.cpp::getModulePaths()
+    return FileSearchPath ("~/.vst3/;/usr/lib/vst3/;/usr/lib64/vst3/;/usr/lib/x86_64-linux-gnu/vst3/;/usr/lib/i386-linux-gnu/vst3/;/usr/lib/arm-linux-gnueabihf/vst3/;/usr/lib/aarch64-linux-gnu/vst3/;/usr/lib/riscv64-linux-gnu/vst3/;/usr/local/lib/vst3/;/usr/local/lib64/vst3/;/usr/local/lib/x86_64-linux-gnu/vst3/;/usr/local/lib/i386-linux-gnu/vst3/;/usr/local/lib/arm-linux-gnueabihf/vst3/;/usr/local/lib/aarch64-linux-gnu/vst3/;/usr/local/lib/riscv64-linux-gnu/vst3/;/opt/vst3/");
    #endif
 }
 

--- a/modules/juce_audio_processors_headless/format_types/VST3_SDK/public.sdk/source/vst/hosting/module_linux.cpp
+++ b/modules/juce_audio_processors_headless/format_types/VST3_SDK/public.sdk/source/vst/hosting/module_linux.cpp
@@ -264,8 +264,10 @@ Module::PathList Module::getModulePaths ()
 {
 	/* VST3 component locations on linux :
 	 * User privately installed	: $HOME/.vst3/
-	 * Distribution installed	: /usr/lib/vst3/, /usr/lib64/vst3/, /usr/lib/<arch>-linux-gnu/vst3/	 *   Supported architectures: x86_64, i386, arm-linux-gnueabihf, aarch64, riscv64	 * Locally installed		: /usr/local/lib/vst3/, /usr/local/lib64/vst3/, /usr/local/lib/<arch>-linux-gnu/vst3/, /opt/vst3/
+	 * Distribution installed	: /usr/lib/vst3/, /usr/lib64/vst3/, /usr/lib/<arch>-linux-gnu/vst3/
+	 * Locally installed		: /usr/local/lib/vst3/, /usr/local/lib64/vst3/, /usr/local/lib/<arch>-linux-gnu/vst3/, /opt/vst3/
 	 * Application				: /$APPFOLDER/vst3/
+	 * Supported architectures  : x86_64, i386, arm-linux-gnueabihf, aarch64, riscv64
 	 * NOTE: Keep this list in sync with juce_VST3PluginFormat.cpp::getDefaultLocationsToSearch()
 	 */
 

--- a/modules/juce_audio_processors_headless/format_types/VST3_SDK/public.sdk/source/vst/hosting/module_linux.cpp
+++ b/modules/juce_audio_processors_headless/format_types/VST3_SDK/public.sdk/source/vst/hosting/module_linux.cpp
@@ -264,22 +264,26 @@ Module::PathList Module::getModulePaths ()
 {
 	/* VST3 component locations on linux :
 	 * User privately installed	: $HOME/.vst3/
-	 * Distribution installed	: /usr/lib/vst3/, /usr/lib64/vst3/
-	 * Locally installed		: /usr/local/lib/vst3/, /usr/local/lib64/vst3/, /opt/vst3/
+	 * Distribution installed	: /usr/lib/vst3/, /usr/lib64/vst3/, /usr/lib/<arch>-linux-gnu/vst3/	 *   Supported architectures: x86_64, i386, arm-linux-gnueabihf, aarch64, riscv64	 * Locally installed		: /usr/local/lib/vst3/, /usr/local/lib64/vst3/, /usr/local/lib/<arch>-linux-gnu/vst3/, /opt/vst3/
 	 * Application				: /$APPFOLDER/vst3/
+	 * NOTE: Keep this list in sync with juce_VST3PluginFormat.cpp::getDefaultLocationsToSearch()
 	 */
 
-	const auto systemPaths = {"/usr/lib/vst3/", "/usr/lib64/vst3/", "/usr/local/lib/vst3/", "/usr/local/lib64/vst3/", "/opt/vst3/"};
+	const auto systemPaths = {"/usr/lib/vst3/", "/usr/lib64/vst3/", "/usr/lib/x86_64-linux-gnu/vst3/", "/usr/lib/i386-linux-gnu/vst3/", "/usr/lib/arm-linux-gnueabihf/vst3/", "/usr/lib/aarch64-linux-gnu/vst3/", "/usr/lib/riscv64-linux-gnu/vst3/", "/usr/local/lib/vst3/", "/usr/local/lib64/vst3/", "/usr/local/lib/x86_64-linux-gnu/vst3/", "/usr/local/lib/i386-linux-gnu/vst3/", "/usr/local/lib/arm-linux-gnueabihf/vst3/", "/usr/local/lib/aarch64-linux-gnu/vst3/", "/usr/local/lib/riscv64-linux-gnu/vst3/", "/opt/vst3/"};
 
 	PathList list;
 	if (auto homeDir = getenv ("HOME"))
 	{
 		filesystem::path homePath (homeDir);
 		homePath /= ".vst3";
-		findModules (homePath.generic_string (), list);
+		if (filesystem::exists(homePath))
+			findModules (homePath.generic_string (), list);
 	}
 	for (auto path : systemPaths)
-		findModules (path, list);
+	{
+		if (filesystem::exists(path))
+			findModules (path, list);
+	}
 
 	// application level
 	auto appPath = getApplicationPath ();

--- a/modules/juce_audio_processors_headless/format_types/VST3_SDK/public.sdk/source/vst/hosting/module_linux.cpp
+++ b/modules/juce_audio_processors_headless/format_types/VST3_SDK/public.sdk/source/vst/hosting/module_linux.cpp
@@ -264,12 +264,12 @@ Module::PathList Module::getModulePaths ()
 {
 	/* VST3 component locations on linux :
 	 * User privately installed	: $HOME/.vst3/
-	 * Distribution installed	: /usr/lib/vst3/
-	 * Locally installed		: /usr/local/lib/vst3/
+	 * Distribution installed	: /usr/lib/vst3/, /usr/lib64/vst3/
+	 * Locally installed		: /usr/local/lib/vst3/, /usr/local/lib64/vst3/, /opt/vst3/
 	 * Application				: /$APPFOLDER/vst3/
 	 */
 
-	const auto systemPaths = {"/usr/lib/vst3/", "/usr/local/lib/vst3/"};
+	const auto systemPaths = {"/usr/lib/vst3/", "/usr/lib64/vst3/", "/usr/local/lib/vst3/", "/usr/local/lib64/vst3/", "/opt/vst3/"};
 
 	PathList list;
 	if (auto homeDir = getenv ("HOME"))


### PR DESCRIPTION
- This adds a bunch of paths to vst3 systemPaths list and also filters the list according to filesystem::exists at the time that getModulePaths() is run