### PR TITLE
Component: Avoid sending mouse-drag events to a component whose mouse-down was consumed by a modal component

### DIFF
--- a/modules/juce_gui_basics/components/juce_Component.cpp
+++ b/modules/juce_gui_basics/components/juce_Component.cpp
@@ -2612,6 +2612,13 @@ void Component::internalMouseUp (SafePointer<Component> target,
 
 void Component::internalMouseDrag (SafePointer<Component> target, MouseInputSource source, const detail::PointerState& relativePointerState, Time time)
 {
+    // If the mouse-down that started this drag was blocked by a modal component, the
+    // rest of the gesture shouldn't be delivered either, even if the modal component
+    // has since been dismissed - the target never received the mouse-down that these
+    // drag events would continue.
+    if (target->flags.mouseDownWasBlocked)
+        return;
+
     if (! target->isCurrentlyBlockedByAnotherModalComponent())
     {
         const auto me = makeMouseEvent (source,


### PR DESCRIPTION
Dragging a window's bottom-right corner resizer can snap the window instantly to its minimum size, if a CallOutBox happened to be open when the drag started. More generally, any component that captures state in mouseDown then runs its mouseDrag against stale state, because it received the drag without ever receiving the press.

That happens when a modal component consumes the mouse-down but dismisses itself asynchronously, as a CallOutBox with setDismissalMouseClicksAreAlwaysConsumed (true) does via postCommandMessage. The component under the mouse never gets the mouse-down, but internalMouseDrag only checks whether the target is blocked at the time each drag event arrives, so once the modal component finishes going away mid-gesture the drags get delivered anyway. In the resizer case, ResizableCornerComponent::originalBounds was never set.

Repro:

1. Make a window resizable with setResizable (true, true) and give it a constrainer with a minimum size
2. Open a CallOutBox with setDismissalMouseClicksAreAlwaysConsumed (true)
3. Click and drag the corner resizer
4. The window snaps to its minimum size instead of ignoring the drag

internalMouseUp already checks mouseDownWasBlocked before delivering, so this just applies the same check to mouseDrag: if the press that started the gesture was swallowed by a modal component, the drags shouldn't be delivered either.
