### PR TITLE
AAX: Fix editor size on Windows when DPI scaling moves off the master scale

### DIFF
--- a/modules/juce_audio_plugin_client/juce_audio_plugin_client_AAX.cpp
+++ b/modules/juce_audio_plugin_client/juce_audio_plugin_client_AAX.cpp
@@ -569,7 +569,8 @@ namespace AAXClasses
             if (component != nullptr)
             {
                 *viewSize = convertToHostBounds ({ (float) component->getHeight(),
-                                                   (float) component->getWidth() });
+                                                   (float) component->getWidth() },
+                                                 component.get());
 
                 return AAX_SUCCESS;
             }
@@ -626,15 +627,23 @@ namespace AAXClasses
         AAX_CParamID getAAXParamIDFromJuceIndex (int index) const noexcept;
 
         //==============================================================================
-        static AAX_Point convertToHostBounds (AAX_Point pluginSize)
+        static AAX_Point convertToHostBounds (AAX_Point pluginSize, const Component* comp)
         {
-            auto desktopScale = Desktop::getInstance().getGlobalScaleFactor();
+            // The host works in physical pixels. The logical-to-physical scale is
+            // the global scale times the window's platform scale; depending on the
+            // platform's DPI awareness either term may carry the factor, so apply
+            // both.
+            auto scale = (float) Desktop::getInstance().getGlobalScaleFactor();
 
-            if (approximatelyEqual (desktopScale, 1.0f))
+            if (comp != nullptr)
+                if (auto* peer = comp->getPeer())
+                    scale *= (float) peer->getPlatformScaleFactor();
+
+            if (approximatelyEqual (scale, 1.0f))
                 return pluginSize;
 
-            return { pluginSize.vert * desktopScale,
-                     pluginSize.horz * desktopScale };
+            return { pluginSize.vert * scale,
+                     pluginSize.horz * scale };
         }
 
         //==============================================================================
@@ -720,7 +729,8 @@ namespace AAXClasses
                 if (pluginEditor != nullptr)
                 {
                     auto newSize = convertToHostBounds ({ (float) pluginEditor->getHeight(),
-                                                          (float) pluginEditor->getWidth() });
+                                                          (float) pluginEditor->getWidth() },
+                                                        this);
 
                     return owner.GetViewContainer()->SetViewSize (newSize) == AAX_SUCCESS;
                 }


### PR DESCRIPTION
### Summary

On Windows, the AAX wrapper reports the editor size to the host in the wrong units when the DPI factor is carried by the window's platform scale rather than the desktop master scale. The host receives logical-sized bounds and clips the physical-resolution editor. This is reproducible in Pro Tools at any Windows display scale above 100%: the plugin UI overflows its window and is clipped.

### Regression

This is a regression introduced by 8bbe48c1 ("Windows: Use 1.0 as the master scale if DPI awareness is available"). That commit changed `Desktop::getDefaultMasterScale()` to return `1.0` whenever DPI awareness is available:

```diff
 double Desktop::getDefaultMasterScale()
 {
-    if (isPerMonitorDPIAwareProcess())
+    if (setDPIAwareness())
         return 1.0;

     return getGlobalDPI() / USER_DEFAULT_SCREEN_DPI;
}
```

Previously only *per-monitor*-aware processes got a master scale of `1.0`; a *system*-DPI-aware process (which is how Pro Tools runs) got `getGlobalDPI() / 96` (e.g. `1.25`), and the DPI factor therefore lived on the master scale. After 8bbe48c1 the master scale for those processes is `1.0` and the DPI factor lives on the window's platform scale (`ComponentPeer::getPlatformScaleFactor()`) instead. The peer-based paths (VST3, mouse/window positioning) were updated to match, but the AAX host-bounds conversion still reads only the master scale, so it silently became a no-op for system-DPI-aware hosts and started reporting logical bounds as physical.

### Root cause

`ContentWrapperComponent::convertToHostBounds` scales the editor's logical size into the host's physical pixels by multiplying by `getGlobalScaleFactor()` (the desktop master scale) only:

```cpp
auto desktopScale = Desktop::getInstance().getGlobalScaleFactor();
```

Pro Tools runs system-DPI-aware, so after 8bbe48c1 its master scale is `1.0` and its platform scale is the monitor DPI (e.g. `1.25`). With the master scale alone, `convertToHostBounds` reports logical bounds as physical, so the host sizes the view too small while the editor still paints at physical resolution - hence the overflow and clipping.

### Fix

Multiply by both the global (master) scale and the window's platform scale, so the full logical-to-physical factor is applied regardless of which term carries the DPI factor. The product is invariant to where 8bbe48c1 leaves it: pre-8bbe48c1 the master scale held the DPI factor and the platform scale was `1.0`; post-8bbe48c1 the split is reversed. Either way the product is the true logical-to-physical scale, so this restores the pre-regression sizing without depending on which term the DPI factor is stored in.

### Testing

- Pro Tools on Windows at 100%, 125%, and 150% display scaling: the editor now fills its window with no clipping, and resizing behaves correctly.