### PR TITLE
JACK: Fail AudioIODevice::open() if the client can't be activated

### DIFF
--- a/modules/juce_audio_devices/native/juce_JackAudio_linux.cpp
+++ b/modules/juce_audio_devices/native/juce_JackAudio_linux.cpp
@@ -302,7 +302,16 @@ public:
         juce::jack_on_shutdown (client, shutdownCallback, this);
         juce::jack_on_info_shutdown (client, infoShutdownCallback, this);
         juce::jack_set_xrun_callback (client, xrunCallback, this);
-        juce::jack_activate (client);
+
+        // If the client can't be activated, fail the whole open call:
+        // reporting success here would produce a device that appears to be
+        // running but never invokes its callback.
+        if (juce::jack_activate (client) != 0)
+        {
+            lastError = "Failed to activate JACK client";
+            return lastError;
+        }
+
         deviceIsOpen = true;
 
         if (! inputChannels.isZero())


### PR DESCRIPTION
An application can end up completely silent, with a device that reports itself open and running but never invokes its audio callback, and no error surfaced anywhere. With pipewire-jack this happens in practice by changing the enabled channels in AudioDeviceSelectorComponent, whose rapid deactivate/activate cycle pipewire-jack can refuse.

The cause is that JackAudioIODevice::open() calls jack_activate() and ignores its return value, so a failed activation still reports success and marks the device open.

With this change open() fails with an error when jack_activate() returns nonzero, so AudioDeviceManager tears the device down and reports the error instead of silently keeping a dead device.
