### PR TITLE
Windows: Allow opting back into Direct2D under Wine

### DIFF
--- a/modules/juce_core/juce_core.h
+++ b/modules/juce_core/juce_core.h
@@ -197,6 +197,24 @@
  #define JUCE_ENABLE_ALLOCATION_HOOKS 0
 #endif
 
+/** Config: JUCE_ALLOW_DIRECT2D_UNDER_WINE
+    On Windows, JUCE falls back to the software renderer when it detects that it is
+    running under Wine, because stock Wine does not implement the Direct2D and
+    DirectComposition surface that the Direct2D renderer needs. Wine remains an
+    unsupported platform either way.
+
+    Some Wine builds do implement that surface. Enabling this tells JUCE to use the
+    Direct2D renderer there anyway; you then own whatever follows. It can also be
+    enabled at run time by setting the JUCE_ALLOW_DIRECT2D_UNDER_WINE environment
+    variable to something other than "0", which lets a Wine distribution turn it on
+    for binaries it did not build itself.
+
+    This has no effect anywhere except under Wine.
+*/
+#ifndef JUCE_ALLOW_DIRECT2D_UNDER_WINE
+ #define JUCE_ALLOW_DIRECT2D_UNDER_WINE 0
+#endif
+
 #ifndef JUCE_STRING_UTF_TYPE
  #define JUCE_STRING_UTF_TYPE 8
 #endif

--- a/modules/juce_core/native/juce_Threads_windows.cpp
+++ b/modules/juce_core/native/juce_Threads_windows.cpp
@@ -306,6 +306,41 @@ bool juce_isRunningInWine()
     return ntdll != nullptr && GetProcAddress (ntdll, "wine_get_version") != nullptr;
 }
 
+/*  Whether the Direct2D render path should be avoided because we are on Wine.
+
+    Wine is not a supported platform, and by default this returns true for every
+    Wine build, which is what selects the software fallback. Some Wine builds do
+    implement the Direct2D 1.3 and DirectComposition surface that JUCE needs, and
+    on those the fallback is not wanted. Rather than requiring those users to
+    patch JUCE, they can opt back in and take responsibility for the result:
+
+      - define JUCE_ALLOW_DIRECT2D_UNDER_WINE=1 when building, or
+      - set the JUCE_ALLOW_DIRECT2D_UNDER_WINE environment variable to something
+        other than "0", which lets a Wine distribution enable it for binaries it
+        did not build.
+
+    Neither makes Wine supported; both are off unless explicitly requested, so the
+    default behaviour is unchanged.
+*/
+bool juce_shouldAvoidDirect2DUnderWine();
+bool juce_shouldAvoidDirect2DUnderWine()
+{
+    if (! juce_isRunningInWine())
+        return false;
+
+   #if JUCE_ALLOW_DIRECT2D_UNDER_WINE
+    return false;
+   #else
+    static const bool optedIn = []
+    {
+        const auto v = SystemStats::getEnvironmentVariable ("JUCE_ALLOW_DIRECT2D_UNDER_WINE", {}).trim();
+        return v.isNotEmpty() && v != "0";
+    }();
+
+    return ! optedIn;
+   #endif
+}
+
 //==============================================================================
 bool DynamicLibrary::open (const String& name)
 {

--- a/modules/juce_graphics/native/juce_Direct2DImage_windows.cpp
+++ b/modules/juce_graphics/native/juce_Direct2DImage_windows.cpp
@@ -1023,12 +1023,12 @@ auto Direct2DPixelData::getNativeExtensions() -> NativeExtensions
     return NativeExtensions { Wrapped { this } };
 }
 
