### PR TITLE
DragAndDropContainer: Document support for dragging between windows

### DIFF
--- a/modules/juce_gui_basics/mouse/juce_DragAndDropContainer.h
+++ b/modules/juce_gui_basics/mouse/juce_DragAndDropContainer.h
@@ -48,6 +48,12 @@ namespace juce
     callbacks to any child components derived from DragAndDropTarget which the mouse
     moves over.
 
+    By default, a drop can only be received by DragAndDropTargets inside this container. To
+    allow targets in the application's other windows to receive it too, pass true for
+    startDragging()'s allowDraggingToOtherJuceWindows parameter. The drag image then becomes a
+    desktop window of its own, and targets are found by hit-testing the desktop, so a drag can
+    be dropped onto a target in any window belonging to the same application.
+
     Note: If all that you need to do is to respond to files being drag-and-dropped from
     the operating system onto your component, you don't need any of these classes: you can do this
     simply by overriding FileDragAndDropTarget::filesDropped().


### PR DESCRIPTION
## What

Adds a paragraph to the `DragAndDropContainer` class documentation noting that a drag can be dropped onto targets in the application's other windows, and pointing at the `allowDraggingToOtherJuceWindows` parameter of `startDragging()`.

Documentation only. No functional change.

## Why

The class comment currently describes a drag as being delivered to "any child components derived from DragAndDropTarget which the mouse moves over", which reads as though a drop is confined to the container's own window. Cross-window support does exist, but it is reachable only through the fourth positional parameter of `startDragging()`, it defaults to `false`, and it is documented solely in that parameter's own `@param` entry.

Someone reading the class documentation to find out whether JUCE can do this comes away believing it cannot.

As evidence that this is a real failure mode rather than a hypothetical one: I hand-rolled cross-window dragging across roughly 180 lines and five files in [Keys](https://github.com/owenpkent/Keys), a VST3 plugin that drags chords from a detached window onto a pad strip in the main editor. I had concluded from this class comment that the framework did not support it. Three separate comments in that codebase state it as settled fact:

> The drag crosses windows, and nothing in JUCE does that for free. [...] a `DragAndDropContainer` would never see the drop

> no drag-and-drop container spans two desktop windows, so the source cannot find this component and this component never sees the mouse

> The drag crosses two top-level windows, which JUCE gives nothing for: a `DragAndDropContainer` only ever sees a drop inside its own window

All three are wrong. The hand-rolled version locates its target with `juce::Desktop::findComponentAt()` followed by a walk up the parent chain, which is close to exactly what `findDesktopComponentBelow()` and `findTarget()` already do. Had the class comment mentioned the capability, none of it would have been written.

The implementation has supported this for a long time: `startDragging()` puts the drag image on the desktop when the flag is set, which makes `getParentComponent()` null in `findTarget()` and routes target lookup through `findDesktopComponentBelow()`, iterating every desktop component in z-order before walking up the parent chain for an interested `DragAndDropTarget`.

The added paragraph goes in the class comment so the capability is visible to someone deciding whether the class fits their problem, rather than only to someone who has already chosen it and is reading the parameter list.
