### PR TITLE
Fix VST3 COM Ptr incorrect initialization in headless format (#1673)

### DIFF
--- a/modules/juce_audio_processors_headless/format_types/juce_VST3PluginFormatHeadless.cpp
+++ b/modules/juce_audio_processors_headless/format_types/juce_VST3PluginFormatHeadless.cpp
@@ -74,7 +74,7 @@ void VST3PluginFormatHeadless::findAllTypesForFile (OwnedArray<PluginDescription
         if (pluginFactory == nullptr)
             continue;
 
-        VSTComSmartPtr host { new VST3HostContextHeadless(), IncrementRef::yes };
+        VSTComSmartPtr host { new VST3HostContextHeadless(), IncrementRef::no };
 
         for (const auto& d : DescriptionLister::findDescriptionsSlow (*host, *pluginFactory, File (file)))
             results.add (new PluginDescription (d));


### PR DESCRIPTION
### Description
This PR fixes a memory leak during headless VST3 scanning, as reported in #1673.
The VSTComSmartPtr host was incorrectly initialized with IncrementRef::yes, resulting in an incorrect reference count of 2. Changed it to IncrementRef::no to match the standard initialization behavior of other VST3 host context pointers in the codebase.

Fixes #1673.