-extern bool juce_isRunningInWine();
+extern bool juce_shouldAvoidDirect2DUnderWine();
 
 //==============================================================================
 ImagePixelData::Ptr NativeImageType::create (Image::PixelFormat format, int width, int height, bool clearImage) const
 {
-    if (! juce_isRunningInWine())
+    if (! juce_shouldAvoidDirect2DUnderWine())
     {
         SharedResourcePointer<DirectX> directX;
 

--- a/modules/juce_gui_basics/native/juce_Windowing_windows.cpp
+++ b/modules/juce_gui_basics/native/juce_Windowing_windows.cpp
@@ -4599,11 +4599,11 @@ private:
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (HWNDComponentPeer)
 };
 
-extern bool juce_isRunningInWine();
+extern bool juce_shouldAvoidDirect2DUnderWine();
 
 ComponentPeer* Component::createNewPeer (int styleFlags, void* parentHWND)
 {
-    const auto renderer = juce_isRunningInWine() ? 0 : 1;
+    const auto renderer = juce_shouldAvoidDirect2DUnderWine() ? 0 : 1;
     return new HWNDComponentPeer { *this, styleFlags, (HWND) parentHWND, false, renderer };
 }
 


### PR DESCRIPTION
## What this does

`5179690ff7` ("Restore Wine functionality"; the commit message says nothing more) made JUCE fall
back to the software renderer whenever it detects Wine. The reason is plain enough on stock Wine
11.0: `CreateSwapChainForComposition` and `DCompositionCreateDevice`, which the Direct2D peer
presents through, are `FIXME` stubs
returning `E_NOTIMPL` there (`dlls/dxgi/factory.c`, `dlls/dcomp/device.c`), so the Direct2D path
cannot put anything on screen. That is the right default and this PR does not
change it.

It adds a way to turn the fallback off, for Wine builds that *do* implement that surface:

- `JUCE_ALLOW_DIRECT2D_UNDER_WINE=1` at build time, or
- an environment variable of the same name set to something other than `0` at run time.

Both are off by default, so behaviour is unchanged unless someone asks for it. Wine stays
unsupported either way.

The two Wine checks that select the renderer (`Component::createNewPeer` and
`NativeImageType::create`) now go through a single `juce_shouldAvoidDirect2DUnderWine()`.
The same commit also removed the Wine-specific default font names in
`juce_DirectWriteTypeface_windows.cpp`; that part is left alone.

## Why — the two checks have to move together

The peer's public API already switches the renderer back: under Wine
`getAvailableRenderingEngines()` lists Direct2D and `setCurrentRenderingEngine (1)` constructs
the `D2DRenderContext`. What it cannot do is switch `NativeImageType::create`, which has no peer
and no override. That leaves a Direct2D context whose images are all `SoftwarePixelData`, and
the context does not handle that: `PagesAndArea::make` converts through `NativeImageType`, gets
software pixel data again, finds no bitmap pages and gives up. Measured on 8.0.15 with a
fifteen-panel probe: every `drawImage`, every `setBufferedToImage` child, `setTiledImageFill`,
`DropShadow::drawForPath`, `DropShadowEffect` and `GlowEffect` come out empty or as a solid
rectangle in that state (`DropShadow::drawForRectangle` is unaffected — it draws gradients, not
an image). Details, with the code path, are in #1721.

So the choice is not "which renderer" but "one switch for both halves or none". This PR is the
smallest form of that switch. The environment variable exists because the people who need it —
Wine users and distributions — have the binaries but not the build.

## What it is not

This is **not** a claim that the software fallback loses anything visible. I measured that
directly (same probe: fallback versus both checks bypassed, Wine detection untouched): across
knob bodies, value rings, gradients, PNG bitmaps with alpha, drop shadows, transparency layers,
path clipping, tiled fills, buffered children and effect filters, nothing is missing under the
fallback. The differences are anti-aliasing, text hinting, and — in the other direction — two
rendering gaps in Wine's own d2d1 (a `GaussianBlur` effect that is created but never drawn, and
cubic Béziers approximated by a single quadratic). Those are Wine's to fix, and they are why the
switch is opt-in and unsupported: whoever enables it owns the result.

An earlier revision of this description argued that `WebBrowserComponent` loses its page content
under the fallback. That was wrong and is retracted in the comments below; WebView2 presents into
its own composition swapchain and does not depend on the peer's renderer.

## Testing

Built JUCE 8.0.15 with this patch (MinGW cross-compile) and ran the resulting GUI app under a
Wine build that implements the Direct2D and DirectComposition path — [giang17/wine, branch
`d2d1-dcomp-11.0`](https://github.com/giang17/wine/tree/d2d1-dcomp-11.0) — counting d2d1 entry
points via `WINEDEBUG=+d2d` over 16-second runs:

| Run | `JUCE_ALLOW_DIRECT2D_UNDER_WINE` | d2d1 calls | of which `d2d_device_context_*` |
|---|---|---|---|
| A | unset | 28 | 0 |
| B | `1` | 45,761 | 19,595 |
| C | `0` | 28 | 0 |

A and C are factory/device creation and teardown only — the existing fallback, and their
screenshots match within capture noise. B renders the full panel set with `Image (Image::ARGB, …)`
backed by `Direct2DPixelData`; its only deviations from the software renderer are the two
Wine-side d2d1 gaps named above.

## Context

This comes out of the discussion in
[Juce8 Direct2D WINE/yabridge](https://forum.juce.com/t/juce8-direct2d-wine-yabridge/64298).
The stated hope there (t0m, 9 February 2026) was "I hope we can reduce the number of JUCE forks
being used by people" — for the subset of Wine builds that implement the surface, the
unconditional fallback currently works against that: a plug-in developer can only reach a
*consistent* Direct2D state by patching JUCE, and a user of an already-compiled plug-in only by
hiding Wine from the whole process (a Wine-side patch that hides `wine_get_version`), which flips
every Wine-aware component at once (that is
exactly what produced the mistaken WebView2 claim retracted below).

Happy to adjust the naming, drop the environment variable if a build-time switch alone is
preferred, or gate it behind a deliberately unappealing name if that helps signal that it is
unsupported.

