### PR TITLE
AudioDeviceManager: Fix a hang when a device reports a zero buffer size

### DIFF
--- a/modules/juce_audio_devices/audio_io/juce_AudioDeviceManager.cpp
+++ b/modules/juce_audio_devices/audio_io/juce_AudioDeviceManager.cpp
@@ -111,6 +111,20 @@ public:
         jassert ((int) storedInputChannels.size()  == numInputChannels);
         jassert ((int) storedOutputChannels.size() == numOutputChannels);
 
+        // A device that is mid-reconfiguration can report a buffer size of 0
+        // (e.g. the JACK backend does this when its client is unavailable),
+        // which would otherwise make the chunking loop below spin forever on
+        // the audio thread. Emit a silent block instead; the next call to
+        // audioDeviceAboutToStart() will restore the real block size.
+        if (maximumSize <= 0)
+        {
+            for (int i = 0; i < numOutputChannels; ++i)
+                if (auto* channel = outputChannelData[i])
+                    zeromem (channel, (size_t) numSamples * sizeof (float));
+
+            return;
+        }
+
         int position = 0;
 
         while (position < numSamples)


### PR DESCRIPTION
The audio thread spins forever and the application stops producing audio, when a device reports a current buffer size of 0. The JACK backend does this while its client is unavailable, so an ordinary mid-reconfiguration moment is enough to trigger it.

CallbackMaxSizeEnforcer's chunking loop computes a block length of 0 from that and never advances.

With this change the enforcer emits a silent block instead and recovers on the next audioDeviceAboutToStart(), which restores the real block size.
