### PR TITLE
JACK: Stabilise requested channel masks during open

### DIFF
--- a/modules/juce_audio_devices/native/juce_JackAudio.cpp
+++ b/modules/juce_audio_devices/native/juce_JackAudio.cpp
@@ -289,6 +289,11 @@ public:
     String open (const BigInteger& inputChannels, const BigInteger& outputChannels,
                  double /* sampleRate */, int /* bufferSizeSamples */) override
     {
+        // The port connection callback may update the device manager's channel masks while this
+        // function is still running. Take copies so that the requested channels remain stable.
+        const auto requestedInputChannels = inputChannels;
+        const auto requestedOutputChannels = outputChannels;
+
         if (client == nullptr)
         {
             lastError = "No JACK client running";
@@ -307,11 +312,11 @@ public:
         juce::jack_activate (client);
         deviceIsOpen = true;
 
-        if (! inputChannels.isZero())
+        if (! requestedInputChannels.isZero())
         {
             forEachClientChannel (inputName, false, [&] (const char* portName, int index)
             {
-                if (! inputChannels[index])
+                if (! requestedInputChannels[index])
                     return;
 
                 jassert (index < inputPorts.size());
@@ -328,11 +333,11 @@ public:
             });
         }
 
-        if (! outputChannels.isZero())
+        if (! requestedOutputChannels.isZero())
         {
             forEachClientChannel (outputName, true, [&] (const char* portName, int index)
             {
-                if (! outputChannels[index])
+                if (! requestedOutputChannels[index])
                     return;
 
                 jassert (index < outputPorts.size());


### PR DESCRIPTION
## Summary

Snapshot the requested JACK input and output channel masks at the start of `JackAudioIODevice::open()`.

The masks passed by `AudioDeviceManager` may alias its mutable current setup. JACK port-connection callbacks can trigger a device-state refresh while `open()` is still connecting ports. Without a snapshot, the connection loops can observe partially updated masks and stop connecting requested channels.

## Observed failure

This was reproduced through a JUCE-based desktop audio application using PipeWire JACK and a Focusrite Scarlett 18i8:

- requested mask: 26 inputs / 2 outputs
- connection loop stopped after 6 inputs
- output mask became empty before output connections
- device validation then failed with 6 inputs / 0 outputs

With local copies of both requested masks, the same hardware completed duplex configuration successfully and the application persisted JACK as its active backend.

## Why this change

The copies are taken before JACK callbacks are installed and before the client is activated. The remainder of `open()` uses only these stable request snapshots. No public API or non-JACK backend is changed.

## Verification

- Built the current JUCE `develop` branch with `JUCE_JACK=1` in a minimal CMake console application.
- The verifier linked `juce_audio_devices` and ran successfully.
- The equivalent change was runtime-tested with the Scarlett 18i8 on the application's currently pinned JUCE revision, where it changed the failing partial connection into a successful duplex open.

Commit is signed off under DCO. I understand that JUCE also requires the contributor CLA.
