### PR TITLE
Linux: Cap the poll timeout in the curl WebInputStream loop so cancel() stays responsive

### DIFF
--- a/modules/juce_core/native/juce_Network_curl.cpp
+++ b/modules/juce_core/native/juce_Network_curl.cpp
@@ -449,8 +449,13 @@ public:
                 return;
         }
 
+        // Cap the wait even when curl suggests a long timeout (it reports the
+        // full remaining connect budget during the connect phase), so that
+        // cancel() never has to wait for more than one bounded step: closing
+        // the transfer's sockets does not wake a select() that is already
+        // sleeping on them.
         // why 980? see http://curl.haxx.se/libcurl/c/curl_multi_timeout.html
-        if (curl_timeo < 0)
+        if (curl_timeo < 0 || curl_timeo > 980)
             curl_timeo = 980;
 
         struct timeval tv;


### PR DESCRIPTION
The curl WebInputStream transfer loop passes curl_multi_timeout's suggestion straight to select(), only clamping the negative no-suggestion case to 980ms. During the connect phase recent libcurl versions suggest the full remaining connect budget as the timeout, and a cancel() that closes the transfer's sockets does not wake a select() that is already sleeping on them, so a cancel issued mid-connect blocks for the entire connection timeout (with the default that can be tens of seconds on a thread the caller is joining).

This caps every wait at the loop's existing 980ms step, which bounds cancellation latency to a single step. The curl documentation for curl_multi_timeout, already referenced by the loop's comment, recommends not waiting longer than a few seconds regardless of the suggested value.