### PR TITLE
Fix unbalanced COM refcount in findAllTypesForFile (#1665)

### DIFF
--- a/modules/juce_audio_processors_headless/format_types/juce_VST3PluginFormatHeadless.cpp
+++ b/modules/juce_audio_processors_headless/format_types/juce_VST3PluginFormatHeadless.cpp
@@ -74,7 +74,7 @@ void VST3PluginFormatHeadless::findAllTypesForFile (OwnedArray<PluginDescription
         if (pluginFactory == nullptr)
             continue;
 
-        VSTComSmartPtr host { new VST3HostContextHeadless(), IncrementRef::yes };
+        VSTComSmartPtr host { new VST3HostContextHeadless(), IncrementRef::no };
 
         for (const auto& d : DescriptionLister::findDescriptionsSlow (*host, *pluginFactory, File (file)))
             results.add (new PluginDescription (d));


### PR DESCRIPTION
This PR fixes a memory leak where `VST3HostContextHeadless` instances are leaked when scanning plugins via `findAllTypesForFile()`. 

Using `IncrementRef::yes` on creation increments the refcount to 2, causing the object to persist after the temporary smart pointer goes out of scope. Changing it to `IncrementRef::no` properly balances the reference count, matching the behavior already present in `createPluginInstance()`.

Fixes #1665.
