### PR TITLE
Linux: Fix bug where editor steals X input focus

### DIFF
--- a/modules/juce_audio_plugin_client/detail/juce_PluginUtilities.h
+++ b/modules/juce_audio_plugin_client/detail/juce_PluginUtilities.h
@@ -62,6 +62,10 @@ struct PluginUtilities
                    ? 0
                    : ComponentPeer::windowRequiresSynchronousCoreGraphicsRendering;
 
+#if (JUCE_LINUX || JUCE_BSD) && ! JucePlugin_EditorRequiresKeyboardFocus
+        flags |= ComponentPeer::windowIgnoresKeyPresses;
+#endif
+
         return { flags, editor.usesWindowsMultiTouch() };
     }
 

--- a/modules/juce_gui_basics/native/juce_Windowing_linux.cpp
+++ b/modules/juce_gui_basics/native/juce_Windowing_linux.cpp
@@ -323,6 +323,16 @@ public:
 
     void grabFocus() override
     {
+        const auto style = getStyleFlags();
+
+        const auto shouldDeferToEmbedder =
+            parentWindow != 0
+            && (style & ComponentPeer::windowIgnoresKeyPresses) != 0
+            && (style & ComponentPeer::windowIsTemporary) == 0;
+
+        if (shouldDeferToEmbedder)
+            return;
+
         if (XWindowSystem::getInstance()->grabFocus (windowH))
             isActiveApplication = true;
     }


### PR DESCRIPTION
Related issue https://github.com/juce-framework/JUCE/issues/1171, which has already explained the bug pretty well.

The changes:

- add `ComponentPeer::windowIgnoresKeyPresses` to Linux/BSD plug-in editor desktop flags when `JucePlugin_EditorRequiresKeyboardFocus` is false.
- prevent `LinuxComponentPeer::grabFocus()` from taking native focus when the peer:
    - is embedded in another native window
    - has windowIgnoresKeyPresses
    - is not a temporary window

I have tested on a Linux VM hosted on macOS, in Reaper. And the above fix solve the issue.