### PR TITLE
Audio formats: Harden WAV/AIFF parsers against three malformed-input issues

### DIFF
--- a/modules/juce_audio_formats/codecs/juce_AiffAudioFormat.cpp
+++ b/modules/juce_audio_formats/codecs/juce_AiffAudioFormat.cpp
@@ -549,6 +549,7 @@ public:
                     }
                     else if (type == chunkName ("INST"))
                     {
+                        length = (uint32) jmin ((int64) length, input->getNumBytesRemaining());
                         HeapBlock<InstChunk> inst;
                         inst.calloc (jmax ((size_t) length + 1, sizeof (InstChunk)), 1);
                         input->read (inst, (int) length);

--- a/modules/juce_audio_formats/codecs/juce_AiffAudioFormat.cpp
+++ b/modules/juce_audio_formats/codecs/juce_AiffAudioFormat.cpp
@@ -594,9 +594,14 @@ public:
 
         input->setPosition (dataChunkStart + startSampleInFile * bytesPerFrame);
 
+        const int tempBufSize = 480 * 3 * 4; // (keep this a multiple of 3)
+
+        // a frame larger than the buffer truncates numThisTime to zero, so the loop would never terminate
+        if (bytesPerFrame <= 0 || bytesPerFrame > tempBufSize)
+            return false;
+
         while (numSamples > 0)
         {
-            const int tempBufSize = 480 * 3 * 4; // (keep this a multiple of 3)
             char tempBuffer [tempBufSize];
 
             const int numThisTime = jmin (tempBufSize / bytesPerFrame, numSamples);

--- a/modules/juce_audio_formats/codecs/juce_AiffAudioFormat.cpp
+++ b/modules/juce_audio_formats/codecs/juce_AiffAudioFormat.cpp
@@ -256,7 +256,7 @@ namespace AiffFileHelpers
             {
                 bool isGenre = false;
 
-                if (isValidTag (data))
+                if (data + 2 < dataEnd && isValidTag (data))
                 {
                     auto tag = String (CharPointer_UTF8 (data), CharPointer_UTF8 (dataEnd));
                     isGenre = isAppleGenre (tag);

--- a/modules/juce_audio_formats/codecs/juce_WavAudioFormat.cpp
+++ b/modules/juce_audio_formats/codecs/juce_WavAudioFormat.cpp
@@ -1494,9 +1494,14 @@ public:
 
         input->setPosition (dataChunkStart + startSampleInFile * bytesPerFrame);
 
+        const int tempBufSize = 480 * 3 * 4; // (keep this a multiple of 3)
+
+        // a frame larger than the buffer truncates numThisTime to zero, so the loop would never terminate
+        if (bytesPerFrame <= 0 || bytesPerFrame > tempBufSize)
+            return false;
+
         while (numSamples > 0)
         {
-            const int tempBufSize = 480 * 3 * 4; // (keep this a multiple of 3)
             char tempBuffer[tempBufSize];
 
             auto numThisTime = jmin (tempBufSize / bytesPerFrame, numSamples);

--- a/modules/juce_audio_formats/codecs/juce_WavAudioFormat.cpp
+++ b/modules/juce_audio_formats/codecs/juce_WavAudioFormat.cpp
@@ -1350,6 +1350,7 @@ public:
                     bwavChunkStart = input->getPosition();
                     bwavSize = length;
 
+                    length = (uint32) jmin ((int64) length, input->getNumBytesRemaining());
                     HeapBlock<BWAVChunk> bwav;
                     bwav.calloc (jmax ((size_t) length + 1, sizeof (BWAVChunk)), 1);
                     input->read (bwav, (int) length);
@@ -1357,6 +1358,7 @@ public:
                 }
                 else if (chunkType == chunkName ("smpl"))
                 {
+                    length = (uint32) jmin ((int64) length, input->getNumBytesRemaining());
                     HeapBlock<SMPLChunk> smpl;
                     smpl.calloc (jmax ((size_t) length + 1, sizeof (SMPLChunk)), 1);
                     input->read (smpl, (int) length);
@@ -1364,6 +1366,7 @@ public:
                 }
                 else if (chunkType == chunkName ("inst") || chunkType == chunkName ("INST")) // need to check which...
                 {
+                    length = (uint32) jmin ((int64) length, input->getNumBytesRemaining());
                     HeapBlock<InstChunk> inst;
                     inst.calloc (jmax ((size_t) length + 1, sizeof (InstChunk)), 1);
                     input->read (inst, (int) length);
@@ -1371,6 +1374,7 @@ public:
                 }
                 else if (chunkType == chunkName ("cue "))
                 {
+                    length = (uint32) jmin ((int64) length, input->getNumBytesRemaining());
                     HeapBlock<CueChunk> cue;
                     cue.calloc (jmax ((size_t) length + 1, sizeof (CueChunk)), 1);
                     input->read (cue, (int) length);


### PR DESCRIPTION
Three memory-safety / DoS fixes in the WAV and AIFF parsers, reached through
the normal createReaderFor + read path on an untrusted file. Each is a
separate commit.

### 1. Clamp metadata chunk length before allocating
The `bext`/`smpl`/`inst`/`cue` WAV chunks and the AIFF `INST` chunk pass an
untrusted 32-bit chunk length straight to `HeapBlock::calloc` before checking
the stream holds that many bytes. A tiny file declaring a ~4 GB chunk requests
a ~4 GB allocation: benign lazy zero-fill on 64-bit, but a failed allocation
and null dereference on 32-bit. Clamp the length to `getNumBytesRemaining()`
first.

### 2. Reject a sample frame larger than the read buffer
`readSamples` copies whole frames through a fixed 5760-byte temp buffer, sizing
each batch with `tempBufSize / bytesPerFrame`. `bytesPerFrame` comes from
untrusted header fields with no upper bound, so a frame larger than the buffer
truncates that division to zero: no samples are consumed and the loop never
terminates — a tiny malformed file hangs the reading thread on every platform.
Bail out before the loop when a single frame can't fit. Affects both the AIFF
and WAV readers (the WAV `bitsPerSample <= 32` gate doesn't prevent it — a high
channel count reaches the same state).

### 3. Bounds-check the cate tag read
`CATEChunk::read` walks the chunk body with a `while (data < dataEnd)` guard
that only guarantees one byte is in bounds, but `isValidTag` dereferences three.
When `data` lands one or two bytes short of the end, it reads past the block.
Require three bytes of headroom, matching the guards already used later in the
same loop.