### PR TITLE
Linux: Fix FileChooser ignoring the initial directory with zenity

### DIFF
--- a/modules/juce_gui_basics/native/juce_FileChooser_linux.cpp
+++ b/modules/juce_gui_basics/native/juce_FileChooser_linux.cpp
@@ -265,10 +265,23 @@ private:
         else
             File::getSpecialLocation (File::userHomeDirectory).setAsCurrentWorkingDirectory();
 
-        auto filename = owner.startingFile.getFileName();
+        // zenity needs an absolute path in --filename: a bare relative name is
+        // ignored and the dialog falls back to $HOME. For a directory, a trailing
+        // separator tells zenity to open inside it rather than selecting it within
+        // its parent.
+        String startPath;
 
-        if (! filename.isEmpty())
-            args.add ("--filename=" + filename);
+        if (owner.startingFile.isDirectory())
+            startPath = File::addTrailingSeparator (owner.startingFile.getFullPathName());
+        else if (owner.startingFile.getParentDirectory().exists())
+            startPath = owner.startingFile.getFullPathName();
+        else if (owner.startingFile.getFileName().isNotEmpty())
+            startPath = File::getSpecialLocation (File::userHomeDirectory)
+                            .getChildFile (owner.startingFile.getFileName())
+                            .getFullPathName();
+
+        if (startPath.isNotEmpty())
+            args.add ("--filename=" + startPath);
 
         // supplying the window ID of the topmost window makes sure that Zenity pops up..
         if (uint64 topWindowID = getTopWindowID())


### PR DESCRIPTION
### Summary

On Linux, a `FileChooser` constructed with an initial directory opens in `$HOME` instead of that directory when the zenity backend is used (the default on non-KDE sessions). The kdialog backend is unaffected.

### Cause

`addZenityArgs()` changes the working directory to the target folder and then passes only `startingFile.getFileName()`, a bare, relative basename, as `--filename`. zenity/GTK does not resolve a relative `--filename`, so it is ignored and the dialog falls back to `$HOME`. When the starting location is a directory, `getFileName()` returns the directory's own leaf name, which is never what's intended.

### Fix

Pass an absolute path in `--filename`. For a directory, append a trailing separator so zenity opens *inside* the folder rather than pre-selecting it within its parent. This mirrors what the kdialog branch already does (it passes a full path).

```
zenity --file-selection --filename=/home/user/Documents/Presets/
```

### Testing

Verified on Wayland with zenity 4.2.1: open, save, and import dialogs now start in the requested directory (presets, environments, recording-output folders) instead of `$HOME`.
