### PR TITLE
ALSA: Keep the active input channels in sync with the callback's channel array

### DIFF
--- a/modules/juce_audio_devices/native/juce_ALSA_linux.cpp
+++ b/modules/juce_audio_devices/native/juce_ALSA_linux.cpp
@@ -520,6 +520,13 @@ public:
         sampleRate = newSampleRate;
         bufferSize = newBufferSize;
 
+        // Widened before the loop below fills currentInputChans and
+        // inputChannelDataForCallback, which have to agree: getActiveInputChannels()
+        // must not report more channels than the callback is given pointers for.
+        // A request for no inputs at all stays empty rather than being widened.
+        if (inputChannels.getHighestBit() >= 0)
+            ensureMinimumNumBitsSet (inputChannels, (int) minChansIn);
+
         int maxInputsRequested = inputChannels.getHighestBit() + 1;
         maxInputsRequested = jmax ((int) minChansIn, jmin ((int) maxChansIn, maxInputsRequested));
 
@@ -564,8 +571,6 @@ public:
                 inputDevice.reset();
                 return;
             }
-
-            ensureMinimumNumBitsSet (currentInputChans, (int) minChansIn);
 
             if (! inputDevice->setParameters ((unsigned int) sampleRate,
                                               jlimit ((int) minChansIn, (int) maxChansIn, currentInputChans.getHighestBit() + 1),


### PR DESCRIPTION
Opening an ALSA capture device whose minimum channel count is higher than the number of input channels selected crashes on the audio thread, in the input level meter. To reproduce, open a capture device whose ALSA minimum is 2 channels (a dsnoop device in my case) with only the first input channel enabled.

getActiveInputChannels() ends up reporting more channels than the audio callback is actually handed pointers for. open() fills inputChannelDataForCallback and currentInputChans together in one loop, and then widens currentInputChans to minChansIn afterwards, so the bitset gains a bit with no matching entry in the channel array. AudioDeviceManager sizes CallbackMaxSizeEnforcer's stored channel vectors from getActiveInputChannels(), fills in only the channels the device passes, and forwards the rest as null pointers, which is what then crashes in the meter.

This moves the widening up so that it applies to inputChannels before the loop runs, which is how the output path a few lines below already does it, and the two stay in agreement. A request for no input channels at all is left alone rather than being widened to the minimum.
