### PR TITLE
Linux: Detect Renoise's out-of-process plug-in host

### DIFF
--- a/modules/juce_audio_processors/utilities/juce_PluginHostType.cpp
+++ b/modules/juce_audio_processors/utilities/juce_PluginHostType.cpp
@@ -316,6 +316,12 @@ PluginHostType::HostType PluginHostType::getHostType()
     if (hostFilename.startsWith           ("Bitwig"))            return BitwigStudio;
     if (hostFilename.containsIgnoreCase   ("pluginval"))         return pluginval;
     if (hostFilename.containsIgnoreCase   ("AudioPluginHost"))   return JUCEPluginHost;
+    // Renoise hosts plug-ins in a separate process named "AudioPluginServer_*",
+    // so the host filename never contains "Renoise"; only the versioned install
+    // path (".../renoise-X.Y.Z/...") does. Test the path too so the host is
+    // still recognised when running out of process.
+    if (hostPath.containsIgnoreCase       ("Renoise")
+        || hostFilename.containsIgnoreCase("Renoise"))           return Renoise;
 
    #elif JUCE_IOS
    #elif JUCE_ANDROID


### PR DESCRIPTION
On Linux, Renoise runs plug-ins in a separate process named AudioPluginServer_*, so the host filename never contains "Renoise" and PluginHostType could not identify the host. The versioned install path (.../renoise-X.Y.Z/...) does contain it, so test the host path as well. This mirrors the Windows and macOS branches, which already fall back to the host path to recognise several hosts.