### PR TITLE
Fix: prevent duplicate mousemove listeners in WebViewPluginDemoGUI

### DIFF
--- a/examples/Plugins/WebViewPluginDemoGUI/src/App.tsx
+++ b/examples/Plugins/WebViewPluginDemoGUI/src/App.tsx
@@ -76,7 +76,7 @@ function JuceSlider({
 
   const changeCommitted = (
     _event: SyntheticEvent | Event,
-    newValue: number | number[]
+    newValue: number | number[],
   ) => {
     sliderState.setNormalisedValue(newValue as number);
     sliderState.sliderDragEnded();
@@ -87,7 +87,7 @@ function JuceSlider({
       setValue(sliderState.getNormalisedValue());
     });
     const propertiesListenerId = sliderState.propertiesChangedEvent.addListener(
-      () => setProperties(sliderState.properties)
+      () => setProperties(sliderState.properties),
     );
 
     return function cleanup() {
@@ -142,7 +142,7 @@ function JuceCheckbox({ identifier }: { identifier: string }) {
     });
     const propertiesListenerId =
       checkboxState.propertiesChangedEvent.addListener(() =>
-        setProperties(checkboxState.properties)
+        setProperties(checkboxState.properties),
       );
 
     return function cleanup() {
@@ -280,7 +280,7 @@ class SpectrumDataReceiver {
             for (const f of data.frames)
               self.buffer[mod(self.writeIndex++, self.bufferLength)] = f;
           });
-      }
+      },
     );
   }
 
@@ -306,13 +306,13 @@ class SpectrumDataReceiver {
     return interpolate(
       this.getBufferItem(integralPart),
       this.getBufferItem(integralPart + 1),
-      fractionalPart
+      fractionalPart,
     );
   }
 
   unregister() {
     window.__JUCE__.backend.removeEventListener(
-      this.spectrumDataRegistrationId
+      this.spectrumDataRegistrationId,
     );
   }
 }
@@ -345,7 +345,7 @@ function FreqBandInfo() {
             i * barWidth,
             barHeight - l * barHeight,
             barWidth,
-            l * barHeight
+            l * barHeight,
           );
         }
       }
@@ -383,16 +383,24 @@ function FreqBandInfo() {
 }
 
 function App() {
-  const controlParameterIndexUpdater = new Juce.ControlParameterIndexUpdater(
-    controlParameterIndexAnnotation
-  );
-
-  document.addEventListener("mousemove", (event) => {
-    controlParameterIndexUpdater.handleMouseMove(event);
-  });
-
   const [open, setOpen] = useState(false);
   const [snackbarMessage, setMessage] = useState("No message received yet");
+
+  useEffect(() => {
+    const controlParameterIndexUpdater = new Juce.ControlParameterIndexUpdater(
+      controlParameterIndexAnnotation,
+    );
+
+    const handleMouseMove = (event: MouseEvent) => {
+      controlParameterIndexUpdater.handleMouseMove(event);
+    };
+
+    document.addEventListener("mousemove", handleMouseMove);
+
+    return () => {
+      document.removeEventListener("mousemove", handleMouseMove);
+    };
+  }, []);
 
   const openSnackbar = () => {
     setOpen(true);


### PR DESCRIPTION
## Summary
- `App` previously registered a `document` `mousemove` listener directly in the component body (not inside `useEffect`), so a new listener was added on every re-render without the old one being removed — a listener leak.
- Moves the listener registration into a `useEffect` with an empty dependency array and adds a cleanup function that removes it on unmount.

Discussed on the forum: https://forum.juce.com/t/event-listener-leak-in-the-webviewplugindemogui/69236

## Test plan
- [x] Run the WebView plugin demo GUI and confirm mouse-move driven parameter control still works.
- [x] Verify only one `mousemove` listener is attached after multiple re-renders (e.g. via `getEventListeners(document)` in devtools).