### PR TITLE
ALSA: Avoid closing a device while the audio thread is still using it

### DIFF
--- a/modules/juce_audio_devices/native/juce_ALSA_linux.cpp
+++ b/modules/juce_audio_devices/native/juce_ALSA_linux.cpp
@@ -658,7 +658,17 @@ public:
 
             const int callbacksToStop = numCallbacks;
 
-            if ((! waitForThreadToExit (400)) && audioIoInProgress && numCallbacks == callbacksToStop)
+            // Closing the devices from this thread while the audio thread is
+            // still inside snd_pcm_readi/writei frees the pcm out from under it,
+            // so the wait has to allow for one full period of i/o before
+            // concluding that the thread is stuck rather than simply busy: a
+            // large buffer at a low sample rate takes far longer than the base
+            // timeout on its own. Capped so that closing stays responsive
+            // whatever the device reports.
+            const auto ioPeriodMs = sampleRate > 0.0 ? (int) (1000.0 * bufferSize / sampleRate) : 0;
+            const auto stuckTimeoutMs = 400 + jmin (2000, ioPeriodMs);
+
+            if ((! waitForThreadToExit (stuckTimeoutMs)) && audioIoInProgress && numCallbacks == callbacksToStop)
             {
                 JUCE_ALSA_LOG ("Thread is stuck in i/o. Is pulseaudio suspended?");
 


### PR DESCRIPTION
Changing the audio device can crash inside libasound, on setups using a large buffer at a low sample rate. A 4096 frame buffer at 8kHz is a 512ms read, and that is all it takes.

ALSAThread::close() waits 400ms for the audio thread to exit and then, if the thread still has i/o in progress, calls closeNow() on the devices from the calling thread to unstick it. That frees the snd_pcm_t while the audio thread may still be inside snd_pcm_readi or snd_pcm_writei, and the blocked thread then crashes inside libasound. The 400ms is shorter than a single read or write on plenty of perfectly valid configurations, so merely changing devices on such a setup is enough to free the handle out from under a thread that is not stuck at all and is just part way through one normal read.

This waits for the base timeout plus one i/o period, capped so that closing a genuinely wedged device stays responsive. A typical buffer size and sample rate is unaffected and still waits 400ms.
