### PR TITLE
PopupMenu: Make manually-triggered custom items keyboard-accessible

### DIFF
--- a/modules/juce_gui_basics/menus/juce_PopupMenu.cpp
+++ b/modules/juce_gui_basics/menus/juce_PopupMenu.cpp
@@ -58,6 +58,16 @@ static bool canBeTriggered (const PopupMenu::Item& item) noexcept
         && (item.customComponent == nullptr || item.customComponent->isTriggeredAutomatically());
 }
 
+static bool canBeActivatedByKeyboard (const PopupMenu::Item& item) noexcept
+{
+    // Unlike canBeTriggered, this includes custom components that aren't triggered
+    // automatically: they handle their own mouse clicks, but should still be
+    // possible to highlight and activate with the keyboard.
+    return item.isEnabled
+        && item.itemID != 0
+        && ! item.isSectionHeader;
+}
+
 static bool hasActiveSubMenu (const PopupMenu::Item& item) noexcept
 {
     return item.isEnabled
@@ -643,7 +653,8 @@ struct MenuWindow final : public Component
         }
         else if (key.isKeyCode (KeyPress::returnKey) || key.isKeyCode (KeyPress::spaceKey))
         {
-            triggerCurrentlyHighlightedItem();
+            if (currentChild != nullptr && canBeActivatedByKeyboard (currentChild->item))
+                dismissMenu (&currentChild->item);
         }
         else if (key.isKeyCode (KeyPress::escapeKey))
         {
@@ -1268,7 +1279,7 @@ struct MenuWindow final : public Component
 
             if (auto* mic = items.getUnchecked ((start + items.size()) % items.size()))
             {
-                if (canBeTriggered (mic->item) || hasActiveSubMenu (mic->item))
+                if (canBeActivatedByKeyboard (mic->item) || hasActiveSubMenu (mic->item))
                 {
                     setCurrentlyHighlightedChild (mic);
                     return;


### PR DESCRIPTION
Custom menu items created with isTriggeredAutomatically=false handle their own mouse clicks, but the arrow keys skip over them and return/space cannot activate them, so a menu containing them is unusable from the keyboard.

To reproduce, add a custom item with addCustomItem (..., isTriggeredAutomatically = false), open the menu, and try to reach it with the arrow keys.

This lets them be highlighted like any other item and makes return/space dismiss the menu with the item's ID, which is exactly what CustomComponent::triggerMenuItem() does. Mouse handling still goes through canBeTriggered(), so nothing changes there.
