### PR TITLE
Fix a crash from an audio callback delivered after the device has stopped

### DIFF
--- a/modules/juce_audio_devices/native/juce_WASAPI_windows.cpp
+++ b/modules/juce_audio_devices/native/juce_WASAPI_windows.cpp
@@ -1609,7 +1609,9 @@ public:
             {
                 const ScopedTryLock sl (startStopLock);
 
-                if (sl.isLocked() && (loadedFlags & flagStarted) != 0)
+                // Re-read the flags: stop() clears flagStarted under this lock, so the
+                // value loaded at the top of the loop may be stale by now.
+                if (sl.isLocked() && (flags.load (std::memory_order_acquire) & flagStarted) != 0)
                 {
                     callback->audioDeviceIOCallbackWithContext (ins.getArrayOfReadPointers(),
                                                                 numInputBuffers,

--- a/modules/juce_audio_utils/players/juce_AudioProcessorPlayer.cpp
+++ b/modules/juce_audio_utils/players/juce_AudioProcessorPlayer.cpp
@@ -234,7 +234,15 @@ void AudioProcessorPlayer::audioDeviceIOCallbackWithContext (const float* const*
 {
     const ScopedLock sl (lock);
 
-    jassert (currentDevice != nullptr);
+    // A device may deliver a trailing callback after audioDeviceStopped(), at which
+    // point the buffers below are no longer sized to hold the processor's channels.
+    if (currentDevice == nullptr)
+    {
+        for (int i = 0; i < numOutputChannels; ++i)
+            FloatVectorOperations::clear (outputChannelData[i], numSamples);
+
+        return;
+    }
 
     // These should have been prepared by audioDeviceAboutToStart()...
     jassert (sampleRate > 0 && blockSize > 0);


### PR DESCRIPTION
On Windows, changing or closing the audio device while WASAPI is running can crash the audio thread inside AudioProcessorPlayer with an access violation on a null pointer. I have one report of it from the field, so it is not just a theoretical race.

To reproduce you want a WASAPI device with more inputs than outputs (mine is 8 in, 2 out) driving a standalone app through AudioDeviceManager and AudioProcessorPlayer. Start audio, then switch the device in the audio settings or quit. It is intermittent because it needs the device thread to be parked on its client event at the moment stop() runs.

The faulting frame and the registers from the minidump:

```
EXCEPTION_ACCESS_VIOLATION_WRITE at 0x20
  memcpy
  initialiseIoBuffers                                    juce_AudioProcessorPlayer.cpp:94
  AudioProcessorPlayer::audioDeviceIOCallbackWithContext  juce_AudioProcessorPlayer.cpp:245

rbx=3 (i)  r12=2 (outs.size())  rsi=8 (totalNumChannels)  r14=0x780 (1920 bytes, 480 samples)
r8=0x760 with the fault at 0x20, so the destination was null plus the 32 byte head
```

What happens is that the device delivers one more callback after audioDeviceStopped() has already run. audioDeviceStopped() shrinks tempBuffer with setSize (1, 1), and initialiseIoBuffers then asks that buffer for a write pointer for every processor channel that has no matching system output. AudioBuffer null terminates its channel array and getWritePointer does not bounds check in release builds, so channel 3 of 8 came back null and took a full block memcpy. Channel 2 had already overrun the one sample buffer just before it.

There are two commits. The first makes AudioProcessorPlayer return silence when currentDevice is null, which is the state audioDeviceStopped() leaves behind, and does it before the buffers are set up rather than relying on the jassert that is already there. The second fixes the WASAPI side, which is where the trailing callback comes from: the run loop tests flagStarted against a snapshot taken at the top of the iteration, then blocks for up to a second waiting on the device event before it reaches that test, and in that gap stop() can clear the flag, release startStopLock and call audioDeviceStopped(). Re-reading the flags inside the try lock closes it. The AudioProcessorPlayer change is still worth having on its own, since any backend that can deliver a late callback hits the same buffers.